### PR TITLE
fix: make sure the selected IMAP folder is only readonly mode

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -445,7 +445,7 @@ def selectfolder(account: Type[imaplib.IMAP4_SSL], folder: str) -> bool:
         _LOGGER.error("Error listing folders: %s", str(err))
         return False
     try:
-        account.select(folder)
+        account.select(folder, readonly=True)
     except Exception as err:
         _LOGGER.error("Error selecting folder: %s", str(err))
         return False


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make sure the folder selected by user is in read only mode.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #781 