### PR TITLE
fix: wrong filename for amazon binary_sensor

### DIFF
--- a/custom_components/mail_and_packages/binary_sensor.py
+++ b/custom_components/mail_and_packages/binary_sensor.py
@@ -105,7 +105,7 @@ class PackagesBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         if self._type == "amazon_update":
             if ATTR_AMAZON_IMAGE in self.coordinator.data.keys():
-                image = self.coordinator.data[ATTR_IMAGE_NAME]
+                image = self.coordinator.data[ATTR_AMAZON_IMAGE]
                 path = f"{self.coordinator.data[ATTR_IMAGE_PATH]}amazon/"
                 amazon_image = f"{self.hass.config.path()}/{path}{image}"
                 amazon_none = f"{os.path.dirname(__file__)}/no_deliveries.jpg"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix wrong filename specified for the amazon image binary sensor.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: n/a