### PR TITLE
fix: move amazon image clean up to proper function

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -944,8 +944,6 @@ def get_count(
 
     # Return Amazon delivered info
     if sensor_type == AMAZON_DELIVERED:
-        _LOGGER.debug("Cleaning up amazon images...")
-        cleanup_images(f"{image_path}amazon/")
         result[ATTR_COUNT] = amazon_search(
             account, image_path, hass, amazon_image_name, amazon_domain
         )
@@ -1118,6 +1116,9 @@ def amazon_search(
     count = 0
     domains = amazon_domain.split()
 
+    _LOGGER.debug("Cleaning up amazon images...")
+    cleanup_images(f"{image_path}amazon/")    
+
     for domain in domains:
         for subject in subjects:
             email_address = []
@@ -1139,6 +1140,14 @@ def amazon_search(
                     hass,
                     amazon_image_name,
                 )
+
+    if count == 0:
+        _LOGGER.debug("No Amazon deliveries found.")
+        nomail = f"{os.path.dirname(__file__)}/no_deliveries.jpg"
+        try:
+            copyfile(nomail, f"{image_path}amazon/" + amazon_image_name)
+        except Exception as err:
+            _LOGGER.error("Error attempting to copy image: %s", str(err))
 
     return count
 

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1117,7 +1117,7 @@ def amazon_search(
     domains = amazon_domain.split()
 
     _LOGGER.debug("Cleaning up amazon images...")
-    cleanup_images(f"{image_path}amazon/")    
+    cleanup_images(f"{image_path}amazon/")
 
     for domain in domains:
         for subject in subjects:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -778,47 +778,51 @@ async def test_amazon_shipped_order_it_count(hass, mock_imap_amazon_shipped_it):
 
 @pytest.mark.asyncio
 async def test_amazon_search(hass, mock_imap_no_email):
-    result = amazon_search(
-        mock_imap_no_email, "test/path", hass, "testfilename.jpg", "amazon.com"
-    )
-    assert result == 0
+    with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
+        result = amazon_search(
+            mock_imap_no_email, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+        )
+        assert result == 0
 
 
 @pytest.mark.asyncio
 async def test_amazon_search_results(hass, mock_imap_amazon_shipped):
-    result = amazon_search(
-        mock_imap_amazon_shipped, "test/path", hass, "testfilename.jpg", "amazon.com"
-    )
-    assert result == 8
+    with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
+        result = amazon_search(
+            mock_imap_amazon_shipped, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+        )
+        assert result == 8
 
 
 @pytest.mark.asyncio
 async def test_amazon_search_delivered(
     hass, mock_imap_amazon_delivered, mock_download_img, caplog
 ):
-    result = amazon_search(
-        mock_imap_amazon_delivered, "test/path", hass, "testfilename.jpg", "amazon.com"
-    )
-    assert (
-        "Amazon email search address: ['order-update@amazon.com', 'update-bestelling@amazon.com', 'versandbestaetigung@amazon.com']"
-        in caplog.text
-    )
-    assert result == 8
-    assert mock_download_img.called
+    with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
+        result = amazon_search(
+            mock_imap_amazon_delivered, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+        )
+        assert (
+            "Amazon email search address: ['order-update@amazon.com', 'update-bestelling@amazon.com', 'versandbestaetigung@amazon.com']"
+            in caplog.text
+        )
+        assert result == 8
+        assert mock_download_img.called
 
 
 @pytest.mark.asyncio
 async def test_amazon_search_delivered_it(
     hass, mock_imap_amazon_delivered_it, mock_download_img
 ):
-    result = amazon_search(
-        mock_imap_amazon_delivered_it,
-        "test/path",
-        hass,
-        "testfilename.jpg",
-        "amazon.it",
-    )
-    assert result == 8
+    with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
+        result = amazon_search(
+            mock_imap_amazon_delivered_it,
+            "test/path/amazon/",
+            hass,
+            "testfilename.jpg",
+            "amazon.it",
+        )
+        assert result == 8
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -780,7 +780,11 @@ async def test_amazon_shipped_order_it_count(hass, mock_imap_amazon_shipped_it):
 async def test_amazon_search(hass, mock_imap_no_email):
     with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
         result = amazon_search(
-            mock_imap_no_email, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+            mock_imap_no_email,
+            "test/path/amazon/",
+            hass,
+            "testfilename.jpg",
+            "amazon.com",
         )
         assert result == 0
 
@@ -789,7 +793,11 @@ async def test_amazon_search(hass, mock_imap_no_email):
 async def test_amazon_search_results(hass, mock_imap_amazon_shipped):
     with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
         result = amazon_search(
-            mock_imap_amazon_shipped, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+            mock_imap_amazon_shipped,
+            "test/path/amazon/",
+            hass,
+            "testfilename.jpg",
+            "amazon.com",
         )
         assert result == 8
 
@@ -800,7 +808,11 @@ async def test_amazon_search_delivered(
 ):
     with patch("custom_components.mail_and_packages.helpers.cleanup_images"):
         result = amazon_search(
-            mock_imap_amazon_delivered, "test/path/amazon/", hass, "testfilename.jpg", "amazon.com"
+            mock_imap_amazon_delivered,
+            "test/path/amazon/",
+            hass,
+            "testfilename.jpg",
+            "amazon.com",
         )
         assert (
             "Amazon email search address: ['order-update@amazon.com', 'update-bestelling@amazon.com', 'versandbestaetigung@amazon.com']"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move the amazon image clean up to proper function for cleaning up files.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #985 