### PR TITLE
Fix order sensitivity of sensor computation.

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1,5 +1,5 @@
 DOMAIN = "mail_and_packages"
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 ISSUE_URL = "http://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
 PLATFORM = "sensor"
 

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -130,71 +130,76 @@ class EmailData:
 
             # Only update sensors we're intrested in
             for sensor in self._resources:
-                count = {}
-                if sensor == "usps_mail":
-                    count[sensor] = get_mails(
-                        account,
-                        self._img_out_path,
-                        self._gif_duration,
-                        self._image_name,
-                        self._generate_mp4,
-                    )
-                elif sensor == const.AMAZON_PACKAGES:
-                    count[sensor] = get_items(account, ATTR_COUNT, self._amazon_fwds)
-                    count[const.AMAZON_ORDER] = get_items(
-                        account, ATTR_ORDER, self._amazon_fwds
-                    )
-                elif sensor == const.AMAZON_HUB:
-                    value = amazon_hub(account, self._amazon_fwds)
-                    count[sensor] = value[ATTR_COUNT]
-                    count[const.AMAZON_HUB_CODE] = value[ATTR_CODE]
-                elif "_packages" in sensor:
-                    prefix = sensor.split("_")[0]
-                    delivering = prefix + "_delivering"
-                    delivered = prefix + "_delivered"
-                    total = 0
-                    if delivered in data and delivering in data:
-                        total = data[delivering] + data[delivered]
-                    count[sensor] = total
-                elif "_delivering" in sensor:
-                    prefix = sensor.split("_")[0]
-                    delivering = prefix + "_delivering"
-                    delivered = prefix + "_delivered"
-                    tracking = prefix + "_tracking"
-                    info = get_count(account, sensor, True)
-                    total = info[ATTR_COUNT]
-                    if delivered in data:
-                        total = total - data[delivered]
-                    total = max(0, total)
-                    count[sensor] = total
-                    count[tracking] = info[ATTR_TRACKING]
-                elif sensor == "zpackages_delivered":
-                    count[sensor] = 0  # initialize the variable
-                    for shipper in const.SHIPPERS:
-                        delivered = shipper + "_delivered"
-                        if delivered in data and delivered != sensor:
-                            count[sensor] += data[delivered]
-                elif sensor == "zpackages_transit":
-                    total = 0
-                    for shipper in const.SHIPPERS:
-                        delivering = shipper + "_delivering"
-                        if delivering in data and delivering != sensor:
-                            total += data[delivering]
-                    count[sensor] = max(0, total)
-                elif sensor == "mail_updated":
-                    count[sensor] = update_time()
-                else:
-                    count[sensor] = get_count(
-                        account, sensor, False, self._img_out_path, self._hass
-                    )[ATTR_COUNT]
+                self.fetch(account, data, sensor)
 
-                data.update(count)
+            self._data = data
             self._data = data
         else:
             _LOGGER.error("Host was left blank not attempting connection")
 
         self._scan_time = update_time()
         _LOGGER.debug("Updated scan time: %s", self._scan_time)
+
+    def fetch(self, account, data, sensor):
+        """Fetch data for a single sensor, including any sensors it depends on."""
+        if sensor in data:
+            # Use a value we've already computed this pass, if we have one.
+            return data[sensor]
+
+        count = {}
+        if sensor == "usps_mail":
+            count[sensor] = get_mails(
+                account,
+                self._img_out_path,
+                self._gif_duration,
+                self._image_name,
+                self._generate_mp4,
+            )
+        elif sensor == const.AMAZON_PACKAGES:
+            count[sensor] = get_items(account, ATTR_COUNT, self._amazon_fwds)
+            count[const.AMAZON_ORDER] = get_items(
+                account, ATTR_ORDER, self._amazon_fwds
+            )
+        elif sensor == const.AMAZON_HUB:
+            value = amazon_hub(account, self._amazon_fwds)
+            count[sensor] = value[ATTR_COUNT]
+            count[const.AMAZON_HUB_CODE] = value[ATTR_CODE]
+        elif "_packages" in sensor:
+            prefix = sensor.split("_")[0]
+            delivering = self.fetch(account, data, prefix + "_delivering")
+            delivered = self.fetch(account, data, prefix + "_delivered")
+            count[sensor] = delivering + delivered
+        elif "_delivering" in sensor:
+            prefix = sensor.split("_")[0]
+            info = get_count(account, sensor, True)
+            total = info[ATTR_COUNT]
+            delivered = self.fetch(account, data, prefix + "_delivered")
+            total = max(0, total - delivered)
+            count[sensor] = total
+            count[prefix + "_tracking"] = info[ATTR_TRACKING]
+        elif sensor == "zpackages_delivered":
+            total = 0
+            for shipper in const.SHIPPERS:
+                delivered = shipper + "_delivered"
+                if delivered in self._resources and delivered != sensor:
+                    total += self.fetch(account, data, delivered)
+            count[sensor] = max(0, total)
+        elif sensor == "zpackages_transit":
+            total = 0
+            for shipper in const.SHIPPERS:
+                delivering = shipper + "_delivering"
+                if delivering in self._resources and delivering != sensor:
+                    total += self.fetch(account, data, delivering)
+            count[sensor] = max(0, total)
+        elif sensor == "mail_updated":
+            count[sensor] = update_time()
+        else:
+            count[sensor] = get_count(
+                account, sensor, False, self._img_out_path, self._hass
+            )[ATTR_COUNT]
+
+        data.update(count)
+        return count[sensor]
 
 
 class PackagesSensor(Entity):

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -133,7 +133,6 @@ class EmailData:
                 self.fetch(account, data, sensor)
 
             self._data = data
-            self._data = data
         else:
             _LOGGER.error("Host was left blank not attempting connection")
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The update() method of the sensor iterates through sensors in the order they appear in the \_resources list. Some sensors, such as the \*\_delivering and zpackages\_\* sensors, depend on the values of earlier sensors to compute their value. If the _resources list is not in exactly the right order, this causes these sensors to show the wrong value. Performing setup through the UI does not sort this list, and can cause the summary sensors (zpackages\_\*) to break.

To fix this issue, abstract the "fetch one sensor" logic into a fetch() method. That method can recursively call itself to fetch the value of any of its dependencies. The values are cached, so that a given sensor will only be computed once per update() pass, regardless of how many times that sensor is fetch()ed.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests