### PR TITLE
fix(shipper): exclude Deutsche Post letter sensor from since_date search window

### DIFF
--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -100,8 +100,12 @@ class GenericShipper(Shipper):
         # but the delivered email is not.
         is_delivered = sensor_type.endswith("_delivered")
         search_date = date
-        if since_date and sensor_type.endswith(
-            ("_delivering", "_exception", "_delivered", "_packages")
+        if (
+            since_date
+            and sensor_type.endswith(
+                ("_delivering", "_exception", "_delivered", "_packages")
+            )
+            and sensor_type != "post_de_delivering"
         ):
             search_date = since_date
 

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -990,3 +990,25 @@ async def test_ups_packages_uses_since_date(hass):
     mock_search.assert_called_once()
     # since_date should be passed as the search date, not the regular date
     assert mock_search.call_args.args[2] == "19-Apr-2026"
+
+
+@pytest.mark.asyncio
+async def test_post_de_delivering_ignores_since_date(hass):
+    """post_de_delivering (brief/letter announcement) ignores since_date and uses today's date."""
+    shipper = GenericShipper(hass, {})
+    mock_account = AsyncMock()
+
+    with patch(
+        "custom_components.mail_and_packages.shippers.generic.email_search",
+        return_value=("OK", [b""]),
+    ) as mock_search:
+        await shipper.process(
+            mock_account,
+            "22-Apr-2026",
+            "post_de_delivering",
+            since_date="19-Apr-2026",
+        )
+
+    mock_search.assert_called_once()
+    # today's date should be passed as the search date, ignoring since_date
+    assert mock_search.call_args.args[2] == "22-Apr-2026"


### PR DESCRIPTION
## Proposed change

Fixes an issue where the Deutsche Post brief/letter announcement sensor (`post_de_delivering`) remains stuck at a positive value for up to 3 days. Because letters do not have tracking numbers, they cannot be deduplicated or marked delivered. By excluding `post_de_delivering` from the 3-day extended search window (`since_date`) and letting it default to today's date (`date`), we ensure letter announcements reset correctly at midnight since letter announcements are only valid for the day they are sent.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1250
- This PR is related to issue:
