### PR TITLE
feat: Update Dragonfly to support dutch amazon packages

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -677,6 +677,8 @@ SENSOR_DATA = {
             "notifications@intelcom.ca",
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
+            "notifications@nl.dragonflyinternational.com",
+            
         ],
         "subject": [
             "Your order has been delivered!",
@@ -684,6 +686,7 @@ SENSOR_DATA = {
             "Hooray! Your package is here",
             "Votre commande a été livrée!",
             "Votre colis a été livré!",
+            "We hebben je pakket bezorgd!",
         ],
     },
     "intelcom_delivering": {
@@ -691,12 +694,14 @@ SENSOR_DATA = {
             "notifications@intelcom.ca",
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
+            "notifications@nl.dragonflyinternational.com",
         ],
         "subject": [
             "Your package is on the way!",
             "Your package is on its way",
             "Votre colis est en chemin!",
             "package is on its way",
+            "Vandaag bezorgen we je pakket",
         ],
     },
     "intelcom_packages": {
@@ -704,14 +709,16 @@ SENSOR_DATA = {
             "notifications@intelcom.ca",
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
+            "notifications@nl.dragonflyinternational.com",
         ],
         "subject": [
             "Your package has been received!",
             "We've received your package",
             "We've received your",
+            "Je pakket is bij ons aangekomen",
         ],
     },
-    "intelcom_tracking": {"pattern": ["NSPRSO[0-9]{10}"]},
+    "intelcom_tracking": {"pattern": ["(NSPRSO[0-9]{10}|AMZNL[0-9]{12})"]},
     # Walmart
     "walmart_delivering": {
         "email": ["help@walmart.com"],

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -677,8 +677,7 @@ SENSOR_DATA = {
             "notifications@intelcom.ca",
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
-            "notifications@nl.dragonflyinternational.com",
-            
+            "notifications@nl.dragonflyinternational.com",   
         ],
         "subject": [
             "Your order has been delivered!",


### PR DESCRIPTION
## Proposed change

Amazon Netherlands now uses Dragonfly shipping for their packages. 
They have their down prefix and sent mail a Dutch mail adres, this PR adds support for it. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

