### PR TITLE
feat: make amazon sensor more configurable

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -12,12 +12,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     CONF_ALLOW_EXTERNAL,
+    CONF_AMAZON_DAYS,
     CONF_AMAZON_FWDS,
     CONF_IMAGE_SECURITY,
     CONF_IMAP_TIMEOUT,
     CONF_PATH,
     CONF_SCAN_INTERVAL,
     COORDINATOR,
+    DEFAULT_AMAZON_DAYS,
     DEFAULT_IMAP_TIMEOUT,
     DOMAIN,
     ISSUE_URL,
@@ -156,7 +158,7 @@ async def async_migrate_entry(hass, config_entry):
     """Migrate an old config entry."""
     version = config_entry.version
 
-    # 1 -> 3: Migrate format
+    # 1 -> 4: Migrate format
     if version == 1:
         _LOGGER.debug("Migrating from version %s", version)
         updated_config = config_entry.data.copy()
@@ -178,12 +180,16 @@ async def async_migrate_entry(hass, config_entry):
         if not config_entry.data[CONF_IMAGE_SECURITY]:
             updated_config[CONF_IMAGE_SECURITY] = True
 
+        # Add default Amazon Days configuration
+        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS            
+
         if updated_config != config_entry.data:
             hass.config_entries.async_update_entry(config_entry, data=updated_config)
 
-        config_entry.version = 3
+        config_entry.version = 4
         _LOGGER.debug("Migration to version %s complete", config_entry.version)
 
+    # 2 -> 4
     if version == 2:
         _LOGGER.debug("Migrating from version %s", version)
         updated_config = config_entry.data.copy()
@@ -195,10 +201,26 @@ async def async_migrate_entry(hass, config_entry):
         if not config_entry.data[CONF_IMAGE_SECURITY]:
             updated_config[CONF_IMAGE_SECURITY] = True
 
+        # Add default Amazon Days configuration
+        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS            
+
         if updated_config != config_entry.data:
             hass.config_entries.async_update_entry(config_entry, data=updated_config)
 
-        config_entry.version = 3
+        config_entry.version = 4
+        _LOGGER.debug("Migration to version %s complete", config_entry.version)
+
+    if version == 3:
+        _LOGGER.debug("Migrating from version %s", version)
+        updated_config = config_entry.data.copy()
+
+        # Add default Amazon Days configuration
+        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS
+
+        if updated_config != config_entry.data:
+            hass.config_entries.async_update_entry(config_entry, data=updated_config)
+
+        config_entry.version = 4
         _LOGGER.debug("Migration to version %s complete", config_entry.version)
 
     return True

--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -181,7 +181,7 @@ async def async_migrate_entry(hass, config_entry):
             updated_config[CONF_IMAGE_SECURITY] = True
 
         # Add default Amazon Days configuration
-        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS            
+        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS
 
         if updated_config != config_entry.data:
             hass.config_entries.async_update_entry(config_entry, data=updated_config)
@@ -202,7 +202,7 @@ async def async_migrate_entry(hass, config_entry):
             updated_config[CONF_IMAGE_SECURITY] = True
 
         # Add default Amazon Days configuration
