### PR TITLE
fix: update USPS tracking email to auto-reply@tracking.usps.com

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -283,20 +283,20 @@ AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT = ["AMAZON"]
 SENSOR_DATA = {
     # USPS
     "usps_delivered": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Item Delivered"],
     },
     "usps_delivering": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Expected Delivery on", "Out for Delivery"],
         "body": ["Your item is out for delivery"],
     },
     "usps_exception": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Delivery Exception"],
     },
     "usps_packages": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Expected Delivery by"],
     },
     "usps_tracking": {"pattern": ["9[2345]\\d{15,26}"]},

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -41,6 +41,7 @@ def test_generate_service_email_domains():
     assert "amazon.co.uk" in domains
     # USPS is in SENSOR_DATA default emails
     assert "usps.com" in domains
+    assert "tracking.usps.com" in domains
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

USPS has updated their package tracking email to auto-reply@tracking.usps.com. This PR adds auto-reply@tracking.usps.com to all four USPS package tracking email address lists while keeping auto-reply@usps.com for backward compatibility.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1251 
- This PR is related to issue:
