### PR TITLE
fix: normalize forwarded_emails string to list before concatenation in shippers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ test-output.xml
 pyvenv.cfg
 pip-selfcheck.json
 venv
-.venv
+.venv*
+.ruff_cache
 Pipfile*
 share/*
 Scripts/

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -256,7 +256,13 @@ async def _validate_user_input(user_input: dict) -> tuple:
                 # the user changed their mind, remove the flag and config entry
                 user_input[CONF_ALLOW_FORWARDED_EMAILS] = False
                 del user_input[CONF_FORWARDED_EMAILS]
-            elif status[0] != "ok":
+            elif status[0] == "ok":
+                user_input[CONF_FORWARDED_EMAILS] = [
+                    e.strip()
+                    for e in user_input[CONF_FORWARDED_EMAILS].split(",")
+                    if e.strip()
+                ]
+            else:
                 errors[CONF_FORWARDED_EMAILS] = status[0]
 
     # Check for ffmpeg if option enabled

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -614,7 +614,10 @@ def _get_schema_step_forwarded_emails(
 
     def _get_default(key: str, fallback_default: Any = None) -> list:
         """Get default value for key."""
-        return user_input.get(key, default_dict.get(key, fallback_default))
+        value = user_input.get(key, default_dict.get(key, fallback_default))
+        if isinstance(value, list):
+            value = ", ".join(value)
+        return value
 
     return vol.Schema(
         {

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -74,7 +74,9 @@ class GenericShipper(Shipper):
         # Add forwarded emails if configured
         forwarded_emails = self.config.get("forwarded_emails", [])
         if isinstance(forwarded_emails, str):
-            forwarded_emails = [e.strip() for e in forwarded_emails.split(",") if e.strip()]
+            forwarded_emails = [
+                e.strip() for e in forwarded_emails.split(",") if e.strip()
+            ]
         if forwarded_emails:
             email_addresses = forwarded_emails + email_addresses
 

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -73,6 +73,8 @@ class GenericShipper(Shipper):
 
         # Add forwarded emails if configured
         forwarded_emails = self.config.get("forwarded_emails", [])
+        if isinstance(forwarded_emails, str):
+            forwarded_emails = [e.strip() for e in forwarded_emails.split(",") if e.strip()]
         if forwarded_emails:
             email_addresses = forwarded_emails + email_addresses
 

--- a/custom_components/mail_and_packages/shippers/usps.py
+++ b/custom_components/mail_and_packages/shippers/usps.py
@@ -262,7 +262,9 @@ class USPSShipper(Shipper):
         """Search for USPS Informed Delivery emails."""
         forwarded_emails = self.config.get("forwarded_emails", [])
         if isinstance(forwarded_emails, str):
-            forwarded_emails = [e.strip() for e in forwarded_emails.split(",") if e.strip()]
+            forwarded_emails = [
+                e.strip() for e in forwarded_emails.split(",") if e.strip()
+            ]
         _LOGGER.debug("Attempting to find Informed Delivery mail")
         _LOGGER.debug("Informed delivery search date: %s", get_formatted_date())
 

--- a/custom_components/mail_and_packages/shippers/usps.py
+++ b/custom_components/mail_and_packages/shippers/usps.py
@@ -261,6 +261,8 @@ class USPSShipper(Shipper):
     async def _search_informed_delivery(self, account: IMAP4_SSL) -> tuple:
         """Search for USPS Informed Delivery emails."""
         forwarded_emails = self.config.get("forwarded_emails", [])
+        if isinstance(forwarded_emails, str):
+            forwarded_emails = [e.strip() for e in forwarded_emails.split(",") if e.strip()]
         _LOGGER.debug("Attempting to find Informed Delivery mail")
         _LOGGER.debug("Informed delivery search date: %s", get_formatted_date())
 

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -270,6 +270,27 @@ async def test_generic_forwarded_emails(hass):
 
 
 @pytest.mark.asyncio
+async def test_generic_forwarded_emails_string(hass):
+    """Test that a legacy string value for forwarded_emails is normalized to a list."""
+    shipper = GenericShipper(
+        hass,
+        {
+            "forwarded_emails": "forward@test.com, other@test.com",
+            "image_path": "test/path/",
+        },
+    )
+    mock_acc = AsyncMock()
+    with patch(
+        "custom_components.mail_and_packages.shippers.generic.email_search",
+        return_value=("OK", [None]),
+    ) as mock_search:
+        await shipper.process(mock_acc, "today", "ups_delivered")
+        search_addresses = mock_search.call_args[0][1]
+        assert "forward@test.com" in search_addresses
+        assert "other@test.com" in search_addresses
+
+
+@pytest.mark.asyncio
 async def test_generic_body_search(hass):
     """Test GenericShipper with body search (Lines 209-211)."""
     shipper = GenericShipper(hass, {"image_path": "test/path/"})

--- a/tests/shippers/test_usps.py
+++ b/tests/shippers/test_usps.py
@@ -434,6 +434,25 @@ async def test_informed_delivery_forwarded_emails(hass):
 
 
 @pytest.mark.asyncio
+async def test_informed_delivery_forwarded_emails_string(hass):
+    """Test that a legacy string value for forwarded_emails is normalized to a list."""
+    shipper = USPSShipper(
+        hass, {"forwarded_emails": "forward@test.com, other@test.com"}
+    )
+    mock_account = AsyncMock()
+    mock_account.search.return_value = MagicMock(result="OK", lines=[])
+
+    with patch(
+        "custom_components.mail_and_packages.shippers.usps.email_search",
+        return_value=("OK", [None]),
+    ) as mock_search:
+        await shipper.process(mock_account, "today", "usps_mail")
+        search_addresses = mock_search.call_args[0][1]
+        assert "forward@test.com" in search_addresses
+        assert "other@test.com" in search_addresses
+
+
+@pytest.mark.asyncio
 async def test_informed_delivery_gen_mp4_grid(hass):
     """Test USPS Informed Delivery with MP4 and grid generation (Lines 106, 110)."""
     shipper = USPSShipper(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,7 @@ from custom_components.mail_and_packages.config_flow import (
     _check_forwarded_emails,
     _get_mailboxes,
     _get_schema_step_3,
+    _get_schema_step_forwarded_emails,
     _validate_login,
     _validate_user_input,
 )
@@ -4252,6 +4253,16 @@ async def test_validate_user_input_forwarded_emails_saved_as_list():
 
     assert errors == {}
     assert result_input[CONF_FORWARDED_EMAILS] == ["forward@test.com", "other@test.com"]
+
+
+def test_get_schema_step_forwarded_emails_list_to_string():
+    """Test that a stored list is joined to a comma-separated string for form pre-fill."""
+    default_dict = {CONF_FORWARDED_EMAILS: ["forward@test.com", "other@test.com"]}
+    schema = _get_schema_step_forwarded_emails(None, default_dict)
+    req_key = next(
+        k for k in schema.schema if getattr(k, "schema", None) == CONF_FORWARDED_EMAILS
+    )
+    assert req_key.default() == "forward@test.com, other@test.com"
 
 
 async def test_get_mailboxes_parsing_error(hass, caplog):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4239,6 +4239,21 @@ async def test_validate_user_input_forwarded_emails_none():
     assert CONF_FORWARDED_EMAILS not in result_input
 
 
+@pytest.mark.asyncio
+async def test_validate_user_input_forwarded_emails_saved_as_list():
+    """Test that a valid forwarded_emails string is converted to a list on save."""
+    user_input = {
+        CONF_FORWARDED_EMAILS: "forward@test.com, other@test.com",
+        CONF_ALLOW_FORWARDED_EMAILS: True,
+        CONF_GENERATE_MP4: False,
+    }
+
+    errors, result_input = await _validate_user_input(user_input)
+
+    assert errors == {}
+    assert result_input[CONF_FORWARDED_EMAILS] == ["forward@test.com", "other@test.com"]
+
+
 async def test_get_mailboxes_parsing_error(hass, caplog):
     """Test _get_mailboxes handles delimiter parsing failures."""
     mock_conn = AsyncMock()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4522,7 +4522,7 @@ async def test_validate_forwarded_emails_missing_and_invalid():
             {
                 "allow_external": False,
                 "allow_forwarded_emails": True,
-                "forwarded_emails": "user@example.com,testuser@example.com",
+                "forwarded_emails": ["user@example.com", "testuser@example.com"],
                 "amazon_days": 3,
                 "amazon_domain": "amazon.com",
                 "amazon_fwds": [],
@@ -4995,7 +4995,7 @@ async def test_form_allowed_forwarded_emails_entered_none(
             {
                 "allow_external": False,
                 "allow_forwarded_emails": True,
-                "forwarded_emails": "user@example.com,testuser@example.com",
+                "forwarded_emails": ["user@example.com", "testuser@example.com"],
                 "custom_img": False,
                 "auth_type": "password",
                 "host": "imap.test.email",
@@ -5214,7 +5214,7 @@ async def test_form_allow_forwarded_emails_without_amazon_or_custom_img(
                 "amazon_days": 3,
                 "amazon_domain": "amazon.com",
                 "amazon_fwds": [],
-                "forwarded_emails": "user@example.com,testuser@example.com",
+                "forwarded_emails": ["user@example.com", "testuser@example.com"],
                 "custom_img": False,
                 "auth_type": "password",
                 "host": "imap.test.email",
@@ -5434,7 +5434,7 @@ async def test_form_allow_forwarded_emails_without_custom_img(
                 "amazon_days": 3,
                 "amazon_domain": "amazon.com",
                 "amazon_fwds": [],
-                "forwarded_emails": "user@example.com,testuser@example.com",
+                "forwarded_emails": ["user@example.com", "testuser@example.com"],
                 "custom_img": False,
                 "auth_type": "password",
                 "host": "imap.test.email",
@@ -6256,7 +6256,7 @@ async def test_form_allowed_forwards_invalid_email_address_format(
             {
                 "allow_external": False,
                 "allow_forwarded_emails": True,
-                "forwarded_emails": "user@example.com,testuser@example.com",
+                "forwarded_emails": ["user@example.com", "testuser@example.com"],
                 "amazon_days": 3,
                 "amazon_domain": "amazon.com",
                 "amazon_fwds": "fakeuser@test.email,fakeuser2@test.email",
@@ -6509,7 +6509,7 @@ async def test_reconfigure_allow_forwarded_emails(
             {
                 "allow_external": False,
                 "allow_forwarded_emails": True,
-                "forwarded_emails": "no-reply@usps.com",
+                "forwarded_emails": ["no-reply@usps.com"],
                 "amazon_days": 3,
                 "amazon_domain": "amazon.com",
                 "amazon_fwds": [],


### PR DESCRIPTION
## Proposed change

`CONF_FORWARDED_EMAILS` was being stored as a raw comma-separated string in the config entry (e.g. `"me@example.com, other@example.com"`), but both `USPSShipper` and `GenericShipper` attempted to concatenate it directly with a list of carrier email addresses, producing a `TypeError: can only concatenate str (not "list") to str` on every update cycle for users with forwarded email addresses configured.

Three changes are included:

- **`shippers/usps.py`** — normalize `forwarded_emails` from str to list on read before concatenation
- **`shippers/generic.py`** — same normalization
- **`config_flow.py`** — convert the validated string to a list on save, consistent with how `CONF_AMAZON_FWDS` is handled, so newly saved/reconfigured entries store the correct type going forward

The shipper-side fix is defensive and handles all existing config entries immediately without requiring reconfiguration.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a

**Error seen in logs prior to fix:**
```
ERROR (MainThread) [custom_components.mail_and_packages.coordinator] Error processing shipper generic: can only concatenate str (not "list") to str
ERROR (MainThread) [custom_components.mail_and_packages.coordinator] Error processing shipper usps: can only concatenate str (not "list") to str
```