### PR TITLE
fix: Guard against NoneType value when using group in Amazon hub parsing

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from typing import Final
-from homeassistant.components.sensor import SensorEntityDescription
 
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 DOMAIN = "mail_and_packages"

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1058,7 +1058,9 @@ def amazon_hub(account: Type[imaplib.IMAP4_SSL], fwds: Optional[str] = None) -> 
                 # Get combo number from subject line
                 email_subject = msg["subject"]
                 pattern = re.compile(r"{}".format(subject_regex))
-                found.append(pattern.search(email_subject).group(3))
+                search = pattern.search(email_subject)
+                if search is not None:
+                    found.append(search.group(3))
 
     info[const.ATTR_COUNT] = len(found)
     info[const.ATTR_CODE] = found


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix NoneType error when Amazon Hub is in use

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #568 
