### PR TITLE
Remove unit of time measurement

### DIFF
--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -100,12 +100,6 @@ class MailCheck(Entity):
         return self._state
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-
-        return 'Time'
-
-    @property
     def icon(self):
         """Return the unit of measurement."""
 


### PR DESCRIPTION
Seems like a silly change but I don't believe the unit of measurement is required, and if you display the sensor as an entity in lovelace, by default it will say "Feb-12-2020 02:23 PM Time".  Removing the lines will make it read more correctly as just "Feb-12-2020 02:23 PM"