### PR TITLE
Better fix for config flow defaults

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -297,6 +297,7 @@ class MailAndPackagesOptionsFlow(config_entries.OptionsFlow):
             CONF_AMAZON_FWDS: self._data.get(CONF_AMAZON_FWDS) or DEFAULT_AMAZON_FWDS,
             CONF_GENERATE_MP4: self._data.get(CONF_GENERATE_MP4),
             CONF_ALLOW_EXTERNAL: self._data.get(CONF_ALLOW_EXTERNAL),
+            CONF_RESOURCES: self._data.get(CONF_RESOURCES),
         }
 
         return self.async_show_form(

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -111,10 +111,10 @@ def _get_schema_step_2(
             vol.Optional(CONF_AMAZON_FWDS, default=_get_default(CONF_AMAZON_FWDS)): str,
             vol.Optional(
                 CONF_SCAN_INTERVAL, default=_get_default(CONF_SCAN_INTERVAL)
-            ): vol.Coerce(int),
+            ): vol.All(vol.Coerce(int), vol.Range(min=5)),
             vol.Optional(
                 CONF_IMAP_TIMEOUT, default=_get_default(CONF_IMAP_TIMEOUT)
-            ): vol.Coerce(int),
+            ): vol.All(vol.Coerce(int), vol.Range(min=10)),
             vol.Optional(
                 CONF_DURATION, default=_get_default(CONF_DURATION)
             ): vol.Coerce(int),
@@ -285,10 +285,22 @@ class MailAndPackagesOptionsFlow(config_entries.OptionsFlow):
     async def _show_step_options_2(self, user_input):
         """Step 2 of options."""
 
+        # Defaults
+        defaults = {
+            CONF_FOLDER: self._data.get(CONF_FOLDER),
+            CONF_SCAN_INTERVAL: self._data.get(CONF_SCAN_INTERVAL),
+            CONF_PATH: self._data.get(CONF_PATH),
+            CONF_DURATION: self._data.get(CONF_DURATION),
+            CONF_IMAGE_SECURITY: self._data.get(CONF_IMAGE_SECURITY),
+            CONF_IMAP_TIMEOUT: self._data.get(CONF_IMAP_TIMEOUT)
+            or DEFAULT_IMAP_TIMEOUT,
+            CONF_AMAZON_FWDS: self._data.get(CONF_AMAZON_FWDS) or DEFAULT_AMAZON_FWDS,
+            CONF_GENERATE_MP4: self._data.get(CONF_GENERATE_MP4),
+            CONF_ALLOW_EXTERNAL: self._data.get(CONF_ALLOW_EXTERNAL),
+        }
+
         return self.async_show_form(
             step_id="options_2",
-            data_schema=_get_schema_step_2(
-                self.hass, self._data, user_input, self._data
-            ),
+            data_schema=_get_schema_step_2(self.hass, self._data, user_input, defaults),
             errors=self._errors,
         )

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -23,14 +23,14 @@
         "data": {
           "folder": "Mail Folder",
           "resources": "Sensors List",
-          "scan_interval": "Scanning Interval (minutes)",
+          "scan_interval": "Scanning Interval (minutes, minimum 5)",
           "image_path": "Image Path",
           "gif_duration": "Image Duration (seconds)",
           "image_security": "Random Image Filename",
-          "imap_timeout": "Time in seconds before connection timeout",
+          "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
-          "allow_external": "Allow external image use"          
+          "allow_external": "Allow external image use"     
         },
         "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please seperate each address with a comma.",
         "title": "Mail and Packages (Step 2 of 2)"
@@ -59,14 +59,14 @@
         "data": {
           "folder": "Mail Folder",
           "resources": "Sensors List",
-          "scan_interval": "Scanning Interval (minutes)",
+          "scan_interval": "Scanning Interval (minutes, minimum 5)",
           "image_path": "Image Path",
           "gif_duration": "Image Duration (seconds)",
           "image_security": "Random Image Filename",
-          "imap_timeout": "Time in seconds before connection timeout",
+          "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
-          "allow_external": "Allow external image use"          
+          "allow_external": "Allow external image use"         
         },
         "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please seperate each address with a comma.",
         "title": "Mail and Packages (Step 2 of 2)"

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -23,14 +23,14 @@
         "data": {
           "folder": "Mail Folder",
           "resources": "Sensors List",
-          "scan_interval": "Scanning Interval (minutes)",
+          "scan_interval": "Scanning Interval (minutes, minimum 5)",
           "image_path": "Image Path",
           "gif_duration": "Image Duration (seconds)",
           "image_security": "Random Image Filename",
-          "imap_timeout": "Time in seconds before connection timeout",
+          "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
-          "allow_external": "Allow external image use"
+          "allow_external": "Allow external image use"  
         },
         "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please seperate each address with a comma.",
         "title": "Mail and Packages (Step 2 of 2)"
@@ -58,11 +58,11 @@
         "data": {
           "folder": "Mail Folder",
           "resources": "Sensors List",
-          "scan_interval": "Scanning Interval (minutes)",
+          "scan_interval": "Scanning Interval (minutes, minimum 5)",
           "image_path": "Image Path",
           "gif_duration": "Image Duration (seconds)",
           "image_security": "Random Image Filename",
-          "imap_timeout": "Time in seconds before connection timeout",
+          "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
           "allow_external": "Allow external image use"          


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A better fix for config flow defaults.
Added an additional test for config flow with missing/incomplete data.
Update config flow text to specify the minimum values for "imap timeout" and "scan interval".

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #375 
