### PR TITLE
refactor: a Couple of Small Issues (variable name, documentation, pytest bug)

### DIFF
--- a/DEVCONTAINER.md
+++ b/DEVCONTAINER.md
@@ -2,7 +2,7 @@
 
 The easiest way to get started with custom integration development is to use Visual Studio Code with devcontainers. This approach will create a preconfigured development environment with all the tools you need.
 
-In the container you will have a dedicated Home Assistant core instance running with your custom component code. You can configure this instance by updating the `./devcontainer/configuration.yaml` file.
+In the container you will have a dedicated Home Assistant core instance running with your custom component code. You can configure this instance by updating the `/config/configuration.yaml` file.
 
 **Prerequisites**
 
@@ -37,7 +37,7 @@ The available tasks are:
 
 Task | Description
 -- | --
-Run Home Assistant on port 9123 | Launch Home Assistant with your custom component code and the configuration defined in `.devcontainer/configuration.yaml`.
+Run Home Assistant on port 9123 | Launch Home Assistant with your custom component code and the configuration defined in `/config/configuration.yaml`.
 Run Home Assistant configuration against /config | Check the configuration.
 Upgrade Home Assistant to latest dev | Upgrade the Home Assistant core version in the container to the latest version of the `dev` branch.
 Install a specific version of Home Assistant | Install a specific version of Home Assistant core in the container.
@@ -47,7 +47,7 @@ Install a specific version of Home Assistant | Install a specific version of Hom
 With the development container,
 you can test your custom component in Home Assistant with step by step debugging.
 
