### PR TITLE
Fix device_state_attributes warning

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -179,7 +179,7 @@ class MailCam(Camera):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the camera state attributes."""
         return {"file_path": self._file_path, CONF_HOST: self._host}
 

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -87,7 +87,7 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         return self.coordinator.last_update_success
 
     @property
-    def device_state_attributes(self) -> Optional[str]:
+    def extra_state_attributes(self) -> Optional[str]:
         """Return device specific state attributes."""
         attr = {}
         attr[const.ATTR_SERVER] = self._host
@@ -183,7 +183,7 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
         return self.coordinator.last_update_success
 
     @property
-    def device_state_attributes(self) -> Optional[str]:
+    def extra_state_attributes(self) -> Optional[str]:
         """Return device specific state attributes."""
         attr = {}
         return attr


### PR DESCRIPTION
## Proposed change

Fix startup warnings
```
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity camera.mail_usps_camera (<class 'custom_components.mail_and_packages.camera.MailCam'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity camera.mail_amazon_delivery_camera (<class 'custom_components.mail_and_packages.camera.MailCam'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_amazon_packages (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_fedex_packages (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_updated (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_ups_packages (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_usps_mail (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_usps_packages (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_packages_delivered (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_packages_in_transit (<class 'custom_components.mail_and_packages.sensor.PackagesSensor'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_image_system_path (<class 'custom_components.mail_and_packages.sensor.ImagePathSensors'>) implements device_state_attributes. Please report it to the custom component author.
2022-01-05 21:28:24 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.mail_image_url (<class 'custom_components.mail_and_packages.sensor.ImagePathSensors'>) implements device_state_attributes. Please report it to the custom component author.
```

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper
