### PR TITLE
fix(shipper): add new `auto-confirm` for amazon shipment tracking

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -105,6 +105,7 @@ AMAZON_DELIVERED_SUBJECT = [
     "Zugestellt: deine",
 ]
 AMAZON_SHIPMENT_TRACKING = [
+    "auto-confirm",
     "shipment-tracking",
     "order-update",
     "conferma-spedizione",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1149,7 +1149,7 @@ async def test_amazon_shipped_fwd(hass, mock_imap_amazon_fwd, caplog):
         mock_imap_amazon_fwd, "order", fwds="testuser@test.com", the_domain="amazon.com"
     )
     assert (
-        "Amazon email list: ['auto-confirm@amazon.com', 'testuser@test.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
+        "Amazon email list: ['testuser@test.com', 'auto-confirm@amazon.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
         in caplog.text
     )
     assert result == ["123-1234567-1234567"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -393,8 +393,9 @@ async def test_get_mails(mock_imap_no_email, mock_copyfile):
 
 @pytest.mark.asyncio
 async def test_get_mails_makedirs_error(mock_imap_no_email, mock_copyfile, caplog):
-    with patch("os.path.isdir", return_value=False), patch(
-        "os.makedirs", side_effect=OSError
+    with (
+        patch("os.path.isdir", return_value=False),
+        patch("os.makedirs", side_effect=OSError),
     ):
         get_mails(mock_imap_no_email, "./", "5", "mail_today.gif", False)
         assert "Error creating directory:" in caplog.text
@@ -713,7 +714,7 @@ async def test_royal_out_for_delivery(hass, mock_imap_royal_out_for_delivery):
 async def test_amazon_shipped_count(hass, mock_imap_amazon_shipped, caplog):
     result = get_items(mock_imap_amazon_shipped, "count", the_domain="amazon.com")
     assert (
-        "Amazon email search addresses: ['shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
+        "Amazon email search addresses: ['auto-confirm@amazon.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
         in caplog.text
     )
     assert result == 1
@@ -822,7 +823,7 @@ async def test_amazon_search_delivered(
         )
         await hass.async_block_till_done()
         assert (
-            "Amazon email search addresses: ['shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
+            "Amazon email search addresses: ['auto-confirm@amazon.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
             in caplog.text
         )
         assert result == 9
@@ -1028,8 +1029,9 @@ async def test_download_img_error(hass, aioclient_mock_error, caplog):
 async def test_image_file_name_path_error(hass, caplog):
     config = FAKE_CONFIG_DATA_CORRECTED
 
-    with patch("os.path.exists", return_value=False), patch(
-        "os.makedirs", side_effect=OSError
+    with (
+        patch("os.path.exists", return_value=False),
+        patch("os.makedirs", side_effect=OSError),
     ):
         result = image_file_name(hass, config)
         assert result == "mail_none.gif"
@@ -1042,8 +1044,9 @@ async def test_image_file_name_amazon(
 ):
     config = FAKE_CONFIG_DATA_CORRECTED
 
-    with patch("os.path.exists", return_value=True), patch(
-        "os.makedirs", return_value=True
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.makedirs", return_value=True),
     ):
         result = image_file_name(hass, config, True)
         assert result == "testfile.jpg"
@@ -1055,8 +1058,9 @@ async def test_image_file_name(
 ):
     config = FAKE_CONFIG_DATA_CORRECTED
 
-    with patch("os.path.exists", return_value=True), patch(
-        "os.makedirs", return_value=True
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.makedirs", return_value=True),
     ):
         result = image_file_name(hass, config)
         assert ".gif" in result
@@ -1084,7 +1088,7 @@ async def test_amazon_exception(hass, mock_imap_amazon_exception, caplog):
     )
     assert result["count"] == 1
     assert (
-        "Amazon email list: ['shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
+        "Amazon email list: ['auto-confirm@amazon.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
         in caplog.text
     )
 
@@ -1145,7 +1149,7 @@ async def test_amazon_shipped_fwd(hass, mock_imap_amazon_fwd, caplog):
         mock_imap_amazon_fwd, "order", fwds="testuser@test.com", the_domain="amazon.com"
     )
     assert (
-        "Amazon email list: ['testuser@test.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
+        "Amazon email list: ['auto-confirm@amazon.com', 'testuser@test.com', 'shipment-tracking@amazon.com', 'order-update@amazon.com', 'conferma-spedizione@amazon.com', 'confirmar-envio@amazon.com', 'versandbestaetigung@amazon.com', 'confirmation-commande@amazon.com', 'verzending-volgen@amazon.com', 'update-bestelling@amazon.com']"
         in caplog.text
     )
     assert result == ["123-1234567-1234567"]


### PR DESCRIPTION
## Proposed change

There is a new shipment email used by amazon; `auto-confirm`, which meant that packages weren't tracked but still marked delivered.

**note**: I'm based in the UK.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

![image](https://github.com/user-attachments/assets/a71eb87b-e332-4dab-b302-4a2808645a8f)
