### PR TITLE
fix: Add extra matcher for USPS Informed Delivery

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -103,6 +103,7 @@ SENSOR_DATA = {
             "USPSInformedDelivery@usps.gov",
             "USPSInformeddelivery@email.informeddelivery.usps.com",
             "USPSInformeddelivery@informeddelivery.usps.com",
+            "USPS Informed Delivery",
         ],
         "subject": ["Your Daily Digest"],
     },

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -525,6 +525,7 @@ async def test_informed_delivery_emails(
         assert "USPSInformedDelivery@usps.gov" in caplog.text
         assert "USPSInformeddelivery@informeddelivery.usps.com" in caplog.text
         assert "USPSInformeddelivery@email.informeddelivery.usps.com" in caplog.text
+        assert "USPS Informed Delivery" in caplog.text
 
 
 async def test_get_mails_imageio_error(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For some reason that I'm still not sure of, my email server is not finding the USPS Informed Delivery emails when matching purely on the address but adding the Name "USPS Informed Delivery" causes it to match

The mail server is just docker-mailcow which is just postfix so I'm not sure why it would behave differently but adding this fixes the issue for me

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
