### PR TITLE
fix(shipper): filter email IDs by body search before tracking extraction

### DIFF
--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -28,7 +28,7 @@ from custom_components.mail_and_packages.const import (
     SENSOR_DATA,
 )
 from custom_components.mail_and_packages.utils.cache import EmailCache
-from custom_components.mail_and_packages.utils.email import find_text
+from custom_components.mail_and_packages.utils.email import find_text, find_text_matches
 from custom_components.mail_and_packages.utils.imap import (
     email_fetch,
     email_fetch_headers,
@@ -527,19 +527,20 @@ class GenericShipper(Shipper):
     ) -> tuple[int, bool]:
         """Process a batch of matched unique emails."""
         image_found = False
-        count = await self._process_emails_by_type(
+        count, matched_ids = await self._process_emails_by_type(
             account, config, new_ids, current_count, cache
         )
-        found_data.append(b" ".join(new_ids))
+        if matched_ids:
+            found_data.append(b" ".join(matched_ids))
 
-        if shipper_cfg:
-            if await self._extract_images_for_shipper(
-                account, new_ids, shipper_cfg, cache
-            ):
-                image_found = True
+            if shipper_cfg:
+                if await self._extract_images_for_shipper(
+                    account, matched_ids, shipper_cfg, cache
+                ):
+                    image_found = True
 
-        if sensor_type.endswith("_delivered") and sensor_type != AMAZON_DELIVERED:
-            await self._check_amazon_mentions(account, new_ids, result, cache)
+            if sensor_type.endswith("_delivered") and sensor_type != AMAZON_DELIVERED:
+                await self._check_amazon_mentions(account, matched_ids, result, cache)
 
         return count, image_found
 
@@ -611,19 +612,20 @@ class GenericShipper(Shipper):
         ids: list,
         current_count: int,
         cache: EmailCache | None = None,
-    ) -> int:
+    ) -> tuple[int, list]:
         """Process emails based on body search or just count."""
         if ATTR_BODY in config:
             body_count = config.get(ATTR_BODY_COUNT, False)
             mock_data = (b" ".join(ids),)
