### PR TITLE
fix(shipper): Updated subject for Walmart delivered sensor.

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -560,7 +560,7 @@ SENSOR_DATA = {
         "subject": [
             "Your order was delivered",
             "Some of your items were delivered",
-            "Delivered: items from order",
+            "Delivered:",
         ],
     },
     "walmart_exception": {


### PR DESCRIPTION


## Proposed change

Update subject for Walmart delivered sensor. Currently Subject is  "Delivered: items from order", but needs to be changes to  "Delivered:", as Walmart doesn't always use the " items from order" line in the subject.  For example, today I received an email with the subject:  "Delivered: Milk, Cheese, Pepper, Etc." and it didn't get picked up. Changing the subject query to just "Delivered:" will resolve this without breaking the query, which is what I should have done the first time.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
