### PR TITLE
refactor: utilize EntityDescription

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1,4 +1,11 @@
 """ Constants for Mail and Packages."""
+from __future__ import annotations
+
+from typing import Final
+from homeassistant.components.sensor import SensorEntityDescription
+
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
+
 DOMAIN = "mail_and_packages"
 DOMAIN_DATA = "{}_data".format(DOMAIN)
 VERSION = "0.0.0-dev"  # Now updated by release workflow
@@ -201,139 +208,229 @@ SENSOR_DATA = {
 }
 
 # Sensor definitions
-# Name, unit of measure, icon
-SENSOR_TYPES = {
-    "mail_updated": ["Mail Updated", None, "mdi:update"],
-    "usps_mail": ["Mail USPS Mail", "piece(s)", "mdi:mailbox-up"],
-    "usps_delivered": [
-        "Mail USPS Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "usps_delivering": ["Mail USPS Delivering", "package(s)", "mdi:truck-delivery"],
-    "usps_exception": ["Mail USPS Exception", "package(s)", "mdi:archive-alert"],
-    "usps_packages": [
-        "Mail USPS Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "ups_delivered": [
-        "Mail UPS Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "ups_delivering": ["Mail UPS Delivering", "package(s)", "mdi:truck-delivery"],
-    "ups_exception": ["Mail UPS Exception", "package(s)", "mdi:archive-alert"],
-    "ups_packages": ["Mail UPS Packages", "package(s)", "mdi:package-variant-closed"],
-    "fedex_delivered": [
-        "Mail FedEx Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "fedex_delivering": ["Mail FedEx Delivering", "package(s)", "mdi:truck-delivery"],
-    "fedex_packages": [
-        "Mail FedEx Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "amazon_packages": ["Mail Amazon Packages", "package(s)", "mdi:package"],
-    "amazon_delivered": [
-        "Mail Amazon Packages Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "amazon_exception": ["Mail Amazon Exception", "package(s)", "mdi:archive-alert"],
-    "amazon_hub": ["Mail Amazon Hub Packages", "package(s)", "mdi:package"],
-    "capost_delivered": [
-        "Mail Canada Post Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "capost_delivering": [
-        "Mail Canada Post Delivering",
-        "package(s)",
-        "mdi:truck-delivery",
-    ],
-    "capost_packages": [
-        "Mail Canada Post Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "dhl_delivered": [
-        "Mail DHL Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "dhl_delivering": ["Mail DHL Delivering", "package(s)", "mdi:truck-delivery"],
-    "dhl_packages": ["Mail DHL Packages", "package(s)", "mdi:package-variant-closed"],
-    "hermes_delivered": [
-        "Mail Hermes Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "hermes_delivering": ["Mail Hermes Delivering", "package(s)", "mdi:truck-delivery"],
-    "hermes_packages": [
-        "Mail Hermes Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "royal_delivered": [
-        "Mail Royal Mail Delivered",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "royal_delivering": [
-        "Mail Royal Mail Delivering",
-        "package(s)",
-        "mdi:truck-delivery",
-    ],
-    "royal_packages": [
-        "Mail Royal Mail Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
-    "auspost_delivered": [
-        "Mail AusPost Delivered",
-        "package(s)",
-        "mdi:package-variant",
-    ],
-    "auspost_delivering": [
-        "Mail AusPost Delivering",
-        "package(s)",
-        "mdi:truck-delivery",
-    ],
-    "auspost_packages": [
-        "Mail AusPost Packages",
-        "package(s)",
-        "mdi:package-variant-closed",
-    ],
+SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
+    "mail_updated": SensorEntityDescription(
+        name="Mail Updated",
+        icon="mdi:update",
+        key="mail_updated",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "usps_mail": SensorEntityDescription(
+        name="Mail USPS Mail",
+        native_unit_of_measurement="piece(s)",
+        icon="mdi:mailbox-up",
+        key="usps_mail",
+    ),
+    "usps_delivered": SensorEntityDescription(
+        name="Mail USPS Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="usps_delivered",
+    ),
+    "usps_delivering": SensorEntityDescription(
+        name="Mail USPS Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="usps_delivering",
+    ),
+    "usps_exception": SensorEntityDescription(
+        name="Mail USPS Exception",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:archive-alert",
+        key="usps_exception",
+    ),
+    "usps_packages": SensorEntityDescription(
+        name="Mail USPS Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="usps_packages",
+    ),
+    "ups_delivered": SensorEntityDescription(
+        name="Mail UPS Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="ups_delivered",
+    ),
+    "ups_delivering": SensorEntityDescription(
+        name="Mail UPS Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="ups_delivering",
+    ),
+    "ups_exception": SensorEntityDescription(
+        name="Mail UPS Exception",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:archive-alert",
+        key="ups_exception",
+    ),
+    "ups_packages": SensorEntityDescription(
+        name="Mail UPS Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="ups_packages",
+    ),
+    "fedex_delivered": SensorEntityDescription(
+        name="Mail FedEx Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="fedex_delivered",
+    ),
+    "fedex_delivering": SensorEntityDescription(
+        name="Mail FedEx Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="fedex_delivering",
+    ),
+    "fedex_packages": SensorEntityDescription(
+        name="Mail FedEx Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="fedex_packages",
+    ),
+    "amazon_packages": SensorEntityDescription(
+        name="Mail Amazon Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package",
+        key="amazon_packages",
+    ),
+    "amazon_delivered": SensorEntityDescription(
+        name="Mail Amazon Packages Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="amazon_delivered",
+    ),
+    "amazon_exception": SensorEntityDescription(
+        name="Mail Amazon Exception",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:archive-alert",
+        key="amazon_exception",
+    ),
+    "amazon_hub": SensorEntityDescription(
+        name="Mail Amazon Hub Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package",
+        key="amazon_hub",
+    ),
+    "capost_delivered": SensorEntityDescription(
+        name="Mail Canada Post Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="capost_delivered",
+    ),
+    "capost_delivering": SensorEntityDescription(
+        name="Mail Canada Post Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="capost_delivering",
+    ),
+    "capost_packages": SensorEntityDescription(
+        name="Mail Canada Post Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="capost_packages",
+    ),
+    "dhl_delivered": SensorEntityDescription(
+        name="Mail DHL Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="dhl_delivered",
+    ),
+    "dhl_delivering": SensorEntityDescription(
+        name="Mail DHL Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="dhl_delivering",
+    ),
+    "dhl_packages": SensorEntityDescription(
+        name="Mail DHL Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="dhl_packages",
+    ),
+    "hermes_delivered": SensorEntityDescription(
+        name="Mail Hermes Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="hermes_delivered",
+    ),
+    "hermes_delivering": SensorEntityDescription(
+        name="Mail Hermes Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="hermes_delivering",
+    ),
+    "hermes_packages": SensorEntityDescription(
+        name="Mail Hermes Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="hermes_packages",
+    ),
+    "royal_delivered": SensorEntityDescription(
+        name="Mail Royal Mail Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="royal_delivered",
+    ),
+    "royal_delivering": SensorEntityDescription(
+        name="Mail Royal Mail Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="royal_delivering",
+    ),
+    "royal_packages": SensorEntityDescription(
+        name="Mail Royal Mail Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="royal_packages",
+    ),
+    "auspost_delivered": SensorEntityDescription(
+        name="Mail AusPost Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="auspost_delivered",
+    ),
+    "auspost_delivering": SensorEntityDescription(
+        name="Mail AusPost Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="auspost_delivering",
+    ),
+    "auspost_packages": SensorEntityDescription(
+        name="Mail AusPost Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="auspost_packages",
+    ),
     ###
     # !!! Insert new sensors above these two !!!
     ###
-    "zpackages_delivered": [
-        "Mail Packages Delivered",
-        "package(s)",
-        "mdi:package-variant",
-    ],
-    "zpackages_transit": [
-        "Mail Packages In Transit",
-        "package(s)",
-        "mdi:truck-delivery",
-    ],
+    "zpackages_delivered": SensorEntityDescription(
+        name="Mail Packages Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="zpackages_delivered",
+    ),
+    "zpackages_transit": SensorEntityDescription(
+        name="Mail Packages In Transit",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="zpackages_transit",
+    ),
 }
 
-# Name, unit of measure, icon
-IMAGE_SENSORS = {
-    "usps_mail_image_system_path": [
-        "Mail Image System Path",
-        None,
-        "mdi:folder-multiple-image",
-    ],
-    "usps_mail_image_url": [
-        "Mail Image URL",
-        None,
-        "mdi:link-variant",
-    ],
+IMAGE_SENSORS: Final[dict[str, SensorEntityDescription]] = {
+    "usps_mail_image_system_path": SensorEntityDescription(
+        name="Mail Image System Path",
+        icon="mdi:folder-multiple-image",
+        key="usps_mail_image_system_path",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "usps_mail_image_url": SensorEntityDescription(
+        name="Mail Image URL",
+        icon="mdi:link-variant",
+        key="usps_mail_image_url",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 }
 
 # Name

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -43,8 +43,7 @@ def get_resources() -> dict:
     """
 
     known_available_resources = {
-        sensor_id: sensor[const.SENSOR_NAME]
-        for sensor_id, sensor in const.SENSOR_TYPES.items()
+        sensor_id: sensor.name for sensor_id, sensor in const.SENSOR_TYPES.items()
     }
 
     return known_available_resources

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -7,27 +7,45 @@ Configuration code contribution from @firstof9 https://github.com/firstof9/
 import logging
 from typing import Optional
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_RESOURCES
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import const
+from .const import (
+    AMAZON_EXCEPTION_ORDER,
+    AMAZON_ORDER,
+    ATTR_IMAGE,
+    ATTR_IMAGE_NAME,
+    ATTR_IMAGE_PATH,
+    ATTR_ORDER,
+    ATTR_SERVER,
+    ATTR_TRACKING_NUM,
+    CONF_PATH,
+    COORDINATOR,
+    DOMAIN,
+    IMAGE_SENSORS,
+    SENSOR_TYPES,
+    VERSION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the sensor entities."""
-    coordinator = hass.data[const.DOMAIN][entry.entry_id][const.COORDINATOR]
-    unique_id = entry.entry_id
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
     sensors = []
     resources = entry.data[CONF_RESOURCES]
 
     for variable in resources:
-        sensors.append(PackagesSensor(entry, variable, coordinator, unique_id))
+        sensors.append(PackagesSensor(entry, SENSOR_TYPES[variable], coordinator))
 
-    for variable in const.IMAGE_SENSORS:
-        sensors.append(ImagePathSensors(hass, entry, variable, coordinator, unique_id))
+    for variable in IMAGE_SENSORS:
+        sensors.append(
+            ImagePathSensors(hass, entry, IMAGE_SENSORS[variable], coordinator)
+        )
 
     async_add_entities(sensors, False)
 
@@ -35,19 +53,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class PackagesSensor(CoordinatorEntity, SensorEntity):
     """Representation of a sensor."""
 
-    def __init__(self, config, sensor_type, coordinator, unique_id):
+    def __init__(
+        self,
+        config: ConfigEntry,
+        sensor_description: SensorEntityDescription,
+        coordinator: str,
+    ):
         """Initialize the sensor"""
         super().__init__(coordinator)
+        self.entity_description = sensor_description
         self.coordinator = coordinator
         self._config = config
-        self._name = const.SENSOR_TYPES[sensor_type][const.SENSOR_NAME]
-        self._icon = const.SENSOR_TYPES[sensor_type][const.SENSOR_ICON]
-        self._attr_native_unit_of_measurement = const.SENSOR_TYPES[sensor_type][
-            const.SENSOR_UNIT
-        ]
-        self.type = sensor_type
+        self._name = sensor_description.name
+        self.type = sensor_description.key
         self._host = config.data[CONF_HOST]
-        self._unique_id = unique_id
+        self._unique_id = self._config.unique_id
         self.data = self.coordinator.data
 
     @property
@@ -55,10 +75,10 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         """Return device information about the mailbox."""
 
         return {
-            "connections": {(const.DOMAIN, self._unique_id)},
+            "connections": {(DOMAIN, self._unique_id)},
             "name": self._host,
             "manufacturer": "IMAP E-Mail",
-            "sw_version": const.VERSION,
+            "sw_version": VERSION,
         }
 
     @property
@@ -83,11 +103,6 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         return value
 
     @property
-    def icon(self) -> str:
-        """Return the unit of measurement."""
-        return self._icon
-
-    @property
     def should_poll(self) -> bool:
         """No need to poll. Coordinator notifies entity of updates."""
         return False
@@ -101,7 +116,7 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
     def device_state_attributes(self) -> Optional[str]:
         """Return device specific state attributes."""
         attr = {}
-        attr[const.ATTR_SERVER] = self._host
+        attr[ATTR_SERVER] = self._host
         tracking = f"{self.type.split('_')[0]}_tracking"
         data = self.coordinator.data
 
@@ -111,43 +126,46 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
 
         if "Amazon" in self._name:
             if self._name == "amazon_exception":
-                attr[const.ATTR_ORDER] = data[const.AMAZON_EXCEPTION_ORDER]
+                attr[ATTR_ORDER] = data[AMAZON_EXCEPTION_ORDER]
             else:
-                attr[const.ATTR_ORDER] = data[const.AMAZON_ORDER]
+                attr[ATTR_ORDER] = data[AMAZON_ORDER]
         elif self._name == "Mail USPS Mail":
-            attr[const.ATTR_IMAGE] = data[const.ATTR_IMAGE_NAME]
+            attr[ATTR_IMAGE] = data[ATTR_IMAGE_NAME]
         elif "_delivering" in self.type and tracking in self.data.keys():
-            attr[const.ATTR_TRACKING_NUM] = data[tracking]
+            attr[ATTR_TRACKING_NUM] = data[tracking]
         return attr
 
 
 class ImagePathSensors(CoordinatorEntity, SensorEntity):
     """Representation of a sensor."""
 
-    def __init__(self, hass, config, sensor_type, coordinator, unique_id):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config: ConfigEntry,
+        sensor_description: SensorEntityDescription,
+        coordinator: str,
+    ):
         """Initialize the sensor"""
         super().__init__(coordinator)
+        self.entity_description = sensor_description
         self.hass = hass
         self.coordinator = coordinator
         self._config = config
-        self._name = const.IMAGE_SENSORS[sensor_type][const.SENSOR_NAME]
-        self._icon = const.IMAGE_SENSORS[sensor_type][const.SENSOR_ICON]
-        self._attr_native_unit_of_measurement = const.IMAGE_SENSORS[sensor_type][
-            const.SENSOR_UNIT
-        ]
-        self.type = sensor_type
+        self._name = sensor_description.name
+        self.type = sensor_description.key
         self._host = config.data[CONF_HOST]
-        self._unique_id = unique_id
+        self._unique_id = self._config.unique_id
 
     @property
     def device_info(self) -> dict:
         """Return device information about the mailbox."""
 
         return {
-            "connections": {(const.DOMAIN, self._unique_id)},
+            "connections": {(DOMAIN, self._unique_id)},
             "name": self._host,
             "manufacturer": "IMAP E-Mail",
-            "sw_version": const.VERSION,
+            "sw_version": VERSION,
         }
 
     @property
@@ -163,13 +181,13 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Optional[str]:
         """Return the state of the sensor."""
-        image = self.coordinator.data[const.ATTR_IMAGE_NAME]
+        image = self.coordinator.data[ATTR_IMAGE_NAME]
         the_path = None
 
-        if const.ATTR_IMAGE_PATH in self.coordinator.data.keys():
-            path = self.coordinator.data[const.ATTR_IMAGE_PATH]
+        if ATTR_IMAGE_PATH in self.coordinator.data.keys():
+            path = self.coordinator.data[ATTR_IMAGE_PATH]
         else:
-            path = self._config.data[const.CONF_PATH]
+            path = self._config.data[CONF_PATH]
 
         if self.type == "usps_mail_image_system_path":
             _LOGGER.debug("Updating system image path to: %s", path)
@@ -190,11 +208,6 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
         return the_path
 
     @property
-    def icon(self) -> str:
-        """Return the unit of measurement."""
-        return self._icon
-
-    @property
     def should_poll(self) -> bool:
         """No need to poll. Coordinator notifies entity of updates."""
         return False
@@ -203,9 +216,3 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success
-
-    @property
-    def device_state_attributes(self) -> Optional[str]:
-        """Return device specific state attributes."""
-        attr = {}
-        return attr


### PR DESCRIPTION
## Breaking change

Entities are now using `Entity Description`s, this means you will need version 2021.11.x+

## Proposed change

Utilize entity descriptions where applicable.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: n/a