### PR TITLE
fix: switch to using extra_state_attributes

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -179,7 +179,7 @@ class MailCam(Camera):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the camera state attributes."""
         return {"file_path": self._file_path, CONF_HOST: self._host}
 

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -87,7 +87,7 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         return self.coordinator.last_update_success
 
     @property
-    def device_state_attributes(self) -> Optional[str]:
+    def extra_state_attributes(self) -> Optional[str]:
         """Return device specific state attributes."""
         attr = {}
         attr[const.ATTR_SERVER] = self._host
@@ -183,7 +183,7 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
         return self.coordinator.last_update_success
 
     @property
-    def device_state_attributes(self) -> Optional[str]:
+    def extra_state_attributes(self) -> Optional[str]:
         """Return device specific state attributes."""
         attr = {}
         return attr


### PR DESCRIPTION
## Proposed change
Users will start to get warned about integrations that use `device_state_attributes` in 2021.12.0

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
