### PR TITLE
feat: add amazon.ae to amazon sensor 

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -83,6 +83,7 @@ AMAZON_DOMAINS = [
     "amazon.pl",
     "amazon.es",
     "amazon.fr",
+    "amazon.ae",
 ]
 AMAZON_DELIVERED_SUBJECT = [
     "Delivered: Your",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -869,7 +869,7 @@ async def test_amazon_search_results(hass, mock_imap_amazon_shipped):
     result = amazon_search(
         mock_imap_amazon_shipped, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 48
+    assert result == 52
 
 
 @pytest.mark.asyncio
@@ -879,7 +879,7 @@ async def test_amazon_search_delivered(
     result = amazon_search(
         mock_imap_amazon_delivered, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 48
+    assert result == 52
     assert mock_download_img.called
 
 
@@ -890,7 +890,7 @@ async def test_amazon_search_delivered_it(
     result = amazon_search(
         mock_imap_amazon_delivered_it, "test/path", hass, "testfilename.jpg"
     )
-    assert result == 48
+    assert result == 52
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1120,13 +1120,13 @@ async def test_image_file_name(
 @pytest.mark.asyncio
 async def test_amazon_exception(hass, mock_imap_amazon_exception, caplog):
     result = amazon_exception(mock_imap_amazon_exception, ['""'])
-    assert result["order"] == ["123-1234567-1234567"] * 12
-    assert result["count"] == 12
+    assert result["order"] == ["123-1234567-1234567"] * 13
+    assert result["count"] == 13
 
     result = amazon_exception(mock_imap_amazon_exception, ["testemail@fakedomain.com"])
-    assert result["count"] == 13
+    assert result["count"] == 14
     assert (
-        "Amazon domains to be checked: ['amazon.com', 'amazon.ca', 'amazon.co.uk', 'amazon.in', 'amazon.de', 'amazon.it', 'amazon.com.au', 'amazon.pl', 'amazon.es', 'amazon.fr', 'fakeuser@fake.email', 'fakeuser2@fake.email', 'testemail@fakedomain.com']"
+        "Amazon domains to be checked: ['amazon.com', 'amazon.ca', 'amazon.co.uk', 'amazon.in', 'amazon.de', 'amazon.it', 'amazon.com.au', 'amazon.pl', 'amazon.es', 'amazon.fr', 'amazon.ae', 'fakeuser@fake.email', 'fakeuser2@fake.email', 'testemail@fakedomain.com']"
         in caplog.text
     )
 


### PR DESCRIPTION
## Proposed change

Add Amazon.ae to amazon sensor.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

I think we just need to add the domain, the rest of it is identical to the parent .com domain.

![image](https://user-images.githubusercontent.com/4633243/214895700-ec0cb759-f265-47fb-b99b-dc8c8bdf1cf4.png)
![image](https://user-images.githubusercontent.com/4633243/214896043-f220171d-c7ce-4866-9df0-ec18dbffd697.png)
