### PR TITLE
feat: rebase DHL DE and AliExpress mail support

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -408,6 +408,11 @@ SENSOR_DATA = {
             "wurde zugestellt",
             "DHL Shipment Notification",
             "liegt am gewünschten Ablageort",
+            "Ihre Sendung liegt im Briefkasten",
+            "Zustellung an Ablageort",
+            "Sendung zugestellt",
+            "Paket wurde zugestellt",
+            "Ihre AliExpress Sendung liegt im Briefkasten",
             "succesvol bezorgd",
             "is bezorgd",
         ],
@@ -417,6 +422,10 @@ SENSOR_DATA = {
             "ist angekommen",
             'Notification for shipment event group "Delivered',
             " - Delivered - ",
+            "liegt im Briefkasten",
+            "zugestellt",
+            "Zustellung",
+            "wurde zugestellt",
             "succesvol bezorgd",
             "is bezorgd",
             "pakket is afgeleverd",
@@ -894,6 +903,47 @@ SENSOR_DATA = {
         "subject": ["Deine Rechnung zu"],
         "body": ["Im Anhang dieser E-Mail kommt"],
     },
+    # AliExpress
+    "aliexpress_delivered": {
+        "email": [
+            "promotion@aliexpress.com",
+            "transaction@notice.aliexpress.com",
+            "chocieservice@aliexpress.com",
+            "aebuyersservices@aliexpress.com",
+        ],
+        "subject": [
+            "Package delivered",
+            "Your package has been delivered",
+            "Sendung zugestellt",
+        ],
+        "body": [
+            "delivered",
+            "zugestellt",
+        ],
+    },
+    "aliexpress_delivering": {
+        "email": [
+            "promotion@aliexpress.com",
+            "transaction@notice.aliexpress.com",
+            "chocieservice@aliexpress.com",
+            "aebuyersservices@aliexpress.com",
+        ],
+        "subject": [
+            "Package is on the way",
+            "Your package is on the way",
+            "Ihre Sendung ist unterwegs",
+            "Sendung wird versandt",
+        ],
+        "body": [
+            "on the way",
+            "unterwegs",
+            "wird versandt",
+        ],
+    },
+    "aliexpress_packages": {},
+    "aliexpress_tracking": {
+        "pattern": ["(?:[A-Z]{2}[0-9]{9}[A-Z]{2}|[0-9]{13}|[0-9]{20})"],
+    },
     # DPD Netherlands
     "dpd_nl_delivered": {
         "email": [
@@ -1066,6 +1116,25 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Mail Amazon OTP Code",
         icon="mdi:counter",
         key="amazon_otp",
+    ),
+    # AliExpress
+    "aliexpress_delivered": SensorEntityDescription(
+        name="Mail AliExpress Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="aliexpress_delivered",
+    ),
+    "aliexpress_delivering": SensorEntityDescription(
+        name="Mail AliExpress Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="aliexpress_delivering",
+    ),
+    "aliexpress_packages": SensorEntityDescription(
+        name="Mail AliExpress Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="aliexpress_packages",
     ),
     # Canada Post
     "capost_delivered": SensorEntityDescription(

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -448,6 +448,11 @@ SENSOR_DATA = {
             "wurde zugestellt",
             "DHL Shipment Notification",
             "liegt am gewünschten Ablageort",
+            "Ihre Sendung liegt im Briefkasten",
+            "Zustellung an Ablageort",
+            "Sendung zugestellt",
+            "Paket wurde zugestellt",
+            "Ihre AliExpress Sendung liegt im Briefkasten",
             "succesvol bezorgd",
             "is bezorgd",
         ],
@@ -457,6 +462,10 @@ SENSOR_DATA = {
             "ist angekommen",
             'Notification for shipment event group "Delivered',
             " - Delivered - ",
+            "liegt im Briefkasten",
+            "zugestellt",
+            "Zustellung",
+            "wurde zugestellt",
             "succesvol bezorgd",
             "is bezorgd",
             "pakket is afgeleverd",
@@ -943,6 +952,47 @@ SENSOR_DATA = {
         "subject": ["Deine Rechnung zu"],
         "body": ["Im Anhang dieser E-Mail kommt"],
     },
+    # AliExpress
+    "aliexpress_delivered": {
+        "email": [
+            "promotion@aliexpress.com",
+            "transaction@notice.aliexpress.com",
+            "chocieservice@aliexpress.com",
+            "aebuyersservices@aliexpress.com",
+        ],
+        "subject": [
+            "Package delivered",
+            "Your package has been delivered",
+            "Sendung zugestellt",
+        ],
+        "body": [
+            "delivered",
+            "zugestellt",
+        ],
+    },
+    "aliexpress_delivering": {
+        "email": [
+            "promotion@aliexpress.com",
+            "transaction@notice.aliexpress.com",
+            "chocieservice@aliexpress.com",
+            "aebuyersservices@aliexpress.com",
+        ],
+        "subject": [
+            "Package is on the way",
+            "Your package is on the way",
+            "Ihre Sendung ist unterwegs",
+            "Sendung wird versandt",
+        ],
+        "body": [
+            "on the way",
+            "unterwegs",
+            "wird versandt",
+        ],
+    },
+    "aliexpress_packages": {},
+    "aliexpress_tracking": {
+        "pattern": ["(?:[A-Z]{2}[0-9]{9}[A-Z]{2}|[0-9]{13}|[0-9]{20})"],
+    },
     # DPD Netherlands
     "dpd_nl_delivered": {
         "email": [
@@ -1121,6 +1171,25 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Mail Amazon OTP Code",
         icon="mdi:counter",
         key="amazon_otp",
+    ),
+    # AliExpress
+    "aliexpress_delivered": SensorEntityDescription(
+        name="Mail AliExpress Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="aliexpress_delivered",
+    ),
+    "aliexpress_delivering": SensorEntityDescription(
+        name="Mail AliExpress Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="aliexpress_delivering",
+    ),
+    "aliexpress_packages": SensorEntityDescription(
+        name="Mail AliExpress Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="aliexpress_packages",
     ),
     # Canada Post
     "capost_delivered": SensorEntityDescription(

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -45,18 +45,19 @@ def get_decoded_subject(msg: email.message.Message) -> str:
     header_val = msg["subject"]
     if not header_val:
         return ""
-    decoded = decode_header(header_val)[0]
-    subject_bytes, encoding = decoded
-    if encoding:
-        try:
-            if isinstance(subject_bytes, bytes):
-                return subject_bytes.decode(encoding, "ignore")
-            return str(subject_bytes)
-        except (LookupError, UnicodeError):
-            pass
-    if isinstance(subject_bytes, bytes):
-        return subject_bytes.decode("utf-8", "ignore")
-    return str(subject_bytes)
+    decoded_parts = []
+    for subject_bytes, encoding in decode_header(header_val):
+        if isinstance(subject_bytes, bytes):
+            if encoding:
+                try:
+                    decoded_parts.append(subject_bytes.decode(encoding, "ignore"))
+                    continue
+                except (LookupError, UnicodeError):
+                    pass
+            decoded_parts.append(subject_bytes.decode("utf-8", "ignore"))
+        else:
+            decoded_parts.append(str(subject_bytes))
+    return "".join(decoded_parts)
 
 
 def get_email_body(msg: email.message.Message) -> str:

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -89,21 +89,30 @@ def filter_amazon_strings(strings: list[str], domain: str) -> list[str]:
 def get_decoded_subject(msg: email.message.Message) -> str:
     """Decode email subject."""
     header_val = msg["subject"]
-    if not header_val:
+    if header_val:
+        decoded_parts = []
+        for subject_bytes, encoding in decode_header(header_val):
+            if isinstance(subject_bytes, bytes):
+                if encoding:
+                    try:
+                        decoded_parts.append(subject_bytes.decode(encoding, "ignore"))
+                        continue
+                    except (LookupError, UnicodeError):
+                        pass
+                decoded_parts.append(subject_bytes.decode("utf-8", "ignore"))
+            else:
+                decoded_parts.append(str(subject_bytes))
+        return "".join(decoded_parts)
+
+    body = get_email_body(msg)
+    if not body:
         return ""
-    decoded_parts = []
-    for subject_bytes, encoding in decode_header(header_val):
-        if isinstance(subject_bytes, bytes):
-            if encoding:
-                try:
-                    decoded_parts.append(subject_bytes.decode(encoding, "ignore"))
-                    continue
-                except (LookupError, UnicodeError):
-                    pass
-            decoded_parts.append(subject_bytes.decode("utf-8", "ignore"))
-        else:
-            decoded_parts.append(str(subject_bytes))
-    return "".join(decoded_parts)
+    title_match = re.search(
+        r"<title[^>]*>([^<]+)</title>", body, re.IGNORECASE | re.DOTALL
+    )
+    if not title_match:
+        return ""
+    return title_match.group(1).strip()
 
 
 def get_email_body(msg: email.message.Message) -> str:

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -91,18 +91,19 @@ def get_decoded_subject(msg: email.message.Message) -> str:
     header_val = msg["subject"]
     if not header_val:
         return ""
-    decoded = decode_header(header_val)[0]
-    subject_bytes, encoding = decoded
-    if encoding:
-        try:
-            if isinstance(subject_bytes, bytes):
-                return subject_bytes.decode(encoding, "ignore")
-            return str(subject_bytes)
-        except (LookupError, UnicodeError):
-            pass
-    if isinstance(subject_bytes, bytes):
-        return subject_bytes.decode("utf-8", "ignore")
-    return str(subject_bytes)
+    decoded_parts = []
+    for subject_bytes, encoding in decode_header(header_val):
+        if isinstance(subject_bytes, bytes):
+            if encoding:
+                try:
+                    decoded_parts.append(subject_bytes.decode(encoding, "ignore"))
+                    continue
+                except (LookupError, UnicodeError):
+                    pass
+            decoded_parts.append(subject_bytes.decode("utf-8", "ignore"))
+        else:
+            decoded_parts.append(str(subject_bytes))
+    return "".join(decoded_parts)
 
 
 def get_email_body(msg: email.message.Message) -> str:

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -544,3 +544,32 @@ async def test_generic_image_reset_on_zero_count(hass):
         assert result[ATTR_COUNT] == 0
         # This is what we are testing: it should be called even if count is 0
         mock_copy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_aliexpress_delivered_class(hass):
+    """Test AliExpress delivered email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_account = AsyncMock()
+
+    with (
+        patch.object(
+            shipper,
+            "_broad_search_then_filter",
+            new_callable=AsyncMock,
+            return_value=["1"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["LP123456789DE"],
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "aliexpress_delivered")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["LP123456789DE"]

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1014,3 +1014,37 @@ async def test_ups_packages_uses_since_date(hass):
     mock_search.assert_called_once()
     # since_date should be passed as the search date, not the regular date
     assert mock_search.call_args.args[2] == "19-Apr-2026"
+
+
+@pytest.mark.asyncio
+async def test_aliexpress_delivered_class(hass):
+    """Test AliExpress delivered email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch.object(
+            shipper,
+            "_verify_matched_subjects",
+            new_callable=AsyncMock,
+            return_value=[b"1"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(1, [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["LP123456789DE"],
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "aliexpress_delivered")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["LP123456789DE"]

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -153,6 +153,14 @@ def test_get_decoded_subject_non_bytes_decoded():
         assert get_decoded_subject(msg) == "String Subject"
 
 
+def test_get_decoded_subject_multiple_encoded_parts():
+    """Test get_decoded_subject joins multi-part encoded headers."""
+    msg = email.message_from_string(
+        "Subject: =?UTF-8?Q?Ihre_Sendung?= =?UTF-8?Q?_ist_unterwegs_=F0=9F=9A=9A?="
+    )
+    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001F69A"
+
+
 def test_amazon_email_addresses_various_fwds():
     """Test amazon_email_addresses with various fwd types (Line 119)."""
     # Test with None (triggers Line 119)

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -158,7 +158,7 @@ def test_get_decoded_subject_multiple_encoded_parts():
     msg = email.message_from_string(
         "Subject: =?UTF-8?Q?Ihre_Sendung?= =?UTF-8?Q?_ist_unterwegs_=F0=9F=9A=9A?="
     )
-    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001F69A"
+    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001f69a"
 
 
 def test_amazon_email_addresses_various_fwds():

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -161,7 +161,7 @@ def test_get_decoded_subject_multiple_encoded_parts():
     msg = email.message_from_string(
         "Subject: =?UTF-8?Q?Ihre_Sendung?= =?UTF-8?Q?_ist_unterwegs_=F0=9F=9A=9A?="
     )
-    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001F69A"
+    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001f69a"
 
 
 def test_amazon_email_addresses_various_fwds():

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -156,6 +156,14 @@ def test_get_decoded_subject_non_bytes_decoded():
         assert get_decoded_subject(msg) == "String Subject"
 
 
+def test_get_decoded_subject_multiple_encoded_parts():
+    """Test get_decoded_subject joins multi-part encoded headers."""
+    msg = email.message_from_string(
+        "Subject: =?UTF-8?Q?Ihre_Sendung?= =?UTF-8?Q?_ist_unterwegs_=F0=9F=9A=9A?="
+    )
+    assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001F69A"
+
+
 def test_amazon_email_addresses_various_fwds():
     """Test amazon_email_addresses with various fwd types (Line 119)."""
     # Test with None (triggers Line 119)

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -164,6 +164,18 @@ def test_get_decoded_subject_multiple_encoded_parts():
     assert get_decoded_subject(msg) == "Ihre Sendung ist unterwegs \U0001f69a"
 
 
+def test_get_decoded_subject_from_html_title():
+    """Test get_decoded_subject falls back to HTML title when Subject is missing."""
+    msg = email.message_from_string(
+        "From: test@test.com\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n"
+        "<html><head><title>Package delivered</title></head>"
+        "<body>Your order arrived.</body></html>"
+    )
+    assert get_decoded_subject(msg) == "Package delivered"
+
+
 def test_amazon_email_addresses_various_fwds():
     """Test amazon_email_addresses with various fwd types (Line 119)."""
     # Test with None (triggers Line 119)


### PR DESCRIPTION
Replaces the stale PR #1134 with a clean branch based on the current `dev` branch.

What changed:
- re-adds German DHL delivered patterns from the old PR on top of the current codebase
- adds AliExpress delivered/delivering/packages sensors and tracking patterns
- improves encoded subject decoding to handle multi-part UTF-8 headers
- adds targeted tests for AliExpress handling and multi-part subject decoding

What was intentionally not carried over:
- the old `total_*` sensor logic, since that was already flagged as redundant in the original review
- the old legacy `helpers.py` changes, because the current `dev` branch now uses the newer shipper architecture

This is the direct replacement for the outdated PR #1134, rebased onto current `dev`.