### PR TITLE
feat(shipper): update amazon sensors

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -12,7 +12,7 @@ from .entity import MailandPackagesBinarySensorEntityDescription
 
 DOMAIN = "mail_and_packages"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.4.3-b15"
+VERSION = "0.0.0-dev"  # Now updated by release workflow
 ISSUE_URL = "http://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
 PLATFORM = "sensor"
 PLATFORMS = ["binary_sensor", "camera", "sensor"]

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -119,6 +119,12 @@ AMAZON_SHIPMENT_TRACKING = [
     "verzending-volgen",
     "update-bestelling",
 ]
+AMAZON_SHIPMENT_SUBJECT = [
+    "Shipped:",
+]
+AMAZON_ORDERED_SUBJECT = [
+    "Ordered:",
+]
 AMAZON_EMAIL = ["order-update@", "update-bestelling@", "versandbestaetigung@"]
 AMAZON_PACKAGES = "amazon_packages"
 AMAZON_ORDER = "amazon_order"

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -12,7 +12,7 @@ from .entity import MailandPackagesBinarySensorEntityDescription
 
 DOMAIN = "mail_and_packages"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.4.3-b15"
+VERSION = "0.0.0-dev"
 ISSUE_URL = "http://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
 PLATFORM = "sensor"
 PLATFORMS = ["binary_sensor", "camera", "sensor"]

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -12,7 +12,7 @@ from .entity import MailandPackagesBinarySensorEntityDescription
 
 DOMAIN = "mail_and_packages"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.0-dev"
+VERSION = "0.4.3-b15"
 ISSUE_URL = "http://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
 PLATFORM = "sensor"
 PLATFORMS = ["binary_sensor", "camera", "sensor"]
