### PR TITLE
fix: adjust SSL contexts to use the defaults provided by HomeAssistant

### DIFF
--- a/custom_components/mail_and_packages/binary_sensor.py
+++ b/custom_components/mail_and_packages/binary_sensor.py
@@ -4,7 +4,6 @@ import logging
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
-    BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
@@ -14,6 +13,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import BINARY_SENSORS, COORDINATOR, DOMAIN, VERSION
+from .entity import MailandPackagesBinarySensorEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class PackagesBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        sensor_description: BinarySensorEntityDescription,
+        sensor_description: MailandPackagesBinarySensorEntityDescription,
         coordinator: DataUpdateCoordinator,
         config: ConfigEntry,
     ) -> None:

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -483,15 +483,15 @@ def login(
     try:
         if security == "SSL":
             if not verify:
-                context = ssl.client_context_no_verify()
+                context = ssl.get_default_no_verify_context()
             else:
-                context = ssl.client_context()
+                context = ssl.get_default_context()
             account = imaplib.IMAP4_SSL(host=host, port=port, ssl_context=context)
         elif security == "startTLS":
             if not verify:
-                context = ssl.client_context_no_verify()
+                context = ssl.get_default_no_verify_context()
             else:
-                context = ssl.client_context()
+                context = ssl.get_default_context()
             account = imaplib.IMAP4(host=host, port=port)
             account.starttls(context)
         else:


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adjust SSL contexts to use python defaults vs `client defaults` as defined by HomeAssistant
Reference:
https://github.com/home-assistant/core/blob/22e0b0e9a77918867932135b91400b1bde8edb8b/homeassistant/util/ssl.py#L104-L139

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #1052 