### PR TITLE
fix(shipper): add amazon.com.au and update auspost_delivering

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -r requirements_test.txt
+          pip install --use-deprecated legacy-resolver -r requirements_test.txt
           sudo apt-get update
           sudo apt-get -y install language-pack-it
       - name: Generate coverage report

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -68,7 +68,7 @@ DEFAULT_CUSTOM_IMG_FILE = "custom_components/mail_and_packages/images/mail_none.
 DEFAULT_AMAZON_DAYS = 3
 
 # Amazon
-AMAZON_DOMAINS = "amazon.com,amazon.ca,amazon.co.uk,amazon.in,amazon.de,amazon.it"
+AMAZON_DOMAINS = "amazon.com,amazon.ca,amazon.co.uk,amazon.in,amazon.de,amazon.it,amazon.com.au"
 AMAZON_DELIVERED_SUBJECT = ["Delivered: Your", "Consegna effettuata:"]
 AMAZON_SHIPMENT_TRACKING = ["shipment-tracking", "conferma-spedizione"]
 AMAZON_EMAIL = "order-update@"
@@ -208,7 +208,7 @@ SENSOR_DATA = {
     },
     "auspost_delivering": {
         "email": ["noreply@notifications.auspost.com.au"],
-        "subject": ["Your delivery is coming today"],
+        "subject": ["is on its way", "is coming today"],
     },
     "auspost_packages": {},
     "auspost_tracking": {"pattern": ["\\d{7,10,12}|[A-Za-z]{2}[0-9]{9}AU "]},

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -812,7 +812,7 @@ async def test_amazon_search_results(hass, mock_imap_amazon_shipped):
     result = amazon_search(
         mock_imap_amazon_shipped, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 12
+    assert result == 14
 
 
 async def test_amazon_search_delivered(
@@ -821,7 +821,7 @@ async def test_amazon_search_delivered(
     result = amazon_search(
         mock_imap_amazon_delivered, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 12
+    assert result == 14
     assert mock_download_img.called
 
 
@@ -831,7 +831,7 @@ async def test_amazon_search_delivered_it(
     result = amazon_search(
         mock_imap_amazon_delivered_it, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 12
+    assert result == 14
 
 
 async def test_amazon_hub(hass, mock_imap_amazon_the_hub):
@@ -1042,20 +1042,13 @@ async def test_image_file_name(
 
 async def test_amazon_exception(hass, mock_imap_amazon_exception, caplog):
     result = amazon_exception(mock_imap_amazon_exception, ['""'])
-    assert result["order"] == [
-        "123-1234567-1234567",
-        "123-1234567-1234567",
-        "123-1234567-1234567",
-        "123-1234567-1234567",
-        "123-1234567-1234567",
-        "123-1234567-1234567",
-    ]
-    assert result["count"] == 6
+    assert result["order"] == ["123-1234567-1234567"]*7
+    assert result["count"] == 7
 
     result = amazon_exception(mock_imap_amazon_exception, ["testemail@fakedomain.com"])
-    assert result["count"] == 7
+    assert result["count"] == 8
     assert (
-        "Amazon domains to be checked: ['amazon.com', 'amazon.ca', 'amazon.co.uk', 'amazon.in', 'amazon.de', 'amazon.it', 'testemail@fakedomain.com']"
+        "Amazon domains to be checked: ['amazon.com', 'amazon.ca', 'amazon.co.uk', 'amazon.in', 'amazon.de', 'amazon.it', 'amazon.com.au', 'testemail@fakedomain.com']"
         in caplog.text
     )
 


### PR DESCRIPTION
Added amazon.com.au domain and updated subject for auspost_delivering as the subject in the emails either say "Your delivery from XXX is on its way" or "Your delivery from XXX is coming today"

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added `amazon.com.au` domain and updated subject for `auspost_delivering` similar to `royal_delivering` to account for the different email subjects

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
