### PR TITLE
fix: update Walmart delivered search

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -624,6 +624,7 @@ SENSOR_DATA = {
             "Your order was delivered",
             "Some of your items were delivered",
             "Delivered:",
+            "Arrived:",
         ],
     },
     "walmart_exception": {


### PR DESCRIPTION
Updated Walmart deliveries to include "Arrived:"

## Proposed change

Update Walmart's list of delivery subjects keywords.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [X] Update existing shipper

## Additional information

I have over 25 delivery notifications and only 9 use the keyword "Delivered;" the other 16 are using the new proposed "Arrived:"
