### PR TITLE
fix: filter out more ads for mail images

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -753,7 +753,7 @@ def get_mails(
                         elif part.get_content_type() == "image/jpeg":
                             _LOGGER.debug("Extracting image from email")
                             filename = part.get_filename()
-                            junkmail = ["mailer", "content"]
+                            junkmail = ["mailer", "content", "package"]
                             if any(junk in filename for junk in junkmail):
                                 _LOGGER.debug("Discarding junk mail.")
                                 continue


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Filter out additional advertisement images so they're not added to USPS mail images.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1103 