### PR TITLE
Use uv instead of pip

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,17 +21,14 @@ jobs:
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@v4
-      - name: 🛠️ Set up Python
-        uses: actions/setup-python@v5
         with:
-          fetch-depth: 2      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+          fetch-depth: 2
+      - name: 🛠️ Set up uv with python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: 📦 Install requirements
-        run: |
-          pip install tox tox-gh-actions          
+        run: uv tool install tox --with tox-uv --with tox-gh-actions
       - name: 🏃 Test with tox
         run: tox
       - name: 📤 Upload coverage to Codecov

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,7 @@ python =
 asyncio_default_fixture_loop_scope=function
 
 [testenv]
-pip_version = pip>=21.0,<22.1
-install_command = python -m pip install {opts} {packages}
+uv_python_preference = only-managed
 commands =
   pytest --log-level=DEBUG --asyncio-mode=auto --timeout=30 --cov=custom_components/mail_and_packages/ --cov-report=xml {posargs}
 deps =


### PR DESCRIPTION
## Proposed change

When bumping homeassistant to the dev version for testing a new function not yet in a released version, I found that pip could not resolve the dependencies when attempting to run the tests: https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/actions/runs/14628231584/job/41046210245?pr=1095 However, when I attempted to install them locally in a venv using `uv pip install -r requirements_test.txt`, I was able to get the package resolution to complete.

This changes to use uv with tox to manage dependencies, similar to Home Assistant, which has also switched to using uv: https://developers.home-assistant.io/blog/2024/04/03/build-images-with-uv/

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

I have made the minimal changes necessary to support using uv, however the rest of the config could be moved to `pyproject.toml`, and the linters could be consolidated to using [ruff](https://docs.astral.sh/ruff/faq/) (by the authors of uv), but I didn't want to disturb too much.

- This PR is related to PR: #1095
