### PR TITLE
feat(shipper): Add Walmart store delivery out-for-delivery subject pattern

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -782,7 +782,11 @@ SENSOR_DATA = {
     # Walmart
     "walmart_delivering": {
         "email": ["help@walmart.com"],
-        "subject": ["Out for delivery", "Your package should arrive by"],
+        "subject": [
+            "Out for delivery",
+            "Your package should arrive by",
+            "Your delivery should arrive by",
+        ],
     },
     "walmart_delivered": {
         "email": ["help@walmart.com"],


### PR DESCRIPTION
Walmart store (same-day) deliveries send a different subject line than carrier shipments: "Your delivery should arrive by <time>" rather than "Your package should arrive by <time>". Add the new subject so the walmart_delivering sensor counts these emails.

https://claude.ai/code/session_01LPaYsV1LS2VHXPu8U3nzsf

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