-You need to modify the `configuration.yaml` file in `.devcontainer` folder
+You need to modify the `configuration.yaml` file in `/config` folder
 by uncommenting the line:
 
 ```yaml

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -413,7 +413,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_config_custom_img(user_input)
 
     async def _show_config_custom_img(self, user_input):
-        """Custom image setup."""
+        """Set up custom image."""
         # Defaults
         defaults = {
             CONF_CUSTOM_IMG_FILE: DEFAULT_CUSTOM_IMG_FILE,

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -247,7 +247,7 @@ def _get_schema_step_2(data: list, user_input: list, default_dict: list) -> Any:
     )
 
 
-def _get_schema_step_3(user_input: list, default_dict: list) -> Any:
+def _get_schema_step_custom_img(user_input: list, default_dict: list) -> Any:
     """Get a schema using the default_dict as a backup."""
     if user_input is None:
         user_input = {}
@@ -370,7 +370,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ):
                     return await self.async_step_config_amazon()
                 if self._data[CONF_CUSTOM_IMG]:
-                    return await self.async_step_config_3()
+                    return await self.async_step_config_custom_img()
                 return self.async_create_entry(
                     title=self._data[CONF_HOST], data=self._data
                 )
@@ -400,7 +400,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_config_3(self, user_input=None):
+    async def async_step_config_custom_img(self, user_input=None):
         """Configure form step 2."""
         self._errors = {}
         if user_input is not None:
@@ -408,20 +408,20 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors, user_input = await _validate_user_input(self._data)
             if len(self._errors) == 0:
                 return await self.async_step_config_storage()
-            return await self._show_config_3(user_input)
+            return await self._show_config_custom_img(user_input)
 
-        return await self._show_config_3(user_input)
+        return await self._show_config_custom_img(user_input)
 
-    async def _show_config_3(self, user_input):
-        """Step 3 setup."""
+    async def _show_config_custom_img(self, user_input):
+        """Custom image setup."""
         # Defaults
         defaults = {
             CONF_CUSTOM_IMG_FILE: DEFAULT_CUSTOM_IMG_FILE,
         }
 
         return self.async_show_form(
-            step_id="config_3",
-            data_schema=_get_schema_step_3(user_input, defaults),
+            step_id="config_custom_img",
+            data_schema=_get_schema_step_custom_img(user_input, defaults),
             errors=self._errors,
         )
 
@@ -433,7 +433,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors, user_input = await _validate_user_input(self._data)
             if len(self._errors) == 0:
                 if self._data[CONF_CUSTOM_IMG]:
-                    return await self.async_step_config_3()
+                    return await self.async_step_config_custom_img()
                 return await self.async_step_config_storage()
 
             return await self._show_config_amazon(user_input)
@@ -441,7 +441,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_config_amazon(user_input)
 
     async def _show_config_amazon(self, user_input):
-        """Step 3 setup."""
+        """Amazon setup."""
         # Defaults
         defaults = {
             CONF_AMAZON_DOMAIN: DEFAULT_AMAZON_DOMAIN,
@@ -470,7 +470,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_config_storage(user_input)
 
     async def _show_config_storage(self, user_input):
-        """Step 3 setup."""
+        """Storage setup."""
         # Defaults
         defaults = {
             CONF_STORAGE: DEFAULT_STORAGE,
@@ -528,7 +528,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ):
                     return await self.async_step_reconfig_amazon()
                 if self._data[CONF_CUSTOM_IMG]:
-                    return await self.async_step_reconfig_3()
+                    return await self.async_step_reconfig_custom_img()
 
                 return await self.async_step_reconfig_storage()
 
@@ -544,7 +544,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_reconfig_3(self, user_input=None):
+    async def async_step_reconfig_custom_img(self, user_input=None):
         """Configure form step 2."""
         self._errors = {}
         if user_input is not None:
@@ -553,20 +553,20 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if len(self._errors) == 0:
                 return await self.async_step_reconfig_storage()
 
-            return await self._show_reconfig_3(user_input)
+            return await self._show_reconfig_custom_img(user_input)
 
-        return await self._show_reconfig_3(user_input)
+        return await self._show_reconfig_custom_img(user_input)
 
-    async def _show_reconfig_3(self, user_input):
-        """Step 3 setup."""
+    async def _show_reconfig_custom_img(self, user_input):
+        """Custom image setup."""
         # Defaults
         defaults = {
             CONF_CUSTOM_IMG_FILE: DEFAULT_CUSTOM_IMG_FILE,
         }
 
         return self.async_show_form(
-            step_id="reconfig_3",
-            data_schema=_get_schema_step_3(user_input, defaults),
+            step_id="reconfig_custom_img",
+            data_schema=_get_schema_step_custom_img(user_input, defaults),
             errors=self._errors,
         )
 
@@ -578,7 +578,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors, user_input = await _validate_user_input(self._data)
             if len(self._errors) == 0:
                 if self._data[CONF_CUSTOM_IMG]:
-                    return await self.async_step_reconfig_3()
+                    return await self.async_step_reconfig_custom_img()
 
                 return await self.async_step_reconfig_storage()
 
@@ -587,7 +587,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_reconfig_amazon(user_input)
 
     async def _show_reconfig_amazon(self, user_input):
-        """Step 3 setup."""
+        """Amazon setup."""
         if self._data[CONF_AMAZON_FWDS] == []:
             self._data[CONF_AMAZON_FWDS] = "(none)"
 
@@ -616,7 +616,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_reconfig_storage(user_input)
 
     async def _show_reconfig_storage(self, user_input):
-        """Step 3 setup."""
+        """Storage 3 setup."""
         return self.async_show_form(
             step_id="reconfig_storage",
             data_schema=_get_schema_step_storage(user_input, self._data),

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -558,7 +558,7 @@ class MailAndPackagesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_reconfig_custom_img(user_input)
 
     async def _show_reconfig_custom_img(self, user_input):
-        """Custom image setup."""
+        """Set up custom image."""
         # Defaults
         defaults = {
             CONF_CUSTOM_IMG_FILE: DEFAULT_CUSTOM_IMG_FILE,

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -43,12 +43,12 @@
                 "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please separate each address with a comma.",
                 "title": "Mail and Packages (Step 2 of 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Path to custom image: (ie: images\/my_custom_no_mail.jpg)"
                 },
                 "description": "Enter the path and file name to your custom no mail image below.\n\nExample: images\/custom_nomail.gif",
-                "title": "Mail and Packages (Step 3 of 3)"
+                "title": "Mail and Packages"
             },
             "config_amazon": {
                 "data": {
@@ -88,12 +88,12 @@
                 "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please separate each address with a comma or enter (none) to clear this setting.",
                 "title": "Mail and Packages (Step 2 of 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Path to custom image: (i.e.: images\/my_custom_no_mail.jpg)"
                 },
                 "description": "Enter the path and file name to your custom no mail image below.\n\nExample: images\/custom_nomail.gif",
-                "title": "Mail and Packages (Step 3 of 3)"
+                "title": "Mail and Packages"
             },
             "reconfig_amazon": {
                 "data": {

--- a/custom_components/mail_and_packages/translations/ca.json
+++ b/custom_components/mail_and_packages/translations/ca.json
@@ -43,7 +43,7 @@
                 "description": "Finalitzeu la configuració personalitzant la següent en funció de la vostra instal·lació de correu electrònic i la instal·lació d’assistència a casa. \n\n Per obtenir més informació sobre les opcions [Integració de paquets i correus] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), reviseu les opcions [configuració, plantilles , secció i automatitzacions] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) a GitHub.",
                 "title": "Correu i paquets (pas 2 de 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Camí a la imatge personalitzada: (és a dir: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Acabeu la configuració personalitzant el següent en funció de l'estructura del vostre correu electrònic i de la instal·lació de Home Assistant.\n\nPer obtenir més detalls sobre les opcions d'[integració de correu i paquets](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), consulteu la [secció de configuració, plantilles i automatitzacions](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) a GitHub.\n\nSi utilitzeu correus electrònics reenviats d'Amazon, separeu cada adreça amb una coma o introduïu (cap) per esborrar aquesta configuració.",
                 "title": "Correu i paquets (pas 2 de 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Camí a la imatge personalitzada: (p. ex.: imatges\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/de.json
+++ b/custom_components/mail_and_packages/translations/de.json
@@ -43,7 +43,7 @@
                 "description": "Beenden Sie die Konfiguration, indem Sie Folgendes basierend auf Ihrer E-Mail-Struktur und der Installation von Home Assistant anpassen. \n\n Weitere Informationen zu den Optionen [Mail- und Paketintegration] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) finden Sie in den [Konfiguration, Vorlagen und Abschnitt Automatisierungen] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) auf GitHub.",
                 "title": "Briefe und Pakete (Schritt 2 von 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Pfad zum benutzerdefinierten Bild: (z. B.: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Schließen Sie die Konfiguration ab, indem Sie das Folgende an Ihre E-Mail-Struktur und Home Assistant-Installation anpassen.\n\nWeitere Informationen zu den [Mail und Packages Integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) Optionen finden Sie im [Konfigurations-, Vorlagen- und Automatisierungsabschnitt](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) auf GitHub.\n\nWenn Sie weitergeleitete E-Mails von Amazon verwenden, trennen Sie bitte jede Adresse durch ein Komma oder geben Sie (keine) ein, um diese Einstellung zu löschen.",
                 "title": "Briefe und Pakete (Schritt 2 von 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Pfad zum benutzerdefinierten Bild: (z.B.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -43,7 +43,7 @@
                 "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please separate each address with a comma.",
                 "title": "Mail and Packages (Step 2 of 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Path to custom image: (ie: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Finish the configuration by customizing the following based on your email structure and Home Assistant installation.\n\nFor details on the [Mail and Packages integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) options review the [configuration, templates, and automations section](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) on GitHub.\n\nIf using Amazon forwarded emails please separate each address with a comma or enter (none) to clear this setting.",
                 "title": "Mail and Packages (Step 2 of 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Path to custom image: (i.e.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/es.json
+++ b/custom_components/mail_and_packages/translations/es.json
@@ -43,7 +43,7 @@
                 "description": "Termine la configuración personalizando lo siguiente según su estructura de correo electrónico y la instalación de Home Assistant. \n\n Para obtener detalles sobre las opciones [Integración de correo y paquetes] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) revise las [configuración, plantillas , y la sección de automatizaciones] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) en GitHub.",
                 "title": "Correo y paquetes (Paso 2 de 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Ruta a la imagen personalizada: (es decir: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Finalice la configuración personalizando lo siguiente en función de la estructura de su correo electrónico y la instalación de Home Assistant.\n\nPara obtener detalles sobre las opciones de [integración de correo y paquetes](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), revise la [sección de configuración, plantillas y automatizaciones](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) en GitHub.\n\nSi utiliza correos electrónicos reenviados de Amazon, separe cada dirección con una coma o ingrese (ninguno) para borrar esta configuración.",
                 "title": "Correo y paquetes (Paso 2 de 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Ruta a la imagen personalizada: (es decir: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/es_419.json
+++ b/custom_components/mail_and_packages/translations/es_419.json
@@ -43,7 +43,7 @@
                 "description": "Termine la configuración personalizando lo siguiente según su estructura de correo electrónico y la instalación de Home Assistant. \n\n Para obtener detalles sobre las opciones [Integración de correo y paquetes] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) revise las [configuración, plantillas , y la sección de automatizaciones] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) en GitHub.",
                 "title": "Correo y paquetes (Paso 2 de 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Ruta a la imagen personalizada: (es decir: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Finalice la configuración personalizando lo siguiente en función de la estructura de su correo electrónico y la instalación de Home Assistant.\n\nPara obtener detalles sobre las opciones de [integración de correo y paquetes](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), revise la [sección de configuración, plantillas y automatizaciones](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) en GitHub.\n\nSi utiliza correos electrónicos reenviados de Amazon, separe cada dirección con una coma o ingrese (ninguno) para borrar esta configuración.",
                 "title": "Correo y paquetes (Paso 2 de 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Ruta a la imagen personalizada: (es decir: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/fi.json
+++ b/custom_components/mail_and_packages/translations/fi.json
@@ -43,7 +43,7 @@
                 "description": "Viimeistele kokoonpano mukauttamalla seuraava sähköpostirakenteen ja Home Assistant -asennuksen perusteella. \n\n Lisätietoja [Posti ja paketit-integroinnista] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) -asetuksista on [kokoonpano, mallit , ja automaatiot-osio] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) GitHubissa.",
                 "title": "Posti ja paketit (vaihe 2\/2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Polku mukautettuun kuvaan: (esim: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Suorita määritys loppuun mukauttamalla seuraavat sähköpostirakenteeseesi ja Home Assistant -asennukseesi perustuen.\n\nLisätietoja [Mail and Packages -integraation](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) vaihtoehdoista löydät GitHubista [määritys-, mallit- ja automaatiot-osiossa](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration).\n\nJos käytät Amazonin välittämiä sähköposteja, erottele jokainen osoite pilkulla tai syötä (none) tyhjentääksesi tämän asetuksen.",
                 "title": "Posti ja paketit (vaihe 2\/2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Polku mukautettuun kuvaan: (esim.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/fr.json
+++ b/custom_components/mail_and_packages/translations/fr.json
@@ -43,7 +43,7 @@
                 "description": "Terminez la configuration en personnalisant les éléments suivants en fonction de votre structure de messagerie et de l'installation de Home Assistant. \n\n Pour plus de détails sur les [Intégration de messagerie et de packages] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), passez en revue les [configuration, modèles et section automatisations] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) sur GitHub.",
                 "title": "Courrier et colis (étape 2 sur 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Chemin vers l'image personnalisée : (par exemple : images\/mon_image_personnalisée_pas_de_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Terminez la configuration en personnalisant ce qui suit en fonction de la structure de votre courrier électronique et de l'installation de Home Assistant.\n\nPour plus de détails sur les options d'[intégration de courrier et de colis](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), consultez la [section configuration, modèles et automatisations](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) sur GitHub.\n\nSi vous utilisez des courriels transférés par Amazon, veuillez séparer chaque adresse par une virgule ou entrer (aucun) pour effacer ce paramètre.",
                 "title": "Courrier et colis (étape 2 sur 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Chemin vers l'image personnalisée : (par exemple : images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/hu.json
+++ b/custom_components/mail_and_packages/translations/hu.json
@@ -43,7 +43,7 @@
                 "description": "Végezze el a konfigurációt az alábbiak testreszabásával az e-mail struktúrája és a Home Assistant telepítése alapján. \n\n A [Levelek és csomagok integrációja] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) opciókkal kapcsolatban tekintse meg a [konfiguráció, sablonok , és az automatizálás szakasz] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) a GitHubon.",
                 "title": "Levél és csomagok (2. lépés a 2-ből)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Egyéni kép elérési útja: (pl.: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Fejezze be a konfigurációt a következők testreszabásával az e-mail struktúrája és a Home Assistant telepítése alapján.\n\nA [Mail and Packages integráció](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) lehetőségeinek részleteiről a GitHub-on található [konfiguráció, sablonok és automatizálások szekcióban](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) található információkat.\n\nHa Amazon továbbított e-maileket használ, kérjük, válassza el minden címet vesszővel, vagy írja be a (none) opciót, hogy törölje ezt a beállítást.",
                 "title": "Levél és csomagok (2. lépés a 2-ből)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Egyéni kép elérési útja: (pl.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/it.json
+++ b/custom_components/mail_and_packages/translations/it.json
@@ -43,7 +43,7 @@
                 "description": "Termina la configurazione personalizzando quanto segue in base alla struttura della tua e-mail e all'installazione di Home Assistant. \n\n Per i dettagli sulle opzioni [Integrazione posta e pacchetti] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) rivedere le [configurazione, modelli e sezione automazioni] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) su GitHub.",
                 "title": "Posta e pacchi (passaggio 2 di 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Percorso per l'immagine personalizzata: (es: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Termina la configurazione personalizzando quanto segue in base alla struttura della tua email e all'installazione di Home Assistant.\n\nPer i dettagli sulle opzioni di [integrazione Mail e Pacchetti](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) consulta la [sezione configurazione, modelli e automazioni](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) su GitHub.\n\nSe utilizzi email inoltrate da Amazon, separa ogni indirizzo con una virgola o inserisci (nessuno) per cancellare questa impostazione.",
                 "title": "Posta e pacchi (passaggio 2 di 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Percorso per l'immagine personalizzata: (ad es.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/ko.json
+++ b/custom_components/mail_and_packages/translations/ko.json
@@ -43,7 +43,7 @@
                 "description": "이메일 구조 및 Home Assistant 설치에 따라 다음을 사용자 정의하여 구성을 완료하십시오. \n\n [메일 및 패키지 통합] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) 옵션에 대한 자세한 내용은 [구성, 템플릿 및 자동화 섹션] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-and-Packages\/wiki\/Configuration-and-Email-Settings#configuration)",
                 "title": "메일 및 패키지 (2\/2 단계)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "사용자 정의 이미지 경로: (예: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "이메일 구조와 Home Assistant 설치에 따라 다음을 사용자 정의하여 구성을 완료하십시오.\n\n[Mail and Packages 통합](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) 옵션에 대한 자세한 내용은 GitHub의 [구성, 템플릿, 자동화 섹션](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration)을 참조하십시오.\n\nAmazon에서 전달된 이메일을 사용하는 경우 각 주소를 쉼표로 구분하거나 이 설정을 지우려면 (none)을 입력하십시오.",
                 "title": "메일 및 패키지 (2\/2 단계)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "사용자 정의 이미지 경로: (예: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/nl.json
+++ b/custom_components/mail_and_packages/translations/nl.json
@@ -43,7 +43,7 @@
                 "description": "Voltooi de configuratie door het volgende aan te passen op basis van uw e-mailstructuur en Home Assistant-installatie. \n\n Voor meer informatie over de [E-mail en pakketten integratie] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) opties bekijk de [configuratie, sjablonen , en automatisering sectie] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) op GitHub.",
                 "title": "Mail en pakketten (stap 2 van 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Pad naar aangepaste afbeelding: (bijv: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Rond de configuratie af door het volgende aan te passen op basis van uw e-mailstructuur en Home Assistant-installatie.\n\nVoor details over de [Mail en Packages integratie](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) opties, bekijk de [configuratie, sjablonen en automatiseringen sectie](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) op GitHub.\n\nAls u doorgestuurde e-mails van Amazon gebruikt, scheid dan elk adres met een komma of voer (geen) in om deze instelling te wissen.",
                 "title": "Mail en pakketten (stap 2 van 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Pad naar aangepaste afbeelding: (bijv.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/no.json
+++ b/custom_components/mail_and_packages/translations/no.json
@@ -43,7 +43,7 @@
                 "description": "Fullfør konfigurasjonen ved å tilpasse følgende basert på e-poststrukturen og Home Assistant-installasjonen. \n\n For detaljer om alternativene [Mail and Packages] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), les gjennom [konfigurasjon, maler , og automatiseringsdel] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) på GitHub.",
                 "title": "E-post og pakker (trinn 2 av 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Sti til tilpasset bilde: (f.eks: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Fullfør konfigurasjonen ved å tilpasse følgende basert på din e-poststruktur og Home Assistant-installasjon.\n\nFor detaljer om [Mail and Packages-integrasjonen](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) alternativene, se gjennom [konfigurasjon, maler og automatiseringsseksjonen](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) på GitHub.\n\nHvis du bruker Amazon videresendte e-poster, vennligst skill hver adresse med et komma eller skriv inn (ingen) for å tømme denne innstillingen.",
                 "title": "E-post og pakker (trinn 2 av 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Sti til tilpasset bilde: (dvs.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/pl.json
+++ b/custom_components/mail_and_packages/translations/pl.json
@@ -43,7 +43,7 @@
                 "description": "Zakończ konfigurację, dostosowując następujące elementy w oparciu o strukturę poczty e-mail i instalację Home Assistant. \n\n Aby uzyskać szczegółowe informacje na temat opcji [Integracja poczty i pakietów] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) sprawdź opcje [konfiguracja, szablony i sekcja automatyzacji] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHub.",
                 "title": "Poczta i paczki (krok 2 z 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Ścieżka do niestandardowego obrazu: (np.: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Zakończ konfigurację, dostosowując następujące elementy do struktury swojego e-maila i instalacji Home Assistant.\n\nAby uzyskać szczegółowe informacje na temat opcji [integracji Mail and Packages](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), zapoznaj się z [sekcją konfiguracji, szablonów i automatyzacji](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHubie.\n\nJeśli korzystasz z przekierowanych e-maili Amazon, oddziel każdy adres przecinkiem lub wprowadź (brak), aby wyczyścić to ustawienie.",
                 "title": "Poczta i paczki (krok 2 z 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Ścieżka do niestandardowego obrazu: (np.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/pt.json
+++ b/custom_components/mail_and_packages/translations/pt.json
@@ -43,7 +43,7 @@
                 "description": "Conclua a configuração, personalizando o seguinte com base na sua estrutura de email e instalação do Home Assistant. \n\n Para obter detalhes sobre as opções [integração de Mail e Pacotes] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), revise as opções de [configuração, modelos e seção de automações] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) no GitHub.",
                 "title": "Correio e pacotes (Etapa 2 de 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Caminho para imagem personalizada: (ex: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Conclua a configuração personalizando o seguinte com base na estrutura do seu email e na instalação do Home Assistant.\n\nPara detalhes sobre as opções de [integração de Correio e Pacotes](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), consulte a [seção de configuração, modelos e automações](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) no GitHub.\n\nSe estiver usando emails encaminhados da Amazon, separe cada endereço com uma vírgula ou insira (nenhum) para limpar essa configuração.",
                 "title": "Correio e pacotes (Etapa 2 de 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Caminho para imagem personalizada: (ex.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/pt_BR.json
+++ b/custom_components/mail_and_packages/translations/pt_BR.json
@@ -43,7 +43,7 @@
                 "description": "Conclua a configuração, personalizando o seguinte com base na sua estrutura de email e instalação do Home Assistant. \n\n Para obter detalhes sobre as opções [integração de Mail e Pacotes] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), revise as opções de [configuração, modelos e seção de automações] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) no GitHub.",
                 "title": "Correio e pacotes (Etapa 2 de 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Caminho para imagem personalizada: (ex: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Conclua a configuração personalizando o seguinte com base na estrutura do seu email e na instalação do Home Assistant.\n\nPara detalhes sobre as opções de [integração de Mail e Pacotes](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration), consulte a [seção de configuração, modelos e automações](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) no GitHub.\n\nSe estiver usando emails encaminhados da Amazon, separe cada endereço com uma vírgula ou insira (nenhum) para limpar essa configuração.",
                 "title": "Correio e pacotes (Etapa 2 de 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Caminho para imagem personalizada: (ex.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/ru.json
+++ b/custom_components/mail_and_packages/translations/ru.json
@@ -43,7 +43,7 @@
                 "description": "Завершите настройку, настроив следующие параметры в зависимости от структуры электронной почты и установки Home Assistant. \n\n Подробнее о параметрах [Интеграция с почтой и пакетами] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) см. В разделе [конфигурация, шаблоны и раздел автоматизации] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) на GitHub.",
                 "title": "Почта и пакеты (шаг 2 из 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Путь к пользовательскому изображению: (например: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Завершите настройку, настроив следующее в соответствии со структурой вашей электронной почты и установкой Home Assistant.\n\nДля получения подробной информации о вариантах [интеграции Почта и Пакеты](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) ознакомьтесь с [разделом конфигурации, шаблонов и автоматизации](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) на GitHub.\n\nЕсли вы используете переадресованные электронные письма Amazon, разделите каждый адрес запятой или введите (none), чтобы очистить эту настройку.",
                 "title": "Почта и пакеты (шаг 2 из 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Путь к пользовательскому изображению: (например: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/sk.json
+++ b/custom_components/mail_and_packages/translations/sk.json
@@ -43,7 +43,7 @@
                 "description": "Dokončite konfiguráciu prispôsobením nasledujúcich položiek na základe štruktúry e-mailu a inštalácie Home Assistant.\n\nPodrobnosti nájdete na [Pošta a balíky integrácia](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) možnosti si pozrite v časti [konfigurácia, šablóny a automatizácie](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHube.",
                 "title": "Pošta a balíky (krok 2 z 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Cesta k vlastnému obrázku: (napr.: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Dokončite konfiguráciu prispôsobením nasledujúceho na základe štruktúry vášho e-mailu a inštalácie Home Assistant.\n\nPre podrobnosti o možnostiach [integrácie Mail a Packages](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) si prečítajte [sekciu o konfigurácii, šablónach a automatizáciách](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHub.\n\nAk používate preposlané e-maily od Amazonu, oddelte každú adresu čiarkou alebo zadajte (none) na vymazanie tohto nastavenia.",
                 "title": "Pošta a balíky (krok 2 z 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Cesta k vlastnému obrázku: (napr.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/sl.json
+++ b/custom_components/mail_and_packages/translations/sl.json
@@ -43,7 +43,7 @@
                 "description": "Končajte konfiguracijo s prilagoditvijo naslednjih na podlagi strukture e-pošte in namestitve Home Assistant. \n\n Za podrobnosti o možnostih [Integracija pošte in paketov] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) preglejte [konfiguracijo, predloge in oddelku za avtomatizacije] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHubu.",
                 "title": "Pošta in paketi (2. korak od 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Pot do prilagojene slike: (npr.: images\/my_custom_no_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Konfiguracijo dokončajte z prilagajanjem naslednjega glede na strukturo vašega e-poštnega sporočila in namestitev Home Assistant.\n\nZa podrobnosti o možnostih [integracije Mail and Packages](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) si oglejte [razdelek o konfiguraciji, predlogah in avtomatizacijah](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) na GitHubu.\n\nČe uporabljate preusmerjena e-poštna sporočila Amazon, ločite vsak naslov z vejico ali vnesite (noben) za izbris te nastavitve.",
                 "title": "Pošta in paketi (2. korak od 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Pot do prilagojene slike: (npr.: images\/my_custom_no_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/sv.json
+++ b/custom_components/mail_and_packages/translations/sv.json
@@ -43,7 +43,7 @@
                 "description": "Avsluta konfigurationen genom att anpassa följande baserat på din e-poststruktur och installation av hemassistent. \n\n Mer information om alternativen [Mail and Packages] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) läser [konfiguration, mallar , och automatiseringsavsnitt] (https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) på GitHub.",
                 "title": "Mail och paket (steg 2 av 2)"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "Sökväg till anpassad bild: (t.ex: bilder\/min_anpassade_ingen_mail.jpg)"
                 },
@@ -88,7 +88,7 @@
                 "description": "Slutför konfigurationen genom att anpassa följande baserat på din e-poststruktur och Home Assistant-installation.\n\nFör detaljer om [Mail and Packages integration](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) alternativen granska [konfiguration, mallar och automatiseringssektionen](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration) på GitHub.\n\nOm du använder vidarebefordrade e-postmeddelanden från Amazon, separera varje adress med ett kommatecken eller ange (ingen) för att rensa denna inställning.",
                 "title": "Mail och paket (steg 2 av 2)"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Sökväg till anpassad bild: (t.ex.: bilder\/min_anpassade_ingen_mail.jpg)"
                 },

--- a/custom_components/mail_and_packages/translations/zh_Hant_HK.json
+++ b/custom_components/mail_and_packages/translations/zh_Hant_HK.json
@@ -43,7 +43,7 @@
                 "description": "通過根據您的電子郵件結構和Home Assistant安裝自定義以下內容來完成配置。 \n\n有關[郵件和軟件包集成]（https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration）選項的詳細信息，請查看[配置，模板和自動化部分]（GitHub上的https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration）。",
                 "title": "郵件和包裹（第2步，共2步）"
             },
-            "config_3": {
+            "config_custom_img": {
                 "data": {
                     "custom_img_file": "自訂圖片的路徑：（例如：images\/my_custom_no_mail.jpg）"
                 },
@@ -88,7 +88,7 @@
                 "description": "根據您的電郵結構和Home Assistant安裝來完成配置。\n\n有關[郵件和包裹整合](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration)選項的詳情，請查閱GitHub上的[配置、模板和自動化部分](https:\/\/github.com\/moralmunky\/Home-Assistant-Mail-And-Packages\/wiki\/Configuration-and-Email-Settings#configuration)。\n\n如果使用Amazon轉發的電郵，請用逗號分隔每個地址，或輸入(none)以清除此設定。",
                 "title": "郵件和包裹（第2步，共2步）"
             },
-            "reconfig_3": {
+            "reconfig_custom_img": {
                 "data": {
                     "custom_img_file": "Path to custom image: (i.e.: images\/my_custom_no_mail.jpg)"
                 },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -81,7 +81,7 @@ _LOGGER = logging.getLogger(__name__)
                 "amazon_days": 3,
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email,amazon@example.com,fake@email%$^&@example.com,bogusemail@testamazon.com",
             },
-            "config_3",
+            "config_custom_img",
             {
                 "custom_img_file": "images/test.gif",
             },
@@ -273,7 +273,7 @@ async def test_form(
                 "amazon_days": 3,
                 "amazon_fwds": "(none)",
             },
-            "config_3",
+            "config_custom_img",
             {
                 "custom_img_file": "images/test.gif",
             },
@@ -464,7 +464,7 @@ async def test_form_no_fwds(
                 "amazon_days": 3,
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email",
             },
-            "config_3",
+            "config_custom_img",
             {
                 "custom_img_file": "images/test.gif",
             },
@@ -1997,7 +1997,7 @@ async def test_form_storage_error(
                 "amazon_days": 3,
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email",
             },
-            "reconfig_3",
+            "reconfig_custom_img",
             {
                 "custom_img_file": "images/test.gif",
             },
@@ -2191,7 +2191,7 @@ async def test_reconfigure(
                     "inpost_pl_packages",
                 ],
             },
-            "reconfig_3",
+            "reconfig_custom_img",
             {
                 "custom_img_file": "images/test.gif",
             },

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
 
 [pytest]
 asyncio_default_fixture_loop_scope=function
+asyncio_mode=auto
 
 [testenv]
 pip_version = pip>=21.0,<22.1


### PR DESCRIPTION
## Proposed change

This PR fixes a couple of small issues that I was running into while trying to learn the code:
- `step_3` in the configuration flow was renamed to `custom_img` to better reflect its purpose. `step_3` was a little confusing to me because the frontend really only refers to two steps, while the backend includes a `step_3`, which is actually just for custom images
- updated configuration path in `DEVCONTAINER.md`
- fixed issue with pytest sometimes complaining about [AttributeError: 'async_generator' object has no attribute 'data'](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/discussions/160)' 

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

n/a