### PR TITLE
fix(imap): robust parsing of IMAP SEARCH response lines

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -273,6 +273,35 @@ def build_search(  # noqa: C901
     return (False, imap_search)
 
 
+def parse_search_response(lines: list[bytes]) -> list[bytes]:
+    """Parse IMAP SEARCH response lines and return list of UID/ID bytes.
+
+    Handles both standard server responses (prefixed with b"SEARCH")
+    and mocked test inputs (which often contain raw UIDs directly).
+    Filters out the SEARCH keyword, tagged OK/status responses,
+    and any non-numeric tokens.
+    """
+    uids = []
+    for line in lines:
+        if not line:
+            continue
+        parts = line.split()
+        if not parts:
+            continue
+
+        if parts[0] == b"SEARCH":
+            # Check if this is a search result line, e.g. b"SEARCH 1001 1002"
+            # (as opposed to b"SEARCH completed")
+            if len(parts) > 1 and parts[1].isdigit():
+                uids.extend(parts[1:])
+        # Check if this line is just a list of numeric UIDs (mock/test compatibility)
+        # and ignore status/existence responses like b"23 EXISTS"
+        elif all(p.isdigit() for p in parts):
+            uids.extend(parts)
+
+    return uids
+
+
 def _parse_esearch_line(line_bytes: bytes) -> list[bytes]:
     """Parse a single ESEARCH line and return list of formatted UID bytes: b'folder/uid'."""
     line_str = line_bytes.decode("utf-8", "ignore")
@@ -326,8 +355,8 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
 
     if len(folders) <= 1:
         res = await account.search(search_query, charset=None)
-        if res.result == "OK" and res.lines[0]:
-            return res.lines[0].split()
+        if res.result == "OK" and res.lines:
+            return parse_search_response(res.lines)
         return []
 
     all_uids = []
@@ -378,10 +407,10 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
                 continue
             try:
                 res = await account.uid_search(search_query, charset=None)
-                if res.result == "OK" and res.lines[0]:
+                if res.result == "OK" and res.lines:
+                    parsed = parse_search_response(res.lines)
                     all_uids.extend(
-                        f"{folder}/{uid.decode()}".encode()
-                        for uid in res.lines[0].split()
+                        f"{folder}/{uid.decode()}".encode() for uid in parsed
                     )
             except TimeoutError:
                 raise
@@ -429,7 +458,8 @@ async def email_search(  # noqa: C901
                 _LOGGER.error("Error searching emails: %s", err)
                 return ("BAD", str(err))
             else:
-                return (res.result, res.lines)
+                parsed = parse_search_response(res.lines)
+                return (res.result, [b" ".join(parsed)])
 
         # Batch subjects in groups of 10
         all_matched_ids = []
@@ -440,8 +470,9 @@ async def email_search(  # noqa: C901
             )
             try:
                 res = await account.search(search, charset=None)
-                if res.result == "OK" and res.lines[0]:
-                    all_matched_ids.extend(res.lines[0].split())
+                if res.result == "OK" and res.lines:
+                    parsed = parse_search_response(res.lines)
+                    all_matched_ids.extend(parsed)
             except TimeoutError:
                 raise
             except (AioImapException, OSError) as err:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1419,7 +1419,7 @@ def test_parse_search_response():
     assert parse_search_response([b"23 EXISTS", b"SEARCH 5 6"]) == [b"5", b"6"]
     # Empty lists or empty lines
     assert parse_search_response([]) == []
-    assert parse_search_response([b"", None]) == []
+    assert parse_search_response([b"", None, b"   "]) == []
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -26,6 +26,7 @@ from custom_components.mail_and_packages.utils.imap import (
     encode_imap_utf7,
     login,
     logout,
+    parse_search_response,
     quote_folder,
     selectfolder,
 )
@@ -1395,6 +1396,30 @@ def test_imap_utf7_encoding_decoding():
 
     # quote_folder on non-atom folder
     assert quote_folder("INBOX/Online Shops") == '"INBOX/Online Shops"'
+
+
+def test_parse_search_response():
+    """Test parse_search_response helper function with various inputs."""
+    # Standard server response with search results
+    assert parse_search_response([b"SEARCH 1 2 3"]) == [b"1", b"2", b"3"]
+    # Server response with multiple lines
+    assert parse_search_response([b"SEARCH 1 2", b"SEARCH 3 4"]) == [
+        b"1",
+        b"2",
+        b"3",
+        b"4",
+    ]
+    # Server response with no results
+    assert parse_search_response([b"SEARCH"]) == []
+    # Server response with status text (tagged OK response)
+    assert parse_search_response([b"SEARCH completed (took 237 ms)"]) == []
+    # Mocked test inputs (raw sequence numbers)
+    assert parse_search_response([b"1001 1002"]) == [b"1001", b"1002"]
+    # Non-search untagged response lines (should be ignored)
+    assert parse_search_response([b"23 EXISTS", b"SEARCH 5 6"]) == [b"5", b"6"]
+    # Empty lists or empty lines
+    assert parse_search_response([]) == []
+    assert parse_search_response([b"", None]) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure robust parsing of standard IMAP SEARCH response lines.

Historically, the integration parsed the raw search result lines directly by splitting the first line. On certain IMAP servers like iCloud (`imap.mail.me.com`), when a search returns no matching emails, the server sends a tagged status response line like `SEARCH completed (took 237 ms)` as the only line in the response. Since the first word is `SEARCH`, the integration split the line into `['SEARCH', 'completed', '(took', '237', 'ms)']` and attempted to fetch headers for each word as a message sequence ID. Queries for these non-numeric IDs caused the IMAP client and connection to hang/timeout during setup.

This PR adds a `parse_search_response` utility to filter out the `SEARCH` keyword, tagged status responses, other unrelated untagged responses (e.g. `23 EXISTS`), and any non-numeric tokens.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1263
- This PR is related to issue:
