### PR TITLE
feat: Add German carrier support and fix Amazon default image

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -347,6 +347,7 @@ SENSOR_DATA = {
             "Your package is now out for delivery",
             "Your shipment is out for delivery today",
             "out for delivery today",
+            "Ihre Sendung wird voraussichtlich heute zugestellt",
         ],
     },
     "fedex_packages": {},
@@ -391,6 +392,7 @@ SENSOR_DATA = {
             "Powiadomienie o przesyłce",
             "wurde zugestellt",
             "DHL Shipment Notification",
+            "liegt am gewünschten Ablageort",
         ],
         "body": [
             "has been delivered",
@@ -415,6 +417,8 @@ SENSOR_DATA = {
             "wird gleich zugestellt",
             "Powiadomienie o przesyłce",
             "DHL Shipment Notification",
+            "ist unterwegs",
+            "Jetzt Live verfolgen",
         ],
         "body": [
             "scheduled for delivery TODAY",
@@ -427,7 +431,7 @@ SENSOR_DATA = {
         ],
     },
     "dhl_packages": {},
-    "dhl_tracking": {"pattern": ["\\d{10,11}"]},
+    "dhl_tracking": {"pattern": ["(?:JJD\\d{18}|JVGL\\d{20}|00\\d{18}|(?<![0-9])\\d{10,11}(?![0-9]))"]},
     # Hermes.co.uk
     "hermes_delivered": {
         "email": ["donotreply@myhermes.co.uk"],

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -431,7 +431,11 @@ SENSOR_DATA = {
         ],
     },
     "dhl_packages": {},
-    "dhl_tracking": {"pattern": ["(?:JJD\\d{18}|JVGL\\d{20}|00\\d{18}|(?<![0-9])\\d{10,11}(?![0-9]))"]},
+    "dhl_tracking": {
+        "pattern": [
+            "(?:JJD\\d{18}|JVGL\\d{20}|00\\d{18}|(?<![0-9])\\d{10,11}(?![0-9]))"
+        ]
+    },
     # Hermes.co.uk
     "hermes_delivered": {
         "email": ["donotreply@myhermes.co.uk"],

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -2152,12 +2152,12 @@ def get_amazon_image(
         hass.add_job(download_img(hass, img_url, image_path, image_name))
     else:
         # No S3 delivery image found in emails, use default image
-        _LOGGER.debug("No Amazon delivery image found in emails, using default.")
-        nomail = f"{Path(__file__).parent}/no_deliveries_amazon.jpg"
         try:
+            _LOGGER.debug("No Amazon delivery image found in emails, using default.")
+            nomail = f"{Path(__file__).parent}/no_deliveries_amazon.jpg"
             copyfile(nomail, f"{image_path}amazon/{image_name}")
-        except Exception as err:
-            _LOGGER.error("Error attempting to copy default image: %s", str(err))
+        except OSError as err:
+            _LOGGER.error("Error attempting to copy default image: %s", err)
 
 
 async def download_img(

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -2151,7 +2151,13 @@ def get_amazon_image(
         _LOGGER.debug("Attempting to download Amazon image.")
         hass.add_job(download_img(hass, img_url, image_path, image_name))
     else:
-        _LOGGER.debug("Amazon delivery image not found in email.")
+        # No S3 delivery image found in emails, use default image
+        _LOGGER.debug("No Amazon delivery image found in emails, using default.")
+        nomail = f"{Path(__file__).parent}/no_deliveries_amazon.jpg"
+        try:
+            copyfile(nomail, f"{image_path}amazon/{image_name}")
+        except Exception as err:
+            _LOGGER.error("Error attempting to copy default image: %s", str(err))
 
 
 async def download_img(


### PR DESCRIPTION
## Proposed change

This PR adds support for German carrier email patterns and fixes the Amazon default image fallback issue.

### Changes:

1. **Fix Amazon default image fallback** (`helpers.py`)

   - When Amazon "Delivered" emails are found but don't contain an S3 delivery photo URL, the integration now copies the default `no_deliveries_amazon.jpg` instead of leaving an empty image.

2. **Add German DHL patterns** (`const.py`)

   - `dhl_delivered` subject: `"liegt am gewünschten Ablageort"` (at drop-off location)
   - `dhl_delivering` subject: `"ist unterwegs"`, `"Jetzt Live verfolgen"` (is on the way, track live)

3. **Add German FedEx pattern** (`const.py`)

   - `fedex_delivering` subject: `"Ihre Sendung wird voraussichtlich heute zugestellt"`

4. **Enhanced DHL tracking regex** (`const.py`)
   ```
   (?:JJD\d{18}|JVGL\d{20}|00\d{18}|(?<![0-9])\d{10,11}(?![0-9]))
   ```
   Captures German DHL tracking formats:
   - `JJD` + 18 digits (German domestic)
   - `JVGL` + 20 digits (German logistics)
   - `00` + 18 digits (German format)
   - 10-11 digits (international, with boundary checks)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

Tested with real German email data over 30 days:

- 11 Amazon delivered emails (8 without S3 images → now show default)
- 5 German DHL tracking numbers captured (previously 0)
- Unmatched carrier emails reduced from 10 to 2

- This PR fixes or closes issue: fixes #1166