@@ -204,6 +204,10 @@ AMAZON_LANGS = [
 AMAZON_OTP = "amazon_otp"
 AMAZON_OTP_REGEX = "(\n)(\\d{6})(\n)"
 AMAZON_OTP_SUBJECT = "A one-time password is required for your Amazon delivery"
+
+AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT = [
+    "AMAZON"
+]
 
 # Sensor Data
 SENSOR_DATA = {

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -205,9 +205,7 @@ AMAZON_OTP = "amazon_otp"
 AMAZON_OTP_REGEX = "(\n)(\\d{6})(\n)"
 AMAZON_OTP_SUBJECT = "A one-time password is required for your Amazon delivery"
 
-AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT = [
-    "AMAZON"
-]
+AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT = ["AMAZON"]
 
 # Sensor Data
 SENSOR_DATA = {

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -12,7 +12,7 @@ from .entity import MailandPackagesBinarySensorEntityDescription
 
 DOMAIN = "mail_and_packages"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.0-dev"  # Now updated by release workflow
+VERSION = "0.4.3-b15"
 ISSUE_URL = "http://github.com/moralmunky/Home-Assistant-Mail-And-Packages"
 PLATFORM = "sensor"
 PLATFORMS = ["binary_sensor", "camera", "sensor"]
@@ -1328,6 +1328,7 @@ SENSOR_ICON = 2
 
 # For sensors with delivering and delivered statuses
 SHIPPERS = [
+    "amazon",
     "capost",
     "dhl",
     "fedex",

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -35,6 +35,7 @@ from homeassistant.util import ssl
 from PIL import Image, ImageOps
 
 from .const import (
+    AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT,
     AMAZON_DELIVERED,
     AMAZON_DELIVERED_SUBJECT,
     AMAZON_EXCEPTION,
@@ -408,6 +409,9 @@ def fetch(
     )
 
     count = {}
+    
+    # Initialize shared variable ONCE
+    data.setdefault("amazon_delivered_by_others", 0)
 
     if sensor == "usps_mail":
         count[sensor] = get_mails(
@@ -452,7 +456,7 @@ def fetch(
     elif "_delivering" in sensor:
         prefix = sensor.replace("_delivering", "")
         delivered = fetch(hass, config, account, data, f"{prefix}_delivered")
-        info = get_count(account, sensor, True, amazon_domain=amazon_domain)
+        info = get_count(account, sensor, True, amazon_domain=amazon_domain, data=data,)
         count[sensor] = max(0, info[ATTR_COUNT] - delivered)
         count[f"{prefix}_tracking"] = info[ATTR_TRACKING]
     elif sensor == "zpackages_delivered":
@@ -463,6 +467,7 @@ def fetch(
                 count[sensor] += fetch(hass, config, account, data, delivered)
     elif sensor == "zpackages_transit":
         total = 0
+        total_delivered = 0
         for shipper in SHIPPERS:
             # There is no delivering for amazon packages because they ship themselves or use other shippers
             if shipper == "amazon":
@@ -470,13 +475,24 @@ def fetch(
             delivering = f"{shipper}_delivering"
             if delivering in data and delivering != sensor:
                 total += fetch(hass, config, account, data, delivering)
+            delivered = f"{shipper}_delivered"
+            if delivered in data and delivered != sensor:
+                total_delivered += fetch(hass, config, account, data, delivered)
+
         # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email. 
-        # But we know if we are expecting packages from amazon, and in tranit is lower than the packages, we can best guess amazon is delivering the package.
-        # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
         if "amazon_packages" in data and "amazon_packages" != sensor:
             amazon_packages = max(0, fetch(hass, config, account, data, "amazon_packages"))
+            
+            # We know if we are expecting packages from amazon, and in tranit is lower than the amazon package count, we can best guess amazon is delivering the package.
+            # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
             if amazon_packages > total:
                 total = amazon_packages
+
+            # Now if a different shipper than amazon delivers the amazon package, the amazon package count will still be counted as in transit when it was delivered. 
+            # However, some shippers state they delivered the package on behalf of amazon. We use that to information to properly decrease in transit. But not all shippers tell us. 
+            # Subtract Amazon packages we believe were delivered by other shippers
+            total -= data.get("amazon_delivered_by_others", 0)
+                
         count[sensor] = max(0, total)
     elif sensor == "mail_updated":
         count[sensor] = update_time()
@@ -491,6 +507,7 @@ def fetch(
             amazon_image_name,
             amazon_domain,
             amazon_fwds,
+            data=data,
         )[ATTR_COUNT]
 
     data.update(count)
@@ -1027,6 +1044,7 @@ def get_count(
     amazon_image_name: Optional[str] = None,
     amazon_domain: Optional[str] = None,
     amazon_fwds: Optional[str] = None,
+    data: Optional[dict] = None, 
 ) -> dict:
     """Get Package Count.
 
@@ -1062,27 +1080,38 @@ def get_count(
             subject,
         )
 
-        (server_response, data) = email_search(
+        (server_response, email_data) = email_search(
             account, SENSOR_DATA[sensor_type][ATTR_EMAIL], today, subject
         )
-        if server_response == "OK" and data[0] is not None:
+        if server_response == "OK" and email_data[0] is not None:
             if ATTR_BODY in SENSOR_DATA[sensor_type].keys():
                 body_count = SENSOR_DATA[sensor_type].get(ATTR_BODY_COUNT, False)
                 _LOGGER.debug("Check body for mail count? %s", body_count)
                 count += find_text(
-                    data, account, SENSOR_DATA[sensor_type][ATTR_BODY], body_count
+                    email_data, account, SENSOR_DATA[sensor_type][ATTR_BODY], body_count
                 )
             else:
-                count += len(data[0].split())
+                count += len(email_data[0].split())
 
             _LOGGER.debug(
                 "Search for (%s) with subject (%s) results: %s count: %s",
                 SENSOR_DATA[sensor_type][ATTR_EMAIL],
                 subject,
-                data[0],
+                email_data[0],
                 count,
             )
-            found.append(data[0])
+            found.append(email_data[0])
+            
+            # If sensor ends with "_delivered", check email content for "AMAZON". UPS, USPS will say delivered for: "AMAZON" in their email. This is used to fix in transit.
+            if sensor_type.endswith("_delivered") and sensor_type != AMAZON_DELIVERED and data is not None:
+                amazon_mentions = find_text(email_data, account, AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT, False)
+                if amazon_mentions > 0:
+                    data["amazon_delivered_by_others"] = data.get("amazon_delivered_by_others", 0) + amazon_mentions
+                    _LOGGER.debug(
+                        "Sensor: %s — Found %s mention(s) of 'AMAZON' in delivered email.",
+                        sensor_type,
+                        amazon_mentions,
+                    )
 
     if (
         f"{'_'.join(sensor_type.split('_')[:-1])}_tracking" in SENSOR_DATA

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1637,7 +1637,7 @@ def get_items(
                     # Skip 'arriving' emails that are not from today
                     if param and 'arriving' in param.lower():
                         if email_date != today_date:
-                            _LOGGER.debug(f"Skipping 'arriving' email from {email_date}, not today")
+                            _LOGGER.debug(f"Skipping 'arriving' email from %s, not today", email_date)
                             continue
 
                     _LOGGER.debug("Email Multipart: %s", str(msg.is_multipart()))

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1759,7 +1759,7 @@ def get_items(
                                 },
                             )
                             if dateobj is None:
-                                _LOGGER.debug(f"Parsed date is None for arrive_date='{arrive_date_clean}'")
+                                _LOGGER.debug(f"Parsed date is None for arrive_date='%s'", arrive_date_clean)
                                 continue
                             parsed_date_only = dateobj.date()
 

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1766,7 +1766,7 @@ def get_items(
                         if parsed_date_only == today_date:
                             deliveries_today.append(found[0] if found else "Amazon Order")
                         else:
-                            _LOGGER.debug(f"Delivery date not today: {parsed_date_only}")
+                            _LOGGER.debug(f"Delivery date not today: %s", parsed_date_only)
 
     # Remove delivered orders from deliveries_today
     deliveries_today = [

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -469,6 +469,7 @@ def fetch(
     elif sensor == "mail_updated":
         count[sensor] = update_time()
     else:
+        _LOGGER.debug("if statement sensor: %s", sensor)
         count[sensor] = get_count(
             account,
             sensor,
@@ -1562,6 +1563,7 @@ def get_items(
 
     Returns list of order numbers or email count as integer
     """
+
     _LOGGER.debug("Attempting to find Amazon email with item list ...")
 
     # Limit to past X days
@@ -1569,6 +1571,7 @@ def get_items(
     tfmt = past_date.strftime("%d-%b-%Y")
     deliveries_today = []
     order_number = []
+    amazon_delivered = []
 
     address_list = amazon_email_addresses(fwds, the_domain)
     _LOGGER.debug("Amazon email list: %s", str(address_list))
@@ -1585,10 +1588,25 @@ def get_items(
                 if isinstance(response_part, tuple):
                     msg = email.message_from_bytes(response_part[1])
 
+                    # Parse email date
+                    email_date_str = msg.get("Date")
+                    email_date = None
+                    if email_date_str:
+                        email_date = email.utils.parsedate_to_datetime(email_date_str).date()
+                    _LOGGER.debug("Email from date: %s", str(email_date))
+
+                    today_date = datetime.date.today()
+
+                    # Skip 'arriving' emails that are not from today
+                    if param and 'arriving' in param.lower():
+                        if email_date != today_date:
+                            _LOGGER.debug(f"Skipping 'arriving' email from {email_date}, not today")
+                            continue
+
                     _LOGGER.debug("Email Multipart: %s", str(msg.is_multipart()))
                     _LOGGER.debug("Content Type: %s", str(msg.get_content_type()))
 
-                    # Get order number from subject line
+                    # Get and decode subject line
                     encoding = decode_header(msg["subject"])[0][1]
                     if encoding is not None:
                         email_subject = decode_header(msg["subject"])[0][0].decode(
@@ -1598,20 +1616,33 @@ def get_items(
                         email_subject = decode_header(msg["subject"])[0][0]
 
                     if not isinstance(email_subject, str):
-                        _LOGGER.debug("Converting subject to string.")
                         email_subject = email_subject.decode("utf-8", "ignore")
 
                     _LOGGER.debug("Amazon Subject: %s", str(email_subject))
-                    pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
 
-                    # Don't add the same order number twice
+                    # Skip delivered emails and record order numbers
+                    if any(subj.lower() in email_subject.lower() for subj in AMAZON_DELIVERED_SUBJECT):
+                        pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
+                        delivered_orders = pattern.findall(email_subject)
+                        if delivered_orders:
+                            for o in delivered_orders:
+                                if o not in amazon_delivered:
+                                    amazon_delivered.append(o)
+                                    _LOGGER.debug("Delivered order found and stored: %s", o)
+                        else:
+                            _LOGGER.debug("Delivered email found, but no order number matched.")
+                        continue  # Skip processing this email
+
+                    # Extract order number from subject
+                    pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
                     if (
                         (found := pattern.findall(email_subject))
-                        and len(found) > 0
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])
+                        _LOGGER.debug("Amazon order number found and appended: %s", str(found[0]))
 
+                    # Try decoding email body
                     try:
                         if msg.is_multipart():
                             email_msg = quopri.decodestring(str(msg.get_payload(0)))
@@ -1621,16 +1652,18 @@ def get_items(
                         _LOGGER.debug("Problem decoding email message: %s", str(err))
                         _LOGGER.error("Unable to process this email. Skipping.")
                         continue
+
                     email_msg = email_msg.decode("utf-8", "ignore")
 
-                    # Check message body for order number
+                    # Check message body for order number again
                     if (
                         (found := pattern.findall(email_msg))
-                        and len(found) > 0
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])
+                        _LOGGER.debug("Amazon order number found and appended again: %s", str(found[0]))
 
+                    # Check for arrival date
                     for search in AMAZON_TIME_PATTERN:
                         _LOGGER.debug("Looking for: %s", search)
                         if search not in email_msg:
@@ -1640,36 +1673,70 @@ def get_items(
                         if amazon_regex_result is not None:
                             _LOGGER.debug("Found regex result: %s", amazon_regex_result)
                             arrive_date = amazon_regex_result
-
                         else:
                             start = email_msg.find(search) + len(search)
                             end = amazon_date_search(email_msg)
-
                             arrive_date = email_msg[start:end].replace(">", "").strip()
-                            _LOGGER.debug("First pass: %s", arrive_date)
-                            arrive_date = arrive_date.split(" ")
-                            arrive_date = arrive_date[0:3]
-                            arrive_date = " ".join(arrive_date).strip()
+                            arrive_date = " ".join(arrive_date.split()[0:3])
 
-                        # Get the date object
-                        dateobj = dateparser.parse(arrive_date)
+                        # --- Arrival date logic ---
+                        weekday_map = {
+                            "monday": 0,
+                            "tuesday": 1,
+                            "wednesday": 2,
+                            "thursday": 3,
+                            "friday": 4,
+                            "saturday": 5,
+                            "sunday": 6,
+                        }
 
-                        if (
-                            dateobj is not None
-                            and dateobj.day == datetime.date.today().day
-                            and dateobj.month == datetime.date.today().month
-                        ):
-                            deliveries_today.append("Amazon Order")
+                        arrive_date_clean = arrive_date.lower()
+                        is_single_word = len(arrive_date_clean.split()) == 1
 
+                        if is_single_word and arrive_date_clean in weekday_map:
+                            email_weekday = email_date.weekday()
+                            arrive_weekday = weekday_map[arrive_date_clean]
+                            days_ahead = (arrive_weekday - email_weekday) % 7
+                            arrive_date_obj = email_date + datetime.timedelta(days=days_ahead)
+
+                            if arrive_date_obj < today_date:
+                                _LOGGER.debug(f"Skipping single-word arrive_date '{arrive_date_clean}' as arrival date {arrive_date_obj} is before today {today_date}")
+                                continue
+
+                            parsed_date_only = arrive_date_obj
+                        else:
+                            dateobj = dateparser.parse(
+                                arrive_date_clean,
+                                settings={
+                                    "PREFER_DATES_FROM": "future",
+                                    "RELATIVE_BASE": datetime.datetime.combine(email_date, datetime.time()),
+                                    "RETURN_AS_TIMEZONE_AWARE": False,
+                                },
+                            )
+                            if dateobj is None:
+                                _LOGGER.debug(f"Parsed date is None for arrive_date='{arrive_date_clean}'")
+                                continue
+                            parsed_date_only = dateobj.date()
+
+                        if parsed_date_only == today_date:
+                            deliveries_today.append(found[0] if found else "Amazon Order")
+                        else:
+                            _LOGGER.debug(f"Delivery date not today: {parsed_date_only}")
+
+    # Remove delivered orders from deliveries_today
+    deliveries_today = [
+        item for item in deliveries_today if item not in amazon_delivered
+    ]
+
+    # Return delivery count or list of order numbers
     value = None
     if param == "count":
-        _LOGGER.debug("Amazon Count: %s", str(len(deliveries_today)))
-        if len(deliveries_today) > len(order_number):
-            value = len(order_number)
-        else:
-            value = len(deliveries_today)
+        _LOGGER.debug("Amazon Delivery Count (today, not delivered): %s", str(len(deliveries_today)))
+        _LOGGER.debug("Amazon Order Count: %s", str(len(order_number)))
+        value = min(len(deliveries_today), len(order_number))
     else:
         _LOGGER.debug("Amazon order: %s", str(order_number))
         value = order_number
 
+    _LOGGER.debug("Amazon value: %s", str(value))
     return value

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1750,14 +1750,19 @@ def get_items(
 
                             parsed_date_only = arrive_date_obj
                         else:
-                            dateobj = dateparser.parse(
-                                arrive_date_clean,
-                                settings={
-                                    "PREFER_DATES_FROM": "future",
-                                    "RELATIVE_BASE": datetime.datetime.combine(email_date, datetime.time()),
-                                    "RETURN_AS_TIMEZONE_AWARE": False,
-                                },
-                            )
+                            dateobj = None
+                            # Some tests don't have a date on the email
+                            if email_date is None:
+                                dateobj = dateparser.parse(arrive_date_clean)
+                            else:
+                                dateobj = dateparser.parse(
+                                    arrive_date_clean,
+                                    settings={
+                                        "PREFER_DATES_FROM": "future",
+                                        "RELATIVE_BASE": datetime.datetime.combine(email_date, datetime.time()),
+                                        "RETURN_AS_TIMEZONE_AWARE": False,
+                                    },
+                                )
                             if dateobj is None:
                                 _LOGGER.debug(f"Parsed date is None for arrive_date='%s'", arrive_date_clean)
                                 continue

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -467,7 +467,6 @@ def fetch(
                 count[sensor] += fetch(hass, config, account, data, delivered)
     elif sensor == "zpackages_transit":
         total = 0
-        total_delivered = 0
         for shipper in SHIPPERS:
             # There is no delivering for amazon packages because they ship themselves or use other shippers
             if shipper == "amazon":
@@ -475,9 +474,6 @@ def fetch(
             delivering = f"{shipper}_delivering"
             if delivering in data and delivering != sensor:
                 total += fetch(hass, config, account, data, delivering)
-            delivered = f"{shipper}_delivered"
-            if delivered in data and delivered != sensor:
-                total_delivered += fetch(hass, config, account, data, delivered)
 
         # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email. 
         if "amazon_packages" in data and "amazon_packages" != sensor:

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -462,9 +462,19 @@ def fetch(
     elif sensor == "zpackages_transit":
         total = 0
         for shipper in SHIPPERS:
+            # There is no delivering for amazon packages because they ship themselves or use other shippers
+            if shipper == "amazon":
+                continue
             delivering = f"{shipper}_delivering"
             if delivering in data and delivering != sensor:
                 total += fetch(hass, config, account, data, delivering)
+        # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email. 
+        # But we know if we are expecting packages from amazon, and in tranit is lower than the packages, we can best guess amazon is delivering the package.
+        # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
+        if "amazon_packages" in data and "amazon_packages" != sensor:
+            amazon_packages = max(0, fetch(hass, config, account, data, "amazon_packages"))
+            if amazon_packages > total:
+                total = amazon_packages
         count[sensor] = max(0, total)
     elif sensor == "mail_updated":
         count[sensor] = update_time()

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -42,7 +42,6 @@ from .const import (
     AMAZON_EXCEPTION_ORDER,
     AMAZON_EXCEPTION_SUBJECT,
     AMAZON_ORDERED_SUBJECT,
-    AMAZON_SHIPMENT_SUBJECT,
     AMAZON_HUB,
     AMAZON_HUB_BODY,
     AMAZON_HUB_CODE,
@@ -409,7 +408,7 @@ def fetch(
     )
 
     count = {}
-    
+
     # Initialize shared variable ONCE
     data.setdefault("amazon_delivered_by_others", 0)
 
@@ -475,20 +474,22 @@ def fetch(
             if delivering in data and delivering != sensor:
                 total += fetch(hass, config, account, data, delivering)
 
-        # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email. 
+        # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email.
         if "amazon_packages" in data and "amazon_packages" != sensor:
-            amazon_packages = max(0, fetch(hass, config, account, data, "amazon_packages"))
-            
+            amazon_packages = max(
+                0, fetch(hass, config, account, data, "amazon_packages")
+            )
+
             # We know if we are expecting packages from amazon, and in tranit is lower than the amazon package count, we can best guess amazon is delivering the package.
             # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
             if amazon_packages > total:
                 total = amazon_packages
 
-            # Now if a different shipper than amazon delivers the amazon package, the amazon package count will still be counted as in transit when it was delivered. 
-            # However, some shippers state they delivered the package on behalf of amazon. We use that to information to properly decrease in transit. But not all shippers tell us. 
+            # Now if a different shipper than amazon delivers the amazon package, the amazon package count will still be counted as in transit when it was delivered.
+            # However, some shippers state they delivered the package on behalf of amazon. We use that to information to properly decrease in transit. But not all shippers tell us.
             # Subtract Amazon packages we believe were delivered by other shippers
             total -= data.get("amazon_delivered_by_others", 0)
-                
+
         count[sensor] = max(0, total)
     elif sensor == "mail_updated":
         count[sensor] = update_time()
@@ -1040,7 +1041,7 @@ def get_count(
     amazon_image_name: Optional[str] = None,
     amazon_domain: Optional[str] = None,
     amazon_fwds: Optional[str] = None,
-    data: Optional[dict] = None, 
+    data: Optional[dict] = None,
 ) -> dict:
     """Get Package Count.
 
@@ -1097,12 +1098,20 @@ def get_count(
                 count,
             )
             found.append(email_data[0])
-            
+
             # If sensor ends with "_delivered", check email content for "AMAZON". UPS, USPS will say delivered for: "AMAZON" in their email. This is used to fix in transit.
-            if sensor_type.endswith("_delivered") and sensor_type != AMAZON_DELIVERED and data is not None:
-                amazon_mentions = find_text(email_data, account, AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT, False)
+            if (
+                sensor_type.endswith("_delivered")
+                and sensor_type != AMAZON_DELIVERED
+                and data is not None
+            ):
+                amazon_mentions = find_text(
+                    email_data, account, AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT, False
+                )
                 if amazon_mentions > 0:
-                    data["amazon_delivered_by_others"] = data.get("amazon_delivered_by_others", 0) + amazon_mentions
+                    data["amazon_delivered_by_others"] = (
+                        data.get("amazon_delivered_by_others", 0) + amazon_mentions
+                    )
                     _LOGGER.debug(
                         "Sensor: %s — Found %s mention(s) of 'AMAZON' in delivered email.",
                         sensor_type,
@@ -1155,14 +1164,16 @@ def get_tracking(
 
                 # Search subject for a tracking number
                 email_subject = msg["subject"]
-                if (found := pattern.findall(email_subject)) and len(found) > 0:
-                    _LOGGER.debug(
-                        "Found tracking number in email subject: (%s)",
-                        found[0],
-                    )
-                    if found[0] not in tracking:
-                        tracking.append(found[0])
-                    continue
+                if email_subject:
+                    email_subject = str(email_subject)
+                    if (found := pattern.findall(email_subject)) and len(found) > 0:
+                        _LOGGER.debug(
+                            "Found tracking number in email subject: (%s)",
+                            found[0],
+                        )
+                        if found[0] not in tracking:
+                            tracking.append(found[0])
+                        continue
 
                 # Search in email body for tracking number
                 _LOGGER.debug("Checking message body using %s ...", the_format)
@@ -1629,15 +1640,21 @@ def get_items(
                     email_date_str = msg.get("Date")
                     email_date = None
                     if email_date_str:
-                        email_date = email.utils.parsedate_to_datetime(email_date_str).date()
+                        email_date = email.utils.parsedate_to_datetime(
+                            email_date_str
+                        ).date()
                     _LOGGER.debug("Email from date: %s", str(email_date))
 
                     today_date = datetime.date.today()
 
                     # Skip 'arriving' emails that are not from today
-                    if param and 'arriving' in param.lower():
+                    # if param and "arriving" in param.lower():
+                    if param and param.lower() == "arriving":
                         if email_date != today_date:
-                            _LOGGER.debug(f"Skipping 'arriving' email from %s, not today", email_date)
+                            _LOGGER.debug(
+                                "Skipping 'arriving' email from %s, not today",
+                                email_date,
+                            )
                             continue
 
                     _LOGGER.debug("Email Multipart: %s", str(msg.is_multipart()))
@@ -1656,25 +1673,35 @@ def get_items(
                         email_subject = email_subject.decode("utf-8", "ignore")
 
                     _LOGGER.debug("Amazon Subject: %s", str(email_subject))
-                    
+
                     # Skip ordered emails because the product hasn't shipped yet.
-                    if any(subj.lower() in email_subject.lower() for subj in AMAZON_ORDERED_SUBJECT):
+                    if any(
+                        subj.lower() in email_subject.lower()
+                        for subj in AMAZON_ORDERED_SUBJECT
+                    ):
                         _LOGGER.debug("Ordered email found, skipping.")
                         continue  # Skip processing this email
-                    
+
                     # Order number pattern
                     pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
-                    
+
                     # Skip delivered emails and record order numbers
-                    if any(subj.lower() in email_subject.lower() for subj in AMAZON_DELIVERED_SUBJECT):
+                    if any(
+                        subj.lower() in email_subject.lower()
+                        for subj in AMAZON_DELIVERED_SUBJECT
+                    ):
                         delivered_orders = pattern.findall(email_subject)
                         if delivered_orders:
                             for o in delivered_orders:
                                 if o not in amazon_delivered:
                                     amazon_delivered.append(o)
-                                    _LOGGER.debug("Delivered order found and stored: %s", o)
+                                    _LOGGER.debug(
+                                        "Delivered order found and stored: %s", o
+                                    )
                         else:
-                            _LOGGER.debug("Delivered email found, but no order number matched.")
+                            _LOGGER.debug(
+                                "Delivered email found, but no order number matched."
+                            )
                         continue  # Skip processing this email
 
                     # Extract order number from subject
@@ -1684,7 +1711,9 @@ def get_items(
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])
-                        _LOGGER.debug("Amazon order number found and appended: %s", str(found[0]))
+                        _LOGGER.debug(
+                            "Amazon order number found and appended: %s", str(found[0])
+                        )
 
                     # Try decoding email body
                     try:
@@ -1706,7 +1735,10 @@ def get_items(
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])
-                        _LOGGER.debug("Amazon order number found and appended again: %s", str(found[0]))
+                        _LOGGER.debug(
+                            "Amazon order number found and appended again: %s",
+                            str(found[0]),
+                        )
 
                     # Check for arrival date
                     for search in AMAZON_TIME_PATTERN:
@@ -1722,6 +1754,7 @@ def get_items(
                             start = email_msg.find(search) + len(search)
                             end = amazon_date_search(email_msg)
                             arrive_date = email_msg[start:end].replace(">", "").strip()
+                            _LOGGER.debug("First pass: %s", arrive_date)
                             arrive_date = " ".join(arrive_date.split()[0:3])
 
                         # --- Arrival date logic ---
@@ -1742,10 +1775,17 @@ def get_items(
                             email_weekday = email_date.weekday()
                             arrive_weekday = weekday_map[arrive_date_clean]
                             days_ahead = (arrive_weekday - email_weekday) % 7
-                            arrive_date_obj = email_date + datetime.timedelta(days=days_ahead)
+                            arrive_date_obj = email_date + datetime.timedelta(
+                                days=days_ahead
+                            )
 
                             if arrive_date_obj < today_date:
-                                _LOGGER.debug(f"Skipping single-word arrive_date '%s' as arrival date %s is before today %s", arrive_date_clean, arrive_date_obj, today_date)
+                                _LOGGER.debug(
+                                    "Skipping single-word arrive_date '%s' as arrival date %s is before today %s",
+                                    arrive_date_clean,
+                                    arrive_date_obj,
+                                    today_date,
+                                )
                                 continue
 
                             parsed_date_only = arrive_date_obj
@@ -1759,19 +1799,28 @@ def get_items(
                                     arrive_date_clean,
                                     settings={
                                         "PREFER_DATES_FROM": "future",
-                                        "RELATIVE_BASE": datetime.datetime.combine(email_date, datetime.time()),
+                                        "RELATIVE_BASE": datetime.datetime.combine(
+                                            email_date, datetime.time()
+                                        ),
                                         "RETURN_AS_TIMEZONE_AWARE": False,
                                     },
                                 )
                             if dateobj is None:
-                                _LOGGER.debug(f"Parsed date is None for arrive_date='%s'", arrive_date_clean)
+                                _LOGGER.debug(
+                                    "Parsed date is None for arrive_date='%s'",
+                                    arrive_date_clean,
+                                )
                                 continue
                             parsed_date_only = dateobj.date()
 
                         if parsed_date_only == today_date:
-                            deliveries_today.append(found[0] if found else "Amazon Order")
+                            deliveries_today.append(
+                                found[0] if found else "Amazon Order"
+                            )
                         else:
-                            _LOGGER.debug(f"Delivery date not today: %s", parsed_date_only)
+                            _LOGGER.debug(
+                                "Delivery date not today: %s", parsed_date_only
+                            )
 
     # Remove delivered orders from deliveries_today
     deliveries_today = [
@@ -1781,7 +1830,10 @@ def get_items(
     # Return delivery count or list of order numbers
     value = None
     if param == "count":
-        _LOGGER.debug("Amazon Delivery Count (today, not delivered): %s", str(len(deliveries_today)))
+        _LOGGER.debug(
+            "Amazon Delivery Count (today, not delivered): %s",
+            str(len(deliveries_today)),
+        )
         _LOGGER.debug("Amazon Order Count: %s", str(len(order_number)))
         value = min(len(deliveries_today), len(order_number))
     else:

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -456,7 +456,7 @@ def fetch(
     elif "_delivering" in sensor:
         prefix = sensor.replace("_delivering", "")
         delivered = fetch(hass, config, account, data, f"{prefix}_delivered")
-        info = get_count(account, sensor, True, amazon_domain=amazon_domain, data=data,)
+        info = get_count(account, sensor, True, amazon_domain=amazon_domain, data=data)
         count[sensor] = max(0, info[ATTR_COUNT] - delivered)
         count[f"{prefix}_tracking"] = info[ATTR_TRACKING]
     elif sensor == "zpackages_delivered":

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -467,25 +467,33 @@ def fetch(
     elif sensor == "zpackages_transit":
         total = 0
         for shipper in SHIPPERS:
-            # There is no delivering for amazon packages because they ship themselves or use other shippers
+            # There is no delivering for amazon packages because they ship themselves
+            # or use other shippers
             if shipper == "amazon":
                 continue
             delivering = f"{shipper}_delivering"
             if delivering in data and delivering != sensor:
                 total += fetch(hass, config, account, data, delivering)
 
-        # We are going to best guess for in transit as amazon doesn't reveal who the shipper is in email.
+        # We are going to best guess for in transit as amazon doesn't reveal who the
+        # shipper is in email.
         if "amazon_packages" in data and "amazon_packages" != sensor:
             amazon_packages = max(
                 0, fetch(hass, config, account, data, "amazon_packages")
             )
 
-            # We know if we are expecting packages from amazon, and in tranit is lower than the amazon package count, we can best guess amazon is delivering the package.
-            # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
+            # We know if we are expecting packages from amazon, and in tranit is lower
+            # than the amazon package count, we can best guess amazon is delivering the
+            # package. This will fail though if say there are 2 packages being delivered,
+            # 1 from amazon and another from another shipper. This would report 1 less
+            # in this example in transit.
             total = max(total, amazon_packages)
 
-            # Now if a different shipper than amazon delivers the amazon package, the amazon package count will still be counted as in transit when it was delivered.
-            # However, some shippers state they delivered the package on behalf of amazon. We use that to information to properly decrease in transit. But not all shippers tell us.
+            # Now if a different shipper than amazon delivers the amazon package, the
+            # amazon package count will still be counted as in transit when it was
+            # delivered. However, some shippers state they delivered the package on
+            # behalf of amazon. We use that to information to properly decrease in
+            # transit. But not all shippers tell us.
             # Subtract Amazon packages we believe were delivered by other shippers
             total -= data.get("amazon_delivered_by_others", 0)
 
@@ -1098,7 +1106,9 @@ def get_count(
             )
             found.append(email_data[0])
 
-            # If sensor ends with "_delivered", check email content for "AMAZON". UPS, USPS will say delivered for: "AMAZON" in their email. This is used to fix in transit.
+            # If sensor ends with "_delivered", check email content for "AMAZON". UPS,
+            # USPS will say delivered for: "AMAZON" in their email. This is used to
+            # fix in transit.
             if (
                 sensor_type.endswith("_delivered")
                 and sensor_type != AMAZON_DELIVERED

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1745,7 +1745,7 @@ def get_items(
                             arrive_date_obj = email_date + datetime.timedelta(days=days_ahead)
 
                             if arrive_date_obj < today_date:
-                                _LOGGER.debug(f"Skipping single-word arrive_date '{arrive_date_clean}' as arrival date {arrive_date_obj} is before today {today_date}")
+                                _LOGGER.debug(f"Skipping single-word arrive_date '%s' as arrival date %s is before today %s", arrive_date_clean, arrive_date_obj, today_date)
                                 continue
 
                             parsed_date_only = arrive_date_obj

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -1677,6 +1677,7 @@ def get_items(
                     # Check message body for order number again
                     if (
                         (found := pattern.findall(email_msg))
+                        and len(found) > 0
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -482,8 +482,7 @@ def fetch(
 
             # We know if we are expecting packages from amazon, and in tranit is lower than the amazon package count, we can best guess amazon is delivering the package.
             # This will fail though if say there are 2 packages being delivered, 1 from amazon and another from another shipper. This would report 1 less in this example in transit.
-            if amazon_packages > total:
-                total = amazon_packages
+            total = max(total, amazon_packages)
 
             # Now if a different shipper than amazon delivers the amazon package, the amazon package count will still be counted as in transit when it was delivered.
             # However, some shippers state they delivered the package on behalf of amazon. We use that to information to properly decrease in transit. But not all shippers tell us.
@@ -1611,7 +1610,6 @@ def get_items(
 
     Returns list of order numbers or email count as integer
     """
-
     _LOGGER.debug("Attempting to find Amazon email with item list ...")
 
     # Limit to past X days
@@ -1781,7 +1779,8 @@ def get_items(
 
                             if arrive_date_obj < today_date:
                                 _LOGGER.debug(
-                                    "Skipping single-word arrive_date '%s' as arrival date %s is before today %s",
+                                    "Skipping single-word arrive_date '%s' as arrival "
+                                    "date %s is before today %s",
                                     arrive_date_clean,
                                     arrive_date_obj,
                                     today_date,

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -40,6 +40,8 @@ from .const import (
     AMAZON_EXCEPTION,
     AMAZON_EXCEPTION_ORDER,
     AMAZON_EXCEPTION_SUBJECT,
+    AMAZON_ORDERED_SUBJECT,
+    AMAZON_SHIPMENT_SUBJECT,
     AMAZON_HUB,
     AMAZON_HUB_BODY,
     AMAZON_HUB_CODE,
@@ -1629,10 +1631,17 @@ def get_items(
                         email_subject = email_subject.decode("utf-8", "ignore")
 
                     _LOGGER.debug("Amazon Subject: %s", str(email_subject))
-
+                    
+                    # Skip ordered emails because the product hasn't shipped yet.
+                    if any(subj.lower() in email_subject.lower() for subj in AMAZON_ORDERED_SUBJECT):
+                        _LOGGER.debug("Ordered email found, skipping.")
+                        continue  # Skip processing this email
+                    
+                    # Order number pattern
+                    pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
+                    
                     # Skip delivered emails and record order numbers
                     if any(subj.lower() in email_subject.lower() for subj in AMAZON_DELIVERED_SUBJECT):
-                        pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
                         delivered_orders = pattern.findall(email_subject)
                         if delivered_orders:
                             for o in delivered_orders:
@@ -1644,9 +1653,9 @@ def get_items(
                         continue  # Skip processing this email
 
                     # Extract order number from subject
-                    pattern = re.compile(r"[0-9]{3}-[0-9]{7}-[0-9]{7}")
                     if (
                         (found := pattern.findall(email_subject))
+                        and len(found) > 0
                         and found[0] not in order_number
                     ):
                         order_number.append(found[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ async def integration_fixture(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_no_path")
@@ -79,7 +79,7 @@ async def integration_fixture_2(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_no_timeout")
@@ -95,7 +95,7 @@ async def integration_fixture_3(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_fwd_string")
@@ -116,7 +116,7 @@ async def integration_fixture_4(hass, caplog):
 
     assert CONF_AMAZON_DOMAIN in entry.data
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_custom_img")
@@ -131,7 +131,7 @@ async def integration_fixture_5(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_fake_external")
@@ -146,7 +146,7 @@ async def integration_fixture_6(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_v4_migration")
@@ -162,7 +162,7 @@ async def integration_fixture_7(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture(name="integration_capost")
@@ -178,7 +178,7 @@ async def integration_fixture_8(hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    return entry
+    yield entry
 
 
 @pytest.fixture()
@@ -1779,6 +1779,87 @@ def mock_imap_capost_mail():
         mock_conn.search.return_value = ("OK", [b"1"])
         mock_conn.uid.return_value = ("OK", [b"1"])
         f = open("tests/test_emails/capost_mail.eml", "r")
+        email_file = f.read()
+        mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
+        mock_conn.select.return_value = ("OK", [])
+
+        yield mock_conn
+
+
+@pytest.fixture()
+def mock_imap_ups_delivered():
+    """Mock imap class values."""
+    with patch(
+        "custom_components.mail_and_packages.helpers.imaplib"
+    ) as mock_imap_ups_delivered:
+        mock_conn = mock.Mock(autospec=imaplib.IMAP4_SSL)
+        mock_imap_ups_delivered.IMAP4_SSL.return_value = mock_conn
+
+        mock_conn.login.return_value = (
+            "OK",
+            [b"user@fake.email authenticated (Success)"],
+        )
+        mock_conn.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"'],
+        )
+        mock_conn.search.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = ("OK", [b"1"])
+        f = open("tests/test_emails/ups_delivered.eml", "r")
+        email_file = f.read()
+        mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
+        mock_conn.select.return_value = ("OK", [])
+
+        yield mock_conn
+
+
+@pytest.fixture()
+def mock_imap_usps_delivered_individual():
+    """Mock imap class values."""
+    with patch(
+        "custom_components.mail_and_packages.helpers.imaplib"
+    ) as mock_imap_usps_delivered_individual:
+        mock_conn = mock.Mock(autospec=imaplib.IMAP4_SSL)
+        mock_imap_usps_delivered_individual.IMAP4_SSL.return_value = mock_conn
+
+        mock_conn.login.return_value = (
+            "OK",
+            [b"user@fake.email authenticated (Success)"],
+        )
+        mock_conn.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"'],
+        )
+        mock_conn.search.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = ("OK", [b"1"])
+        f = open("tests/test_emails/usps_delivered.eml", "r")
+        email_file = f.read()
+        mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
+        mock_conn.select.return_value = ("OK", [])
+
+        yield mock_conn
+
+
+@pytest.fixture()
+def mock_imap_amazon_arriving_today():
+    """Mock imap class values."""
+    with patch(
+        "custom_components.mail_and_packages.helpers.imaplib"
+    ) as mock_imap_amazon_arriving_today:
+        mock_conn = mock.Mock(autospec=imaplib.IMAP4_SSL)
+        mock_imap_amazon_arriving_today.IMAP4_SSL.return_value = mock_conn
+
+        mock_conn.login.return_value = (
+            "OK",
+            [b"user@fake.email authenticated (Success)"],
+        )
+        mock_conn.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"'],
+        )
+        mock_conn.search.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = ("OK", [b"1"])
+        f = open("tests/test_emails/amazon_out_for_delivery_today.eml", "r")
         email_file = f.read()
         mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
         mock_conn.select.return_value = ("OK", [])

--- a/tests/test_emails/amazon_arriving_today.eml
+++ b/tests/test_emails/amazon_arriving_today.eml
@@ -1,0 +1,42 @@
+From: auto-confirm@amazon.com
+To: xxxx@gmail.com
+Subject: Your package was shipped!
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="----=_Part_1636611_29050709.1751435985464"
+
+------=_Part_1636611_29050709.1751435985464
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+=20
+Your Orders
+
+https://www.amazon.com/gp/css/order-history?ref_=xxxx
+
+Your Account
+
+https://www.amazon.com/your-account?ref_=xxxx
+
+Buy Again
+
+https://www.amazon.com/gp/buyagain?ref_=xxxx
+
+
+    Your package was shipped!
+Ordered
+
+Shipped
+
+Out for delivery
+
+Delivered
+
+
+
+
+
+
+
+
+
+Arriving today

--- a/tests/test_emails/amazon_out_for_delivery_today.eml
+++ b/tests/test_emails/amazon_out_for_delivery_today.eml
@@ -1,0 +1,42 @@
+From: auto-confirm@amazon.com
+To: xxxx@gmail.com
+Subject: Your package was shipped!
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="----=_Part_1636611_29050709.1751435985464"
+
+------=_Part_1636611_29050709.1751435985464
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+=20
+Your Orders
+
+https://www.amazon.com/gp/css/order-history?ref_=xxxx
+
+Your Account
+
+https://www.amazon.com/your-account?ref_=xxxx
+
+Buy Again
+
+https://www.amazon.com/gp/buyagain?ref_=xxxx
+
+
+    Your package was shipped!
+Ordered
+
+Shipped
+
+Out for delivery
+
+Delivered
+
+
+
+
+
+
+
+
+
+Arriving today

--- a/tests/test_emails/ups_delivered.eml
+++ b/tests/test_emails/ups_delivered.eml
@@ -1,0 +1,44 @@
+From: UPS <mcinfo@ups.com>
+To: XXXX@gmail.com
+Subject: Your UPS Package was delivered
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary=----NextPart_1752095906717.0000462794
+Date: Wed, 9 Jul 2025 17:18:26 -0400 (EDT)
+
+------NextPart_1752095906717.0000462794
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>UPS</title>
+</head>
+<body>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;" class="responsive-table">
+        <tbody>
+            <tr id="shipperAndArrivalRow">
+                <td bgcolor="#ffffff" align="center" class="padding-copy" style="padding-top:0px; padding-bottom:20px;">
+                    <table role="presentation"  border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;" class="responsive-table">
+                        <tbody>
+                            <tr>
+                                <td align="center" valign="top" style="padding-left:10px; padding-right:10px; font-family: 'Roboto', Tahoma, Arial, Helvetica, sans-serif; font-size:16px; font-weight: normal; color: #121212; line-height:1;">
+                                    <span id="shipperAndArrival" style="line-height:1;">From <strong>AMAZON.COM</strong> </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td align="center" valign="top" style="padding-left:10px; padding-right:10px; font-family: 'Roboto', Tahoma, Arial, Helvetica, sans-serif; font-size:16px; font-weight: normal; color: #121212; line-height:1;">
+                    <span>Tracking Number: 1Z2345YY0678901234</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>
+
+------NextPart_1752095906717.0000462794--

--- a/tests/test_emails/usps_delivered.eml
+++ b/tests/test_emails/usps_delivered.eml
@@ -1,0 +1,31 @@
+From: auto-reply@usps.com
+Date: Sun, 27 Jul 2025 12:15:12 -0500 (CDT)
+Sender: auto-reply@usps.com
+To: xxxx@gmail.com
+Message-ID: <84xxxx.xxx7.xxxxx.JavaMail.ppts2_b@eagnmnmep25d5.usps.gov>
+Subject: USPS® Item Delivered, Left with Individual xxxxxxx
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>USPS</title>
+</head>
+<body>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;" class="responsive-table">
+        <tbody>
+            <tr>
+                <td style="text-align: center;font-size: 20px;">
+                    <p style="font-family: sans-serif;text-align: left;">Hello <strong></strong>,</p>
+                    <p style="font-family: sans-serif;text-align: left;">Your item was delivered to an individual at the address at 1:07 pm on July 27, 2025 in NEW CANAN, CT 06840.</p>
+                    <p style="font-family: sans-serif;text-align: left;">Tracking Number: <a style="color:#3573B1; font-family: sans-serif;font-weight:bold;text-decoration: underline;" href="https://tools.usps.com/go/TrackConfirmAction?tLabels=9400100000000000000000&utm_source=delivered&utm_medium=email&utm_content=tracking-number&utm_campaign=trackingnotify">9400100000000000000000</a></p>
+                    <p style="text-align: left;font-family: sans-serif;">Package Shipped from: <strong>AMAZON</strong></p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Proposed change

I was having issues with the global counts for "delivery" and "in transit" sensors since amazon switched to a single word delivery day (IE tomorrow, today, saturday) vs the old email. While the last change I introduced fixes the specific amazon "in transit" sensor, it wasn't being picked up in the global "in transit total" sensor or the "delivered total" sensor.  This change I have been running for a few weeks locally to test, and have been testing in real life with various shippers and combinations of them. So far, no issues.

Prequel Note: Changes to the function get_items():
Because amazon now uses 1 word as the delivery day, I had issues where the email "Delivery expected Saturday" was incorrectly  being counted for a past Saturday. IE. Say you set the addon to grab 14 days worth of emails, and 14 days ago you got an email saying "expected delivery Saturday" and coincidentally today was also a Saturday.  Then the "In transit" sensor would mark an expected package for today. The new code checks the original date of the email and then get the Saturday after that email, and then compares that date to todays date to determine if it should increment any of the sensors. In addition, there are also changes for "In transit" made. See below. 

Delivered Sensor:
For the delivered sensor, I have noticed that USPS, UPS, FedEx, etc send me the delivery email when the shipped package from amazon is delivered by these 3rd party shippers. However, Amazon sends a unique "Delivered" email when the package is delivered by Amazon.  This change will now look for that email and then increment the "total delivered" sensor if the date matches, vs before amazon "delivered" emails were not added to the global delivered sensor. 

In Transit Sensor:
The global In transit sensor is tricky because amazon sends an email stating that a package is expected to arrive, but they may use a 3rd party shipper or themselves. To combat this, I make a "best guess" to increment the "in transit" sensor.  Unfortunately, there is no metadata in the email that determines if amazon is using a 3rd party - just a link to view the item and then once manually clicked, it will tell you the shipper (like UPS). What I proposed is that if all other "delivering" sensors combined are less than the "amazon package" sensor total, we set the "in transit" sensor to the amazon sensor number.  That way its more accurate. IE. if amazon is shipping 1 package, but USPS, UPS, FedEx, etc are all 0 for delivering, then the "in transit" sensor will now be set to the amazon sensor, or 1 in this case. 
Note: this will fail if one orders from amazon and another from UPS. "In transit" should show 2, but will incorrectly show 1 now because it makes the incorrect assumption that the amazon package being delivered is by UPS and not a separate package.  But I found this better than telling me 0 were in transit, when one was coming from amazon.
In addition, I noticed we never decrement the "amazon package" count after its delivered by amazon.  I corrected this issue by checking for the "delivered" email in the get_items() function and grabbing the order number from the subject and then remove it from the "amazon package" sensor so it correctly shows the right number. 

Open for any suggestions to improve this process as well.  Because I took the time out to correct this and create this for my satisfaction, I hope this PR helps others as well. 

## Type of change


- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information


- This PR fixes or closes issue: fixes #1111
- This PR is related to issue:
