### PR TITLE
fix: Enable usps_mail_delivered binary sensor and fetch its data

### DIFF
--- a/custom_components/mail_and_packages/binary_sensor.py
+++ b/custom_components/mail_and_packages/binary_sensor.py
@@ -37,7 +37,7 @@ BINARY_SENSORS = {
     "usps_mail_delivered": MailandPackagesBinarySensorEntityDescription(
         name="USPS Mail Delivered",
         key="usps_mail_delivered",
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
         selectable=True,
     ),
 }

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -321,6 +321,17 @@ def process_emails(hass: HomeAssistant, config: ConfigEntry) -> dict:
         except Exception as err:
             _LOGGER.error("Error updating sensor: %s reason: %s", sensor, err)
 
+    # Always update binary sensors (they need data even if not in resources)
+    # Import here to avoid circular dependency
+    from .binary_sensor import BINARY_SENSORS
+
+    for sensor_key in BINARY_SENSORS:
+        if sensor_key in SENSOR_DATA:
+            try:
+                fetch(hass, config, account, data, sensor_key)
+            except Exception as err:
+                _LOGGER.error("Error updating binary sensor: %s reason: %s", sensor_key, err)
+
     # Copy image file to www directory if enabled
     if config.get(CONF_ALLOW_EXTERNAL):
         copy_images(hass, config)


### PR DESCRIPTION
The usps_mail_delivered binary sensor was defined but not functional because:
1. Its data was never fetched from the email account (only sensors in the resources list were fetched)
2. It was disabled by default, making it invisible to users

This commit fixes both issues:
- Modified helpers.py to automatically fetch data for all binary sensors that have SENSOR_DATA entries, ensuring usps_mail_delivered gets updated when "Your Mail Was Delivered" emails arrive from USPS
- Changed entity_registry_enabled_default from False to True so the sensor is visible and usable by default

Tested with real USPS delivery confirmation emails with subject line pattern "Your Mail Was Delivered [Day, Mon DD]".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
