### PR TITLE
chore: update integration manifest to add integration_type

### DIFF
--- a/custom_components/mail_and_packages/manifest.json
+++ b/custom_components/mail_and_packages/manifest.json
@@ -9,6 +9,7 @@
     "@firstof9"
   ],
   "config_flow": true,
+  "integration_type": "service",
   "requirements": ["beautifulsoup4","Pillow>=9.0"],
   "iot_class": "cloud_polling",
   "version": "0.0.0-dev"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `manifest.json` to include `integration_type` per the [Home Assistant dev docs](https://developers.home-assistant.io/docs/creating_integration_manifest).

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: n/a