### PR TITLE
fix: Update Intelcom Shipper

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -575,7 +575,11 @@ SENSOR_DATA = {
     "purolator_tracking": {"pattern": ["\\d{12,15}"]},
     # Intelcom
     "intelcom_delivered": {
-        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
+        "email": [
+            "notifications@intelcom.ca",
+            "notifications@dragonflyshipping.ca",
+            "notifications@dragonflyshipping.com",
+        ],
         "subject": [
             "Your order has been delivered!",
             "Your package has been delivered",
@@ -585,7 +589,11 @@ SENSOR_DATA = {
         ],
     },
     "intelcom_delivering": {
-        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
+        "email": [
+            "notifications@intelcom.ca",
+            "notifications@dragonflyshipping.ca",
+            "notifications@dragonflyshipping.com",
+        ],
         "subject": [
             "Your package is on the way!",
             "Your package is on its way",
@@ -593,7 +601,11 @@ SENSOR_DATA = {
         ],
     },
     "intelcom_packages": {
-        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
+        "email": [
+            "notifications@intelcom.ca",
+            "notifications@dragonflyshipping.ca",
+            "notifications@dragonflyshipping.com",
+        ],
         "subject": [
             "Your package has been received!",
             "We've received your package",

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -575,23 +575,29 @@ SENSOR_DATA = {
     "purolator_tracking": {"pattern": ["\\d{12,15}"]},
     # Intelcom
     "intelcom_delivered": {
-        "email": ["notifications@intelcom.ca"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
         "subject": [
             "Your order has been delivered!",
+            "Your package has been delivered",
+            "Hooray! Your package is here",
             "Votre commande a été livrée!",
             "Votre colis a été livré!",
         ],
     },
     "intelcom_delivering": {
-        "email": ["notifications@intelcom.ca"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
         "subject": [
             "Your package is on the way!",
+            "Your package is on its way",
             "Votre colis est en chemin!",
         ],
     },
     "intelcom_packages": {
-        "email": ["notifications@intelcom.ca"],
-        "subject": ["Your package has been received!"],
+        "email": ["notifications@intelcom.ca", "notifications@dragonflyshipping.ca", "notifications@dragonflyshipping.com"],
+        "subject": [
+            "Your package has been received!",
+            "We've received your package",
+        ],
     },
     "intelcom_tracking": {"pattern": ["INTLCMD[0-9]{9}"]},
     # Walmart


### PR DESCRIPTION
fix: Update Intelcom Shipper email info

## Proposed change

Intelcom created new shipper division called Dragonfly and changed all their email info. This fix adds the new email info.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [X] Update existing shipper