-            return current_count + await find_text(
+            count, matched_ids = await find_text_matches(
                 mock_data,
                 account,
                 config[ATTR_BODY],
                 body_count,
                 cache,
             )
-        return current_count + len(ids)
+            return current_count + count, matched_ids
+        return current_count + len(ids), list(ids)
 
     async def _extract_images_for_shipper(
         self,

--- a/custom_components/mail_and_packages/utils/email.py
+++ b/custom_components/mail_and_packages/utils/email.py
@@ -161,3 +161,41 @@ async def find_text(
             count += matches
 
     return count
+
+
+async def find_text_matches(
+    sdata: Any,
+    account: type[IMAP4_SSL],
+    search_terms: list,
+    body_count: bool,
+    cache: EmailCache | None = None,
+) -> tuple[int, list[bytes]]:
+    """Filter for specific words in email and return matches and matching IDs."""
+    _LOGGER.debug("Searching for (%s) in (%s) emails", search_terms, len(sdata))
+    mail_list = sdata[0].split()
+    count = 0
+    matching_ids = []
+
+    # Pre-compile regex patterns once
+    patterns = [re.compile(rf"{term}") for term in search_terms]
+
+    for i in mail_list:
+        matches, value = await _scan_email_for_text(
+            account, i, patterns, body_count, cache
+        )
+
+        matched = False
+        if body_count:
+            # If extracting a value, "last found value wins" (updates count)
+            if value is not None:
+                count = value
+                matched = True
+        # If counting occurrences, accumulate
+        elif matches > 0:
+            count += matches
+            matched = True
+
+        if matched:
+            matching_ids.append(i)
+
+    return count, matching_ids

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -373,6 +373,11 @@ async def test_generic_body_search(hass):
             new_callable=AsyncMock,
             return_value=1,
         ) as mock_find,
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(1, [b"1"]),
+        ) as mock_find_matches,
         patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
         patch(
             "custom_components.mail_and_packages.shippers.generic.GenericShipper._verify_matched_subjects",
@@ -383,8 +388,38 @@ async def test_generic_body_search(hass):
         # dhl_delivered has "body" in SENSOR_DATA
         result = await shipper.process(mock_acc, "today", "dhl_delivered")
         assert result[ATTR_COUNT] == 1
-        # Called once for process_emails_by_type and once for check_amazon_mentions
-        assert mock_find.call_count == 2
+        assert mock_find.call_count == 1
+        assert mock_find_matches.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_generic_body_search_no_match(hass):
+    """Test GenericShipper with body search failing to match."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_acc = AsyncMock()
+    mock_acc.search.return_value = MagicMock(result="OK", lines=[b"1"])
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(0, []),
+        ) as mock_find_matches,
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+        ) as mock_tracking,
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.GenericShipper._verify_matched_subjects",
+            new_callable=AsyncMock,
+            side_effect=lambda a, b, c, d, cache=None: b,
+        ),
+    ):
+        result = await shipper.process(mock_acc, "today", "dhl_delivered")
+        assert result[ATTR_COUNT] == 0
+        assert mock_find_matches.call_count == 1
+        assert mock_tracking.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -8,6 +8,7 @@ from aioimaplib import AUTH, NONAUTH, AioImapException
 
 from custom_components.mail_and_packages.utils.email import (
     find_text,
+    find_text_matches,
     generate_service_email_domains,
     validate_email_address,
 )
@@ -82,6 +83,57 @@ async def test_find_text_body_count():
 
         result = await find_text(sdata, mock_account, search_terms, True)
         assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_find_text_matches_async():
+    """Test find_text_matches utility."""
+    mock_account = MagicMock()
+    sdata = [b"1 2 3"]  # three email IDs
+    search_terms = ["1Z1234567890"]
+
+    with patch(
+        "custom_components.mail_and_packages.utils.email.email_fetch",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        # Email 1 and 2 match, Email 3 does not
+        mock_fetch.side_effect = [
+            ("OK", [b"From: test@example.com\n\nTracking 1Z1234567890"]),
+            ("OK", [b"From: test@example.com\n\nTracking 1Z1234567890"]),
+            ("OK", [b"From: test@example.com\n\nNo tracking info"]),
+        ]
+
+        count, matched_ids = await find_text_matches(
+            sdata, mock_account, search_terms, False
+        )
+        assert count == 2
+        assert matched_ids == [b"1", b"2"]
+        assert mock_fetch.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_find_text_matches_body_count():
+    """Test find_text_matches with body_count=True (value extraction)."""
+    mock_account = MagicMock()
+    sdata = [b"1 2"]
+    search_terms = [r"Count: (\d+)"]
+
+    with patch(
+        "custom_components.mail_and_packages.utils.email.email_fetch",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        # Email 1 matches and extracts 42, Email 2 does not match
+        mock_fetch.side_effect = [
+            ("OK", [b"From: test@example.com\n\nCount: 42"]),
+            ("OK", [b"From: test@example.com\n\nNo count here"]),
+        ]
+
+        count, matched_ids = await find_text_matches(
+            sdata, mock_account, search_terms, True
+        )
+        assert count == 42
+        assert matched_ids == [b"1"]
+        assert mock_fetch.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

Fixes an issue where the DHL delivery sensor counts (`dhl_delivering`, `dhl_packages`) are stuck at `1` because email tracking numbers are extracted from emails that match the subject check but fail the body search filter.

Changes:
- Introduced `find_text_matches` in `email.py` that returns both match counts and the specific matching email IDs.
- Updated `_process_emails_by_type` in `generic.py` to use `find_text_matches` and return matching IDs.
- Updated `_process_matched_emails` to only append/extract tracking from emails that successfully matched the body search filter.
- Added unit tests for `find_text_matches` and a regression test for generic shipper body search with no matches.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1250 
- This PR is related to issue: