### PR TITLE
refactor(beta): add _decode_subject method to generic shipper to properly handle MIME encoded email headers

### DIFF
--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import email
 import logging
+from email.header import decode_header
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
@@ -301,6 +303,27 @@ class GenericShipper(Shipper):
 
         return count, found_data, image_found
 
+    def _decode_subject(self, header_part: bytes | bytearray) -> str | None:
+        """Decode MIME encoded subject from email header part."""
+        msg = email.message_from_bytes(header_part)
+        header_val = msg.get("subject")
+        if not header_val:
+            return None
+
+        decoded = decode_header(header_val)[0]
+        subject_bytes, encoding = decoded
+        if encoding:
+            try:
+                if isinstance(subject_bytes, bytes):
+                    return subject_bytes.decode(encoding, "ignore").strip()
+                return str(subject_bytes).strip()
+            except (LookupError, UnicodeError):
+                pass
+
+        if isinstance(subject_bytes, bytes):
+            return subject_bytes.decode("utf-8", "ignore").strip()
+        return str(subject_bytes).strip()
+
     async def _verify_matched_subjects(
         self,
         account: IMAP4_SSL,
@@ -328,7 +351,10 @@ class GenericShipper(Shipper):
                 subject_found = False
                 for part in header_data:
                     if isinstance(part, (bytes, bytearray)):
-                        subject = part.decode("utf-8", "ignore").strip()
+                        subject = self._decode_subject(part)
+                        if not subject:
+                            continue
+
                         _LOGGER.debug(
                             "Matched email for %s (ID %s): %s",
                             sensor_type,

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -713,3 +713,14 @@ async def test_verify_matched_subjects_empty_expected(hass):
     assert verified == [b"123", b"456"]
     # Verify no IMAP fetch calls were made
     mock_account.fetch.assert_not_called()
+
+
+def test_decode_subject_string_with_encoding(hass):
+    """Test _decode_subject when decode_header returns a string and an encoding."""
+    shipper = GenericShipper(hass, {})
+    with patch(
+        "custom_components.mail_and_packages.shippers.generic.decode_header",
+        return_value=[("A string instead of bytes", "utf-8")],
+    ):
+        result = shipper._decode_subject(b"Subject: dummy")
+        assert result == "A string instead of bytes"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add _decode_subject method to generic shipper to properly handle MIME encoded email headers

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1240 
