### PR TITLE
feat: Improve IMAP search compatibility by stripping non-ASCII characters from subjects and always using `charset=None`.

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -763,10 +763,13 @@ def build_search(address: list, date: str, subject: str = "") -> tuple:
     """Build IMAP search query.
 
     Return tuple of utf8 flag and search query.
+    Non-ASCII characters are stripped from subject to ensure compatibility
+    with servers that only support US-ASCII charset (e.g. Microsoft Exchange).
+    IMAP SUBJECT performs substring matching, so stripping non-ASCII chars
+    still matches the original subject (e.g. 'Livr' matches 'Livré').
     """
     the_date = f"SINCE {date}"
     imap_search = None
-    utf8_flag = False
     prefix_list = None
     email_list = None
 
@@ -779,14 +782,12 @@ def build_search(address: list, date: str, subject: str = "") -> tuple:
     _LOGGER.debug("DEBUG subject: %s", subject)
 
     if subject is not None:
-        if not subject.isascii():
-            utf8_flag = True
+        # Strip non-ASCII characters for IMAP server compatibility
+        safe_subject = subject.encode("ascii", "ignore").decode("ascii")
         if prefix_list is not None:
-            imap_search = (
-                f'({prefix_list} FROM "{email_list}" SUBJECT "{subject}" {the_date})'
-            )
+            imap_search = f'({prefix_list} FROM "{email_list}" SUBJECT "{safe_subject}" {the_date})'
         else:
-            imap_search = f'(FROM "{email_list}" SUBJECT "{subject}" {the_date})'
+            imap_search = f'(FROM "{email_list}" SUBJECT "{safe_subject}" {the_date})'
     elif prefix_list is not None:
         imap_search = f'({prefix_list} FROM "{email_list}" {the_date})'
     else:
@@ -794,20 +795,22 @@ def build_search(address: list, date: str, subject: str = "") -> tuple:
 
     _LOGGER.debug("DEBUG imap_search: %s", imap_search)
 
-    return (utf8_flag, imap_search)
+    return (False, imap_search)
 
 
 async def email_search(
     account: IMAP4_SSL, address: list, date: str, subject: str = ""
 ) -> tuple:
-    """Search emails with from, subject, and date asynchronously."""
-    utf8_flag, search = build_search(address, date, subject)
+    """Search emails with from, subject, and date asynchronously.
+
+    Always uses charset=None to avoid sending CHARSET in the IMAP SEARCH
+    command, ensuring compatibility with servers like Microsoft Exchange
+    that only support US-ASCII.
+    """
+    _unused, search = build_search(address, date, subject)
 
     try:
-        if utf8_flag:
-            res = await account.search(search, charset="UTF-8")
-        else:
-            res = await account.search(search)
+        res = await account.search(search, charset=None)
     except (AioImapException, OSError) as err:
         _LOGGER.error("Error searching emails: %s", err)
         return ("BAD", str(err))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4198,18 +4198,22 @@ async def test_login_exception(hass, caplog):
 
 @pytest.mark.asyncio
 async def test_email_search_unicode_error(caplog):
-    """Test email search with unicode characters failure."""
+    """Test email search with unicode characters strips non-ASCII and uses charset=None."""
     mock_imap = MagicMock()
-    # Simulate OSError during a literal search
-    mock_imap.search.side_effect = OSError("Literal search failed")
+    # Simulate OSError during search
+    mock_imap.search.side_effect = OSError("Search failed")
 
-    # Passing a non-ascii subject triggers the utf8_flag logic
+    # Passing a non-ascii subject should still work (stripped to ASCII)
     check, value = await email_search(
         mock_imap, ["test@test.com"], "01-Jan-2024", subject="Pâckage"
     )
 
     assert check == "BAD"
-    assert "Error searching emails: Literal search failed" in caplog.text
+    assert "Error searching emails: Search failed" in caplog.text
+    # Verify charset=None was used (not UTF-8)
+    mock_imap.search.assert_called_once()
+    call_kwargs = mock_imap.search.call_args
+    assert call_kwargs[1]["charset"] is None
 
 
 def test_cleanup_images_directory_missing(caplog):
@@ -4887,6 +4891,52 @@ def test_build_search_no_subject():
 
     assert utf8 is False
     assert search == '(FROM "test1@test.com" SINCE 01-Jan-2024)'
+
+
+def test_build_search_non_ascii_subject():
+    """Test build_search strips non-ASCII characters from subject."""
+    addresses = ["test@test.com"]
+    # French subject with accented character
+    utf8, search = build_search(addresses, "01-Jan-2024", subject="Livré")
+    assert utf8 is False
+    # "Livré" should be stripped to "Livr"
+    assert 'SUBJECT "Livr"' in search
+    assert "é" not in search
+
+    # Polish subject with special characters
+    utf8, search = build_search(addresses, "01-Jan-2024", subject="została doręczona")
+    assert utf8 is False
+    assert 'SUBJECT "zostaa dorczona"' in search
+
+
+def test_build_search_ascii_subject_unchanged():
+    """Test build_search does not modify ASCII-only subjects."""
+    addresses = ["test@test.com"]
+    utf8, search = build_search(addresses, "01-Jan-2024", subject="Delivered: ")
+    assert utf8 is False
+    assert 'SUBJECT "Delivered: "' in search
+
+
+@pytest.mark.asyncio
+async def test_email_search_always_uses_charset_none():
+    """Test email_search always passes charset=None to account.search()."""
+    mock_imap = MagicMock()
+    mock_res = MagicMock()
+    mock_res.result = "OK"
+    mock_res.lines = [b"1 2"]
+    mock_imap.search = AsyncMock(return_value=mock_res)
+
+    # Test with ASCII subject
+    await email_search(mock_imap, ["test@test.com"], "01-Jan-2024", subject="Delivered")
+    call_kwargs = mock_imap.search.call_args
+    assert call_kwargs[1]["charset"] is None
+
+    mock_imap.search.reset_mock()
+
+    # Test with non-ASCII subject - should still use charset=None
+    await email_search(mock_imap, ["test@test.com"], "01-Jan-2024", subject="Livré")
+    call_kwargs = mock_imap.search.call_args
+    assert call_kwargs[1]["charset"] is None
 
 
 # @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve IMAP search compatibility by stripping non-ASCII characters from subjects


## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1205 
- This PR is related to issue: n/a
