### PR TITLE
fix: support different from addresses on amazon delivered emails

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -109,7 +109,10 @@ AMAZON_SHIPMENT_TRACKING = [
     "verzending-volgen",
     "update-bestelling",
 ]
-AMAZON_EMAIL = "order-update@"
+AMAZON_EMAIL = [
+    "order-update@",
+    "update-bestelling@",
+]
 AMAZON_PACKAGES = "amazon_packages"
 AMAZON_ORDER = "amazon_order"
 AMAZON_DELIVERED = "amazon_delivered"

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1116,7 +1116,9 @@ def amazon_search(
 
     for domain in domains:
         for subject in subjects:
-            email_address = AMAZON_EMAIL + domain
+            email_address = []
+            for address in AMAZON_EMAIL:
+                email_address.append(address + domain)
             _LOGGER.debug("Amazon email search address: %s", str(email_address))
 
             (server_response, data) = email_search(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -794,11 +794,12 @@ async def test_amazon_search_results(hass, mock_imap_amazon_shipped):
 
 @pytest.mark.asyncio
 async def test_amazon_search_delivered(
-    hass, mock_imap_amazon_delivered, mock_download_img
+    hass, mock_imap_amazon_delivered, mock_download_img, caplog
 ):
     result = amazon_search(
         mock_imap_amazon_delivered, "test/path", hass, "testfilename.jpg", "amazon.com"
     )
+    assert "Amazon email search address: ['order-update@amazon.com', 'update-bestelling@amazon.com']" in caplog.text
     assert result == 7
     assert mock_download_img.called
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow more amazon delivered email from addresses.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #925 