### PR TITLE
fix(beta): Direct OAuth2 completion to the reconfig_2 step when reconfiguring an existing entry.

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -722,6 +722,8 @@ class MailAndPackagesFlowHandler(
     ) -> config_entries.ConfigFlowResult:
         """Handle OAuth2 completion — store token and continue to step 2."""
         self._data.update(data)
+        if self._entry:
+            return await self.async_step_reconfig_2()
         return await self.async_step_config_2()
 
     async def _show_auth_form(self, user_input):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7184,6 +7184,7 @@ async def test_oauth_reconfig_flow_selection(hass, mock_imap_no_email, integrati
 
         handler = MailAndPackagesFlowHandler()
         handler.hass = hass
+        handler._entry = entry  # noqa: SLF001
         handler._data = {  # noqa: SLF001
             "auth_type": "oauth2_google",
             "host": "imap.test.email",
@@ -7206,7 +7207,7 @@ async def test_oauth_reconfig_flow_selection(hass, mock_imap_no_email, integrati
         ):
             result2 = await handler.async_oauth_create_entry({"access_token": "fake"})
             assert result2["type"] == "form"
-            assert result2["step_id"] == "config_2"
+            assert result2["step_id"] == "reconfig_2"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix oauth step2 reconfigure not populating existing config.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: n/a
