### PR TITLE
fix: strip `>` from forwarded amazon date capture

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1267,6 +1267,8 @@ def get_items(
                             continue
                         email_msg = email_msg.decode("utf-8", "ignore")
 
+                        _LOGGER.debug("RAW EMAIL: %s", email_msg)
+
                         # Check message body for order number
                         if (
                             (found := pattern.findall(email_msg))
@@ -1289,8 +1291,11 @@ def get_items(
                                 end = email_msg.find("Track your")
                             elif email_msg.find("Per tracciare il tuo pacco") != -1:
                                 end = email_msg.find("Per tracciare il tuo pacco")
+                            elif email_msg.find("View or manage order") != -1:
+                                end = email_msg.find("View or manage order")
 
-                            arrive_date = email_msg[start:end].strip().replace(">", "")
+                            arrive_date = email_msg[start:end].replace(">", "").strip()
+                            _LOGGER.debug("First pass: %s", arrive_date)
                             arrive_date = arrive_date.split(" ")
                             arrive_date = arrive_date[0:3]
                             # arrive_date[2] = arrive_date[2][:3]

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1290,7 +1290,7 @@ def get_items(
                             elif email_msg.find("Per tracciare il tuo pacco") != -1:
                                 end = email_msg.find("Per tracciare il tuo pacco")
 
-                            arrive_date = email_msg[start:end].strip()
+                            arrive_date = email_msg[start:end].strip().replace(">", "")
                             arrive_date = arrive_date.split(" ")
                             arrive_date = arrive_date[0:3]
                             # arrive_date[2] = arrive_date[2][:3]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1229,6 +1229,30 @@ def mock_imap_search_error_none():
         mock_conn.select.return_value = ("OK", [])
         yield mock_conn
 
+@pytest.fixture()
+def mock_imap_amazon_fwd():
+    """Mock imap class values."""
+    with patch(
+        "custom_components.mail_and_packages.helpers.imaplib"
+    ) as mock_imap_amazon_fwd:
+        mock_conn = mock.Mock(spec=imaplib.IMAP4_SSL)
+        mock_imap_amazon_fwd.IMAP4_SSL.return_value = mock_conn
+
+        mock_conn.login.return_value = (
+            "OK",
+            [b"user@fake.email authenticated (Success)"],
+        )
+        mock_conn.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"'],
+        )
+        mock_conn.search.return_value = ("OK", [b"1"])
+        f = open("tests/test_emails/amazon_fwd.eml", "r")
+        email_file = f.read()
+        mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
+        mock_conn.select.return_value = ("OK", [])
+        yield mock_conn
+
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):

--- a/tests/test_emails/amazon_fwd.eml
+++ b/tests/test_emails/amazon_fwd.eml
@@ -1,0 +1,130 @@
+From: Test User <testuser@email.com>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_927437CD-D5BC-4014-BBB7-F16723EF2FAA"
+Mime-Version: 1.0 (Mac OS X Mail 15.0 \(3693.40.0.1.81\))
+Subject: Fwd: Your Amazon.com order #123-1234567-1234567
+To: Test User <testuser@gmail.com>
+Date: Mon, 10 Jan 2022 16:25:17 -0500
+
+
+--Apple-Mail=_927437CD-D5BC-4014-BBB7-F16723EF2FAA
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=utf-8
+
+
+
+> Begin forwarded message:
+>=20
+> From: "Amazon.com" <auto-confirm@amazon.com>
+> Subject: Your Amazon.com order #123-1234567-1234567
+> Date: January 7, 2022 at 10:23:16 AM EST
+> To: testuser@email.com
+> Reply-To: no-reply@amazon.com
+>=20
+>=20
+>=20
+>=20
+>  =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D1P4LKHCMAHR=
+0&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fref%3Dpe_386300_440135490_TE_si=
+mp_&H=3DTLDYOAUPDZ21V0ML4NUV1UHTIYGA&ref_=3Dpe_386300_440135490_TE_simp_>=09=
+
+> Order Confirmation
+>=20
+> Hello TestUser,
+>=20
+> Thank you for shopping with us. We=E2=80=99ll send a confirmation when =
+your item ships.=20
+>=20
+> Details=20
+> Order #123-1234567-1234567 =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3DHJCTSM2BVXB=
+6&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fgp%2Fcss%2Forder-details%3Forde=
+rId%3D123-45678-901%26ref_%3Dpe_386300_440135490_TE_simp_od&H=3DX2OZ=
+6LEMMFWLJF85AESOLFMXNPYA&ref_=3Dpe_386300_440135490_TE_simp_od>
+> Arriving:=20
+> Tuesday, January 11=20
+>=20
+>=20
+> View or manage order =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D35S6FR3CRKF=
+XD&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fgp%2Fcss%2Forder-details%3Ford=
+erId%3D123-45678-901%26ref_%3Dpe_386300_440135490_TE_simp_od&H=3D2IF=
+XLEANNLYQ780EAMAVV2AJ4QMA&ref_=3Dpe_386300_440135490_TE_simp_od>=09
+> Ship to:=20
+> Mark=20
+> Hometown, VA=20
+>=20
+> Order Total:=20
+> $80.61
+>=20
+>=20
+> We hope to see you again soon.=20
+>=20
+> Amazon.com <http://amazon.com/>
+> Top picks for you
+> =09
+> USB Extension Cable 10FT Type A Male...
+>=20
+> $8.99
+>  =
+<https://www.amazon.com/gp/r.html?C=O123456NJ4HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D14QAGBBAHYF=
+DI&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2FExtension-AINOPE-Material-Tran=
+sfer-Compatible%2Fdp%2FB07ZV6FHWF%2Fref%3Dpe_386300_440135490_rtpb_1%2F143=
+-7900164-1929561%2Fref%3Drtpb%3F_encoding%3DUTF8%26pd_rd_i%3DB07ZV6FHWF%26=
+psc%3D1%26pd_rd_w%3DTldc2%26pf_rd_p%3Deda38094-2ca0-4b92-8637-ea5c38015272=
+%26pf_rd_r%3D99GR0ERBDFT2F6N3PKPC%26pd_rd_r%3D2b783e24-541f-4467-adc2-d35a=
+6e9ebfbf%26pd_rd_wg%3DYmQfi&H=3DWAFGMAK3RA6UAWJNRPLE9GXF1BGA&ref_=3Dpe_386=
+300_440135490_rtpb_1>	=09
+> Anker 4-Port USB 3.0 Hub, Ultra-Slim...
+>=20
+> $16.99
+>  =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D38TKJN8H9OD=
+46&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2FAnker-Extended-MacBook-Surface=
+-Notebook%2Fdp%2FB07L32B9C2%2Fref%3Dpe_386300_440135490_rtpb_2%2F143-79001=
+64-1929561%2Fref%3Drtpb%3F_encoding%3DUTF8%26pd_rd_i%3DB07L32B9C2%26psc%3D=
+1%26pd_rd_w%3DTldc2%26pf_rd_p%3Deda38094-2ca0-4b92-8637-ea5c38015272%26pf_=
+rd_r%3D99GR0ERBDFT2F6N3PKPC%26pd_rd_r%3D2b783e24-541f-4467-adc2-d35a6e9ebf=
+bf%26pd_rd_wg%3DYmQfi&H=3DLHBQBZXYFTU129VX7QOMVOCEDKAA&ref_=3Dpe_386300_44=
+0135490_rtpb_2>
+> By placing your order, you agree to Amazon.com =
+<http://amazon.com/>=E2=80=99s Privacy Notice =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D25O8LJPN3FC=
+VL&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fgp%2Fhelp%2Fcustomer%2Fdisplay=
+.html%2Fref%3Dpe_386300_440135490_TE_simp_p%3Fie%3DUTF8%26nodeId%3D468496&=
+H=3DE8W4F41MKQEMG8F8WTCW6FA75FKA&ref_=3Dpe_386300_440135490_TE_simp_p> =
+and Conditions of Use =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3D2VZT1X4X2TI=
+51&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fgp%2Fhelp%2Fcustomer%2Fdisplay=
+.html%2Fref%3Dpe_386300_440135490_TE_simp_p%3Fie%3DUTF8%26nodeId%3D508088&=
+H=3DEE33IICDJSNMTEN9IXFTUIFR6KUA&ref_=3Dpe_386300_440135490_TE_simp_p>. =
+Unless otherwise noted, items sold by Amazon.com <http://amazon.com/> =
+are subject to sales tax in select states in accordance with the =
+applicable laws of that state. If your order contains one or more items =
+from a seller other than Amazon.com <http://amazon.com/>, it may be =
+subject to state and local sales tax, depending upon the seller's =
+business policies and the location of their operations. Learn more about =
+tax and seller information =
+<https://www.amazon.com/gp/r.html?C=3D1GDZONJ9HF37K&K=3D11WKRKSEG5OWD&M=3D=
+urn:rtn:msg:2022010715231662242710ab45484d87f773e4b080p0na&R=3DT2PSFU0SPCU=
+C&T=3DC&U=3Dhttps%3A%2F%2Fwww.amazon.com%2Fgp%2Fhelp%2Fcustomer%2Fdisplay.=
+html%2Fref%3Dpe_386300_440135490_hp_bc_nav%3Fie%3DUTF8%26nodeId%3D20202970=
+0&H=3DFRZVY8OUWOHUOKCR7QCAPGIOSICA&ref_=3Dpe_386300_440135490_hp_bc_nav>.=20=
+
+>=20
+> This email was sent from a notification-only address that cannot =
+accept incoming email. Please do not reply to this message.
+>=20
+>=20
+
+
+--Apple-Mail=_927437CD-D5BC-4014-BBB7-F16723EF2FAA

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1098,3 +1098,8 @@ async def test_email_search_none(mock_imap_search_error_none, caplog):
         mock_imap_search_error_none, "fake@eamil.address", "01-Jan-20"
     )
     assert result == ("OK", [b""])
+
+async def test_amazon_shipped_fwd(hass, mock_imap_amazon_fwd,caplog):
+    result = get_items(mock_imap_amazon_fwd, "order")
+    assert result == ["123-1234567-1234567"]
+    assert "Arrive Date: Tuesday, January 11" in caplog.text


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Strip `>` from forwarded Amazon emails

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://community.home-assistant.io/t/mail-and-packages-custom-component-for-ups-fedex-and-usps/118081/1658
