### PR TITLE
feat(shipper): add support for BuildingLink

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1051,7 +1051,6 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:package-variant-closed",
         key="post_de_packages",
     ),
-
     ###
     # !!! Insert new sensors above these two !!!
     ###

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -556,6 +556,14 @@ SENSOR_DATA = {
         "subject": ["delivery is delayed"],
     },
     "walmart_tracking": {"pattern": ["#[0-9]{7}-[0-9]{7}"]},
+
+    # BuildingLink
+    "buildinglink_delivered": {
+        "email": ["notify@buildinglink.com"],
+        "subject": ["Your Amazon order has arrived", "Your USPS delivery has arrived", "Your UPS delivery has arrived", "Your FEDEX delivery has arrived", "You have a package delivery", "You have a DHL delivery", "You have an envelope"],
+    },
+    "buildinglink_tracking": {},
+
     # Post NL
     "post_nl_delivering": {
         "email": ["noreply@notificatie.postnl.nl"],
@@ -992,6 +1000,13 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:archive-alert",
         key="walmart_exception",
     ),
+    # BuildingLink
+    "buildinglink_delivered": SensorEntityDescription(
+        name="Mail BuildingLink Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="buildinglink_delivered",
+    ),
     # Post NL
     "post_nl_delivering": SensorEntityDescription(
         name="Post NL Delivering",
@@ -1036,6 +1051,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:package-variant-closed",
         key="post_de_packages",
     ),
+
     ###
     # !!! Insert new sensors above these two !!!
     ###

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -556,14 +556,20 @@ SENSOR_DATA = {
         "subject": ["delivery is delayed"],
     },
     "walmart_tracking": {"pattern": ["#[0-9]{7}-[0-9]{7}"]},
-
     # BuildingLink
     "buildinglink_delivered": {
         "email": ["notify@buildinglink.com"],
-        "subject": ["Your Amazon order has arrived", "Your USPS delivery has arrived", "Your UPS delivery has arrived", "Your FEDEX delivery has arrived", "You have a package delivery", "You have a DHL delivery", "You have an envelope"],
+        "subject": [
+            "Your Amazon order has arrived",
+            "Your USPS delivery has arrived",
+            "Your UPS delivery has arrived",
+            "Your FEDEX delivery has arrived",
+            "You have a package delivery",
+            "You have a DHL delivery",
+            "You have an envelope",
+        ],
     },
     "buildinglink_tracking": {},
-
     # Post NL
     "post_nl_delivering": {
         "email": ["noreply@notificatie.postnl.nl"],


### PR DESCRIPTION
## Proposed change

My building uses BuildingLink to manage the mail room... packages aren't really "delivered" until they've been processed and appear, so adding this means i can look for how many other shippers delivered vs. the number in buildinglink.

## Type of change



- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [x] Adds a new shipper
- [ ] Update existing shipper
