### PR TITLE
fix(shipper): update DHL for Germany

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -233,8 +233,9 @@ SENSOR_DATA = {
         "subject": [
             "DHL On Demand Delivery",
             "Powiadomienie o przesyłce",
+            "Ihr DHL Paket wurde zugestellt",
         ],
-        "body": ["has been delivered", "została doręczona"],
+        "body": ["has been delivered", "została doręczona", "ist angekommen"],
     },
     "dhl_delivering": {
         "email": [
@@ -245,10 +246,10 @@ SENSOR_DATA = {
         ],
         "subject": [
             "DHL On Demand Delivery",
-            "paket kommt heute",
+            "Ihr DHL Paket kommt heute",
             "Powiadomienie o przesyłce",
         ],
-        "body": ["scheduled for delivery TODAY", "zostanie dziś do Państwa doręczona"],
+        "body": ["scheduled for delivery TODAY", "zostanie dziś do Państwa doręczona", "wird Ihnen heute"],
     },
     "dhl_packages": {},
     "dhl_tracking": {"pattern": ["\\d{10,11}"]},

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -235,7 +235,11 @@ SENSOR_DATA = {
             "Powiadomienie o przesyłce",
             "Ihr DHL Paket wurde zugestellt",
         ],
-        "body": ["has been delivered", "została doręczona", "ist angekommen"],
+        "body": [
+            "has been delivered",
+            "została doręczona",
+            "ist angekommen",
+        ],
     },
     "dhl_delivering": {
         "email": [
@@ -249,7 +253,11 @@ SENSOR_DATA = {
             "Ihr DHL Paket kommt heute",
             "Powiadomienie o przesyłce",
         ],
-        "body": ["scheduled for delivery TODAY", "zostanie dziś do Państwa doręczona", "wird Ihnen heute"],
+        "body": [
+            "scheduled for delivery TODAY",
+            "zostanie dziś do Państwa doręczona",
+            "wird Ihnen heute",
+        ],
     },
     "dhl_packages": {},
     "dhl_tracking": {"pattern": ["\\d{10,11}"]},


### PR DESCRIPTION
Fixed German DHL sensor

## Breaking change

none

## Proposed change

German DHL sensor did not work. I adjusted the patterns so hopefully it will now detect mails correctly.

## Type of change


- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Update existing shipper