### PR TITLE
fix: usps_mail_delivered device_class

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1133,6 +1133,7 @@ BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "usps_mail_delivered": BinarySensorEntityDescription(
         name="USPS Mail Delivered",
         key="usps_mail_delivered",
+        entity_registry_enabled_default=False,
     ),
 }
 

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1133,7 +1133,6 @@ BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "usps_mail_delivered": BinarySensorEntityDescription(
         name="USPS Mail Delivered",
         key="usps_mail_delivered",
-        device_class=BinarySensorDeviceClass.UPDATE,
     ),
 }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust device_class and enabled by default status for USPS Mail Delivered sensor

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: n/a