### PR TITLE
Update Intelcom Shipper

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -575,23 +575,29 @@ SENSOR_DATA = {
     "purolator_tracking": {"pattern": ["\\d{12,15}"]},
     # Intelcom
     "intelcom_delivered": {
-        "email": ["notifications@intelcom.ca"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
         "subject": [
             "Your order has been delivered!",
+            "Your package has been delivered",
+            "Hooray! Your package is here",
             "Votre commande a été livrée!",
             "Votre colis a été livré!",
         ],
     },
     "intelcom_delivering": {
-        "email": ["notifications@intelcom.ca"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
         "subject": [
             "Your package is on the way!",
+            "Your package is on its way",
             "Votre colis est en chemin!",
         ],
     },
     "intelcom_packages": {
-        "email": ["notifications@intelcom.ca"],
-        "subject": ["Your package has been received!"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
+        "subject": [
+            "Your package has been received!",
+            "We've received your package",
+        ],
     },
     "intelcom_tracking": {"pattern": ["INTLCMD[0-9]{9}"]},
     # Walmart


### PR DESCRIPTION
Intelcom changed its name to Dragonfly and updated email notifications.

## Proposed change

Intelcom shipper changed it's name to Dragonfly and updated its email addresses, email subjects and email content. This change adds all the new info in under the Intelcom name (Dragonfly is a subsidiary of Intelcom).

## Type of change

Updates email addresses and email content of notifications

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [X ] Update existing shipper

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