-        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS            
+        updated_config[CONF_AMAZON_DAYS] = DEFAULT_AMAZON_DAYS
 
         if updated_config != config_entry.data:
             hass.config_entries.async_update_entry(config_entry, data=updated_config)

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.core import callback
 from .const import (
     CONF_ALLOW_EXTERNAL,
     CONF_AMAZON_FWDS,
+    CONF_AMAZON_DAYS,
     CONF_CUSTOM_IMG,
     CONF_CUSTOM_IMG_FILE,
     CONF_DURATION,
@@ -30,6 +31,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_ALLOW_EXTERNAL,
     DEFAULT_AMAZON_FWDS,
+    DEFAULT_AMAZON_DAYS,
     DEFAULT_CUSTOM_IMG,
     DEFAULT_CUSTOM_IMG_FILE,
     DEFAULT_FOLDER,
@@ -189,6 +191,9 @@ def _get_schema_step_2(
                 CONF_AMAZON_FWDS, default=_get_default(CONF_AMAZON_FWDS, "")
             ): str,
             vol.Optional(
+                CONF_AMAZON_DAYS, default=_get_default(CONF_AMAZON_DAYS)
+            ): int,            
+            vol.Optional(
                 CONF_SCAN_INTERVAL, default=_get_default(CONF_SCAN_INTERVAL)
             ): vol.All(vol.Coerce(int)),
             vol.Optional(
@@ -233,7 +238,7 @@ def _get_schema_step_3(
 class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Mail and Packages."""
 
-    VERSION = 3
+    VERSION = 4
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
@@ -305,6 +310,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_IMAGE_SECURITY: DEFAULT_IMAGE_SECURITY,
             CONF_IMAP_TIMEOUT: DEFAULT_IMAP_TIMEOUT,
             CONF_AMAZON_FWDS: DEFAULT_AMAZON_FWDS,
+            CONF_AMAZON_DAYS: DEFAULT_AMAZON_DAYS,
             CONF_GENERATE_MP4: False,
             CONF_ALLOW_EXTERNAL: DEFAULT_ALLOW_EXTERNAL,
             CONF_CUSTOM_IMG: DEFAULT_CUSTOM_IMG,
@@ -417,6 +423,7 @@ class MailAndPackagesOptionsFlow(config_entries.OptionsFlow):
             CONF_IMAP_TIMEOUT: self._data.get(CONF_IMAP_TIMEOUT)
             or DEFAULT_IMAP_TIMEOUT,
             CONF_AMAZON_FWDS: self._data.get(CONF_AMAZON_FWDS) or DEFAULT_AMAZON_FWDS,
+            CONF_AMAZON_DAYS: self._data.get(CONF_AMAZON_DAYS) or DEFAULT_AMAZON_DAYS,
             CONF_GENERATE_MP4: self._data.get(CONF_GENERATE_MP4),
             CONF_ALLOW_EXTERNAL: self._data.get(CONF_ALLOW_EXTERNAL),
             CONF_RESOURCES: self._data.get(CONF_RESOURCES),

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -190,9 +190,7 @@ def _get_schema_step_2(
             vol.Optional(
                 CONF_AMAZON_FWDS, default=_get_default(CONF_AMAZON_FWDS, "")
             ): str,
-            vol.Optional(
-                CONF_AMAZON_DAYS, default=_get_default(CONF_AMAZON_DAYS)
-            ): int,            
+            vol.Optional(CONF_AMAZON_DAYS, default=_get_default(CONF_AMAZON_DAYS)): int,
             vol.Optional(
                 CONF_SCAN_INTERVAL, default=_get_default(CONF_SCAN_INTERVAL)
             ): vol.All(vol.Coerce(int)),

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -48,6 +48,7 @@ CONF_IMAGE_SECURITY = "image_security"
 CONF_IMAP_TIMEOUT = "imap_timeout"
 CONF_GENERATE_MP4 = "generate_mp4"
 CONF_AMAZON_FWDS = "amazon_fwds"
+CONF_AMAZON_DAYS = "amazon_days"
 
 # Defaults
 DEFAULT_CAMERA_NAME = "Mail USPS Camera"
@@ -64,6 +65,7 @@ DEFAULT_AMAZON_FWDS = '""'
 DEFAULT_ALLOW_EXTERNAL = False
 DEFAULT_CUSTOM_IMG = False
 DEFAULT_CUSTOM_IMG_FILE = "custom_components/mail_and_packages/images/mail_none.gif"
+DEFAULT_AMAZON_DAYS = 3
 
 # Amazon
 AMAZON_DOMAINS = "amazon.com,amazon.ca,amazon.co.uk,amazon.in,amazon.de,amazon.it"

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -357,15 +357,15 @@ def fetch(
         )
     elif sensor == AMAZON_PACKAGES:
         count[sensor] = get_items(
-            account=account, 
-            param=ATTR_COUNT, 
-            fwds=amazon_fwds, 
+            account=account,
+            param=ATTR_COUNT,
+            fwds=amazon_fwds,
             days=amazon_days,
         )
         count[AMAZON_ORDER] = get_items(
-            account=account, 
-            param=ATTR_ORDER, 
-            fwds=amazon_fwds, 
+            account=account,
+            param=ATTR_ORDER,
+            fwds=amazon_fwds,
             days=amazon_days,
         )
     elif sensor == AMAZON_HUB:

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -20,7 +20,6 @@ from .const import (
     ATTR_IMAGE_NAME,
     ATTR_IMAGE_PATH,
     ATTR_ORDER,
-    ATTR_SERVER,
     ATTR_TRACKING_NUM,
     CONF_PATH,
     COORDINATOR,

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -35,6 +35,7 @@
           "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
+          "amazon_days": "Days back to check for Amazon emails",
           "allow_external": "Create image for notification apps",
           "custom_img": "Use custom 'no image' image?"    
         },
@@ -82,6 +83,7 @@
           "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
+          "amazon_days": "Days back to check for Amazon emails",
           "allow_external": "Create image for notification apps",
           "custom_img": "Use custom 'no image' image?"      
         },

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -35,6 +35,7 @@
           "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
+          "amazon_days": "Days back to check for Amazon emails",
           "allow_external": "Create image for notification apps",
           "custom_img": "Use custom 'no image' image?"    
         },
@@ -82,6 +83,7 @@
           "imap_timeout": "Time in seconds before connection timeout (seconds, minimum 10)",
           "generate_mp4": "Create mp4 from images",
           "amazon_fwds": "Amazon fowarded email addresses",
+          "amazon_days": "Days back to check for Amazon emails",
           "allow_external": "Create image for notification apps",
           "custom_img": "Use custom 'no image' image?"      
         },

--- a/tests/const.py
+++ b/tests/const.py
@@ -39,6 +39,7 @@ FAKE_CONFIG_DATA_BAD = {
 }
 
 FAKE_CONFIG_DATA = {
+    "amazon_days": 3,
     "amazon_fwds": "fakeuser@fake.email, fakeuser2@fake.email",
     "custom_img": False,
     "folder": '"INBOX"',
@@ -89,6 +90,7 @@ FAKE_CONFIG_DATA = {
 
 FAKE_CONFIG_DATA_EXTERNAL = {
     "allow_external": True,
+    "amazon_days": 3,
     "amazon_fwds": "fakeuser@fake.email, fakeuser2@fake.email",
     "custom_img": False,
     "folder": '"INBOX"',
@@ -138,6 +140,7 @@ FAKE_CONFIG_DATA_EXTERNAL = {
 
 FAKE_CONFIG_DATA_CORRECTED_EXTERNAL = {
     "allow_external": True,
+    "amazon_days": 3,
     "amazon_fwds": ["fakeuser@fake.email", "fakeuser2@fake.email"],
     "custom_img": False,
     "folder": '"INBOX"',
@@ -187,6 +190,7 @@ FAKE_CONFIG_DATA_CORRECTED_EXTERNAL = {
 
 FAKE_CONFIG_DATA_CORRECTED = {
     "allow_external": False,
+    "amazon_days": 3,
     "amazon_fwds": ["fakeuser@fake.email", "fakeuser2@fake.email"],
     "custom_img": False,
     "folder": '"INBOX"',
@@ -282,6 +286,7 @@ FAKE_CONFIG_DATA_NO_PATH = {
 }
 
 FAKE_CONFIG_DATA_NO_RND = {
+    "amazon_days": 3,
     "amazon_fwds": ["fakeuser@fake.email"],
     "custom_img": False,
     "folder": '"INBOX"',

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -31,6 +31,7 @@ from tests.const import FAKE_CONFIG_DATA, FAKE_CONFIG_DATA_BAD
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email",
                 "custom_img": True,
                 "folder": '"INBOX"',
@@ -69,6 +70,7 @@ from tests.const import FAKE_CONFIG_DATA, FAKE_CONFIG_DATA_BAD
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": ["fakeuser@test.email", "fakeuser2@test.email"],
                 "custom_img": True,
                 "custom_img_file": "images/test.gif",
@@ -181,6 +183,7 @@ async def test_form(
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email",
                 "custom_img": True,
                 "folder": '"INBOX"',
@@ -219,6 +222,7 @@ async def test_form(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": ["fakeuser@test.email", "fakeuser2@test.email"],
                 "custom_img": True,
                 "custom_img_file": "images/test.gif",
@@ -369,6 +373,7 @@ async def test_form_connection_error(input_1, step_id_2, hass, mock_imap):
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "folder": '"INBOX"',
                 "generate_mp4": True,
@@ -401,6 +406,7 @@ async def test_form_connection_error(input_1, step_id_2, hass, mock_imap):
             },
             "imap.test.email",
             {
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "host": "imap.test.email",
                 "port": 993,
@@ -492,6 +498,7 @@ async def test_form_invalid_ffmpeg(
             {
                 "allow_external": False,
                 "custom_img": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "folder": '"INBOX"',
                 "generate_mp4": False,
@@ -526,6 +533,7 @@ async def test_form_invalid_ffmpeg(
             {
                 "allow_external": False,
                 "custom_img": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "host": "imap.test.email",
                 "port": 993,
@@ -625,6 +633,7 @@ async def test_form_index_error(
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -659,6 +668,7 @@ async def test_form_index_error(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -759,6 +769,7 @@ async def test_form_index_error_2(
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "folder": '"INBOX"',
                 "generate_mp4": False,
@@ -793,6 +804,7 @@ async def test_form_index_error_2(
             {
                 "allow_external": False,
                 "custom_img": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "host": "imap.test.email",
                 "port": 993,
@@ -919,6 +931,7 @@ async def test_imap_login_error(mock_imap_login_error, caplog):
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": True,
                 "folder": '"INBOX"',
@@ -957,6 +970,7 @@ async def test_imap_login_error(mock_imap_login_error, caplog):
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": True,
                 "custom_img_file": "images/test.gif",
@@ -1083,6 +1097,7 @@ async def test_options_flow(
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": True,
                 "folder": '"INBOX"',
@@ -1121,6 +1136,7 @@ async def test_options_flow(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": True,
                 "custom_img_file": "images/test.gif",
@@ -1300,6 +1316,7 @@ async def test_options_flow_connection_error(
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -1334,6 +1351,7 @@ async def test_options_flow_connection_error(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -1436,6 +1454,7 @@ async def test_options_flow_invalid_ffmpeg(
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -1470,6 +1489,7 @@ async def test_options_flow_invalid_ffmpeg(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -1573,6 +1593,7 @@ async def test_options_flow_index_error(
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -1607,6 +1628,7 @@ async def test_options_flow_index_error(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -1710,6 +1732,7 @@ async def test_options_flow_index_error_2(
             "options_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -1744,6 +1767,7 @@ async def test_options_flow_index_error_2(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": [],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -1880,6 +1904,7 @@ async def test_options_flow_mailbox_format2(
             "imap.test.email",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": ['""'],
                 "custom_img": False,
                 "host": "imap.test.email",
@@ -1992,6 +2017,7 @@ async def test_options_flow_bad(
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "testemail@amazon.com",
                 "custom_img": False,
                 "folder": '"INBOX"',
@@ -2080,6 +2106,7 @@ async def test_form_amazon_error(
             "config_2",
             {
                 "allow_external": False,
+                "amazon_days": 3,
                 "amazon_fwds": "",
                 "custom_img": False,
                 "folder": '"INBOX"',

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -28,122 +28,86 @@ async def test_sensor(hass, mock_update):
     state = hass.states.get("sensor.mail_usps_mail")
     assert state
     assert state.state == "6"
-    assert state.attributes["server"] == "imap.test.email"
+
     assert state.attributes["image"] == "mail_today.gif"
 
     state = hass.states.get("sensor.mail_usps_delivered")
     assert state
     assert state.state == "3"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_usps_delivering")
     assert state
     assert state.state == "3"
     assert state.attributes["tracking_#"] == ["92123456789012345"]
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_usps_packages")
     assert state
     assert state.state == "3"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_ups_delivered")
     assert state
     assert state.state == "1"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_ups_delivering")
     assert state
     assert state.state == "1"
     assert state.attributes["tracking_#"] == ["1Z123456789"]
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_ups_packages")
     assert state
     assert state.state == "1"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_fedex_delivered")
     assert state
     assert state.state == "0"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_fedex_delivering")
     assert state
     assert state.state == "2"
     assert state.attributes["tracking_#"] == ["1234567890"]
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_fedex_packages")
     assert state
     assert state.state == "2"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_fedex_packages")
     assert state
     assert state.state == "2"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_amazon_packages")
     assert state
     assert state.state == "7"
     assert state.attributes["order"] == ["#123-4567890"]
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_amazon_packages_delivered")
     assert state
     assert state.state == "2"
-    assert state.attributes["server"] == "imap.test.email"
-
-    # state = hass.states.get("sensor.mail_amazon_hub")
-    # assert state
-    # assert state.state == "2"
-    # assert state.attributes["code"] == ["1234567890"]
-
-    # state = hass.states.get("sensor.mail_capost_delivered")
-    # assert state
-    # assert state.state == "1"
-
-    # state = hass.states.get("sensor.mail_capost_delivering")
-    # assert state
-    # assert state.state == "1"
-
-    # state = hass.states.get("sensor.mail_capost_packages")
-    # assert state
-    # assert state.state == "2"
 
     state = hass.states.get("sensor.mail_dhl_delivered")
     assert state
     assert state.state == "0"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_dhl_delivering")
     assert state
     assert state.state == "1"
     assert state.attributes["tracking_#"] == ["1234567890"]
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_dhl_packages")
     assert state
     assert state.state == "2"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_auspost_delivered")
     assert state
     assert state.state == "2"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_auspost_delivering")
     assert state
     assert state.state == "1"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_auspost_packages")
     assert state
     assert state.state == "3"
-    assert state.attributes["server"] == "imap.test.email"
 
     state = hass.states.get("sensor.mail_packages_delivered")
     assert state
     assert state.state == "7"
-    assert state.attributes["server"] == "imap.test.email"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow the `days` back email lookup for the amazon sensor to be configurable.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

![image](https://user-images.githubusercontent.com/1105672/148094505-f240b6e5-60b0-4e10-80a5-fdc6cba0c8da.png)


- This PR is related to issue: https://community.home-assistant.io/t/mail-and-packages-custom-component-for-ups-fedex-and-usps/118081/1625
