### PR TITLE
fix: honor configured IMAP timeout on client and commands

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_IMAP_SECURITY,
     CONF_IMAP_TIMEOUT,
     DEFAULT_CUSTOM_DAYS,
+    DEFAULT_IMAP_TIMEOUT,
     DOMAIN,
     MAX_TRACKING_AGE_DAYS,
 )
@@ -74,7 +75,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.interval = timedelta(minutes=config.get(CONF_SCAN_INTERVAL))
         self.name = f"Mail and Packages ({config.get(CONF_HOST)})"
-        self.timeout = config.get(CONF_IMAP_TIMEOUT)
+        self.timeout = config.get(CONF_IMAP_TIMEOUT, DEFAULT_IMAP_TIMEOUT)
         self.config = config
         self.config_entry = config_entry
         self.hass = hass
@@ -228,6 +229,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 config.get(CONF_IMAP_SECURITY),
                 config.get(CONF_VERIFY_SSL),
                 config.get("oauth_token"),
+                timeout=self.timeout,
             )
         except InvalidAuth as err:
             _LOGGER.error("Authentication failed: %s", err)

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -21,6 +21,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import ssl
 
+from custom_components.mail_and_packages.const import DEFAULT_IMAP_TIMEOUT
+
 _LOGGER = logging.getLogger(__name__)
 
 # Register ESEARCH command if not already present in aioimaplib
@@ -125,6 +127,7 @@ async def login(
     security: str,
     verify: bool = True,
     oauth_token: str | None = None,
+    timeout: float = DEFAULT_IMAP_TIMEOUT,
 ) -> IMAP4_SSL | IMAP4:
     """Login to IMAP server asynchronously.
 
@@ -138,9 +141,11 @@ async def login(
         else ssl.create_no_verify_ssl_context()
     )
     if security == "SSL":
-        account = IMAP4_SSL(host=host, port=port, ssl_context=ssl_context)
+        account = IMAP4_SSL(
+            host=host, port=port, ssl_context=ssl_context, timeout=timeout
+        )
     else:
-        account = IMAP4(host=host, port=port)
+        account = IMAP4(host=host, port=port, timeout=timeout)
 
     await account.wait_hello_from_server()
 
@@ -345,12 +350,16 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
         folder_list = " ".join([quote_folder(encode_imap_utf7(f)) for f in folders])
         args = ("IN", f"({folder_list})", search_query)
         try:
+            timeout = getattr(account, "timeout", None)
+            if not isinstance(timeout, (int, float)):
+                timeout = None
             res = await account.protocol.execute(
                 Command(
                     "ESEARCH",
                     account.protocol.new_tag(),
                     *args,
                     loop=account.protocol.loop,
+                    timeout=timeout,
                 )
             )
             if res.result == "OK":


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None (this is a non-breaking bugfix).

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR ensures that the user-configured IMAP timeout (`imap_timeout` option, defaulting to 60 seconds) is honored during all IMAP network operations. 

Previously:
- The IMAP connection objects (`IMAP4` and `IMAP4_SSL`) were initialized without a `timeout` parameter, causing them to fall back to `aioimaplib`'s internal default timeout of 10.0 seconds. As a result, standard search or fetch operations taking longer than 10.0 seconds would raise a `TimeoutError` and fail the update, ignoring the user's config.
- The custom `ESEARCH` command executed directly on the protocol bypassed standard wrappers and did not specify a timeout on the `Command` class, running without a query-level timeout wrapper.

This PR:
1. Passes the configured timeout from the coordinator down to `login` and applies it to the client instance constructors.
2. Forwards the connection's timeout parameter to the custom `ESEARCH` `Command`.
3. Adds a type-check safeguard (`isinstance(timeout, (int, float))`) to ensure mocked connections in tests that set `timeout` to a `MagicMock` do not trigger loop scheduling type errors.

All 515 tests, linting, formatting, type checking, and pre-commit checks pass successfully.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1263 
- This PR is related to issue:
