### PR TITLE
fix: add padding around images for sizing

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from PIL import Image
+from PIL import Image, ImageOps
 
 from .const import (
     AMAZON_DELIVERED,
@@ -782,6 +782,10 @@ def resize_images(images: list, width: int, height: int) -> list:
                 try:
                     img = Image.open(fd_img)
                     img.thumbnail((width, height), resample=Image.LANCZOS)
+
+                    # Add padding as needed
+                    img = ImageOps.pad(img, (width, height), method=Image.LANCZOS)
+                    
                     pre = os.path.splitext(image)[0]
                     image = pre + ".gif"
                     img.save(image, img.format)

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -785,7 +785,7 @@ def resize_images(images: list, width: int, height: int) -> list:
 
                     # Add padding as needed
                     img = ImageOps.pad(img, (width, height), method=Image.LANCZOS)
-                    
+
                     pre = os.path.splitext(image)[0]
                     image = pre + ".gif"
                     img.save(image, img.format)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -942,7 +942,7 @@ def mock_resizeimage():
     """Fixture to mock splitext."""
     with patch(
         "custom_components.mail_and_packages.helpers.Image"
-    ) as mock_resizeimage:
+    ) as mock_resizeimage, patch("custom_components.mail_and_packages.helpers.ImageOps"):
 
         yield mock_resizeimage
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pad images so they are all the same size when resized.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: n/a