### PR TITLE
fix: Update Amazon sensors for delivery and shipped

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -97,7 +97,7 @@ AMAZON_DOMAINS = [
     "amazon.nl",
 ]
 AMAZON_DELIVERED_SUBJECT = [
-    "Delivered: Your",
+    "Delivered: ",
     "Your Amazon order has arrived!",
     "Consegna effettuata:",
     "Dostarczono:",
@@ -171,6 +171,7 @@ AMAZON_TIME_PATTERN_END = [
 AMAZON_TIME_PATTERN_REGEX = [
     "Arriving (\\w+ \\d+) - (\\w+ \\d+)",
     "Arriving (\\w+ \\d+)",
+    "Arriving (\\w+ ?\\d*)",
 ]
 AMAZON_EXCEPTION_SUBJECT = "Delivery update:"
 AMAZON_EXCEPTION_BODY = "running late"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,3 +12,4 @@ pytest-homeassistant-custom-component
 homeassistant
 freezegun
 cython
+turbojpeg


### PR DESCRIPTION
The regex needed to include single words for "today" to be detected, and the deliver email has changed to the following format:
```
Message-ID: <<long-uuid>@email.amazonses.com>
Subject: Delivered: 2 items | Order # 111-9196457-791234
MIME-Version: 1.0
```

## Breaking change

## Proposed change

The regex needed to include single words for "today" to be detected, and the deliver email has changed to the following format:
See - https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/issues/1111

## Type of change

This change should fix the amazon emails that were not being picked up by the sensors, 

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

I apologize in advance, as I made these changes on my phone live in home assistant and wanted to provide a quick fix for others who are having a similar issue, Hope this solves the issues other are having.

- This PR fixes or closes issue: fixes #1111
- This PR is related to issue:  #1111
