### PR TITLE
fix: camera falls back to bundled placeholder instead of HTTP 500 when image file is missing

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -145,6 +145,12 @@ class MailCam(CoordinatorEntity, Camera):
         else:
             self._file_path = f"{Path(__file__).parent}/{default_image}"
 
+        # Canonical bundled placeholder for this camera. Always available
+        # regardless of later _file_path changes, so a missing delivery image
+        # can fall back to it instead of returning None (which makes the HA
+        # camera proxy serve HTTP 500).
+        self._default_image_path = f"{Path(__file__).parent}/{default_image}"
+
         self._cached_image_path: str | None = None
         self._cached_image_bytes: bytes | None = None
         self._last_delivery_images: list[str] | None = None
@@ -178,10 +184,34 @@ class MailCam(CoordinatorEntity, Camera):
             )
         except FileNotFoundError:
             _LOGGER.debug(
-                "Could not read camera %s image from file: %s",
+                "Could not read camera %s image from file: %s; "
+                "falling back to bundled placeholder %s",
                 self._name,
                 self._file_path,
+                self._default_image_path,
             )
+            # Fall back to the bundled placeholder so the camera proxy never
+            # serves HTTP 500 when a delivery image is missing on disk.
+            if self._default_image_path and self._file_path != self._default_image_path:
+                try:
+                    image_bytes = await self.hass.async_add_executor_job(
+                        _read_file, self._default_image_path
+                    )
+                except FileNotFoundError:
+                    _LOGGER.warning(
+                        "Camera %s placeholder image also missing: %s",
+                        self._name,
+                        self._default_image_path,
+                    )
+                    return None
+                else:
+                    # Cache against the placeholder path so repeated reads are
+                    # cheap; update_file_path() invalidates the cache when the
+                    # primary path changes.
+                    self._cached_image_path = self._default_image_path
+                    self._cached_image_bytes = image_bytes
+                    return image_bytes
+            return None
         else:
             self._cached_image_path = self._file_path
             self._cached_image_bytes = image_bytes

--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -191,8 +191,12 @@ class MailCam(CoordinatorEntity, Camera):
                 self._default_image_path,
             )
             # Fall back to the bundled placeholder so the camera proxy never
-            # serves HTTP 500 when a delivery image is missing on disk.
-            if self._default_image_path and self._file_path != self._default_image_path:
+            # serves HTTP 500 when a delivery image is missing on disk. Skip the
+            # fallback when the primary path already IS the placeholder (true for
+            # non-custom cameras, where _file_path and _default_image_path are
+            # both built from the same default image): re-reading the same
+            # missing file would only fail again, so return None instead.
+            if self._file_path != self._default_image_path:
                 try:
                     image_bytes = await self.hass.async_add_executor_job(
                         _read_file, self._default_image_path

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -284,7 +284,7 @@ async def test_async_camera_image_file_error(
     mock_update,
     caplog,
 ):
-    """Test async_camera_image function."""
+    """Test async_camera_image returns None when both image and placeholder are missing."""
     with (
         patch("os.path.exists", return_value=True),
         patch("os.access", return_value=False),
@@ -292,13 +292,74 @@ async def test_async_camera_image_file_error(
         entry = integration
 
         cameras = entry.runtime_data.cameras
+        cam = cameras[0]
+        # Force the primary and placeholder paths to differ so the fallback
+        # branch is exercised; with both reads failing the camera returns None.
+        cam._file_path = "/nonexistent/missing_delivery.jpg"
         with patch(
             "custom_components.mail_and_packages.camera.Path"
         ) as mock_path_class:
             mock_path_class.return_value.open.side_effect = FileNotFoundError
-            await cameras[0].async_camera_image()
+            result = await cam.async_camera_image()
 
+        assert result is None
         assert "Could not read camera" in caplog.text
+        assert "placeholder image also missing" in caplog.text
+
+
+async def test_async_camera_image_falls_back_to_placeholder(
+    hass,
+    mock_imap_no_email,
+    integration,
+    mock_osremove,
+    mock_osmakedir,
+    mock_listdir,
+    mock_update_time,
+    mock_copy_overlays,
+    mock_hash_file,
+    mock_getctime_today,
+    mock_update,
+    caplog,
+):
+    """Test async_camera_image returns bundled placeholder bytes when the image file is missing.
+
+    Regression test: a missing _file_path must NOT return None (which makes the
+    HA camera proxy serve HTTP 500); it must fall back to the bundled placeholder.
+    """
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.access", return_value=False),
+    ):
+        entry = integration
+
+        cameras = entry.runtime_data.cameras
+        cam = cameras[0]
+        # Primary path points at a file that does not exist on disk; the
+        # bundled placeholder (_default_image_path) is still readable.
+        cam._file_path = "/nonexistent/missing_delivery.jpg"
+        placeholder_path = cam._default_image_path
+
+        # First open() (primary path) raises; second open() (placeholder)
+        # returns a readable handle with bytes.
+        placeholder_handle = MagicMock()
+        placeholder_handle.__enter__.return_value = MagicMock(
+            read=MagicMock(return_value=b"placeholder-bytes")
+        )
+        placeholder_handle.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "custom_components.mail_and_packages.camera.Path"
+        ) as mock_path_class:
+            mock_path_class.return_value.open.side_effect = [
+                FileNotFoundError,
+                placeholder_handle,
+            ]
+            result = await cam.async_camera_image()
+
+        assert result == b"placeholder-bytes"
+        # Cache should now key off the placeholder path for cheap repeat reads.
+        assert cam._cached_image_path == placeholder_path
+        assert cam._cached_image_bytes == b"placeholder-bytes"
 
 
 async def test_async_on_demand_update(
@@ -2352,8 +2413,13 @@ async def test_camera_file_not_found(hass, mock_update):
     cam = MailCam(hass, "amazon_camera", mock_config, mock_coordinator)
     cam._file_path = "/nonexistent/path.jpg"
 
+    # A missing primary image must fall back to the bundled placeholder
+    # (no_deliveries_amazon.jpg, shipped in the package) rather than return
+    # None, which would make the HA camera proxy serve HTTP 500.
     image = await cam.async_camera_image()
-    assert image is None
+    assert image is not None
+    assert len(image) > 0
+    assert cam._cached_image_path == cam._default_image_path
 
 
 @pytest.mark.asyncio
@@ -2368,13 +2434,16 @@ async def test_camera_image_read_error(hass, tmp_path):
     mock_config = MagicMock()
     cam = MailCam(hass, "amazon_camera", mock_config, mock_coord)
 
-    # Assign the secure temporary path
+    # Assign the secure temporary path (the file is never created, so the
+    # primary read raises FileNotFoundError).
     cam._file_path = safe_file_path
 
-    # Simulate file existing but failing to open
-    with patch("builtins.open", side_effect=FileNotFoundError):
-        image = await cam.async_camera_image()
-        assert image is None
+    # The missing primary image falls back to the bundled placeholder
+    # (no_deliveries_amazon.jpg) instead of returning None.
+    image = await cam.async_camera_image()
+    assert image is not None
+    assert len(image) > 0
+    assert cam._cached_image_path == cam._default_image_path
 
 
 @pytest.mark.asyncio

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -285,30 +285,22 @@ async def test_async_camera_image_file_error(
     caplog,
 ):
     """Test async_camera_image returns None when both image and placeholder are missing."""
-    # The os.path.exists/os.access patches are integration-setup scaffolding
-    # shared by every camera test; they are not a claim about the delivery file
-    # under test. The Path(...).open FileNotFoundError below is what simulates
-    # the missing file on disk at read time.
-    with (
-        patch("os.path.exists", return_value=True),
-        patch("os.access", return_value=False),
-    ):
-        entry = integration
+    entry = integration
 
-        cameras = entry.runtime_data.cameras
-        cam = cameras[0]
-        # Force the primary and placeholder paths to differ so the fallback
-        # branch is exercised; with both reads failing the camera returns None.
-        cam._file_path = "/nonexistent/missing_delivery.jpg"
-        with patch(
-            "custom_components.mail_and_packages.camera.Path"
-        ) as mock_path_class:
-            mock_path_class.return_value.open.side_effect = FileNotFoundError
-            result = await cam.async_camera_image()
+    cameras = entry.runtime_data.cameras
+    cam = cameras[0]
+    # Force the primary and placeholder paths to differ so the fallback
+    # branch is exercised; with both reads failing the camera returns None.
+    # The missing-on-disk condition is simulated entirely by the open()
+    # FileNotFoundError below — no os.path.exists/os.access patching needed.
+    cam._file_path = "/nonexistent/missing_delivery.jpg"
+    with patch("custom_components.mail_and_packages.camera.Path") as mock_path_class:
+        mock_path_class.return_value.open.side_effect = FileNotFoundError
+        result = await cam.async_camera_image()
 
-        assert result is None
-        assert "Could not read camera" in caplog.text
-        assert "placeholder image also missing" in caplog.text
+    assert result is None
+    assert "Could not read camera" in caplog.text
+    assert "placeholder image also missing" in caplog.text
 
 
 async def test_async_camera_image_falls_back_to_placeholder(
@@ -330,40 +322,35 @@ async def test_async_camera_image_falls_back_to_placeholder(
     Regression test: a missing _file_path must NOT return None (which makes the
     HA camera proxy serve HTTP 500); it must fall back to the bundled placeholder.
     """
-    with (
-        patch("os.path.exists", return_value=True),
-        patch("os.access", return_value=False),
-    ):
-        entry = integration
+    entry = integration
 
-        cameras = entry.runtime_data.cameras
-        cam = cameras[0]
-        # Primary path points at a file that does not exist on disk; the
-        # bundled placeholder (_default_image_path) is still readable.
-        cam._file_path = "/nonexistent/missing_delivery.jpg"
-        placeholder_path = cam._default_image_path
+    cameras = entry.runtime_data.cameras
+    cam = cameras[0]
+    # Primary path points at a file that does not exist on disk; the bundled
+    # placeholder (_default_image_path) is still readable. The missing primary
+    # is simulated by the first open() raising FileNotFoundError below.
+    cam._file_path = "/nonexistent/missing_delivery.jpg"
+    placeholder_path = cam._default_image_path
 
-        # First open() (primary path) raises; second open() (placeholder)
-        # returns a readable handle with bytes.
-        placeholder_handle = MagicMock()
-        placeholder_handle.__enter__.return_value = MagicMock(
-            read=MagicMock(return_value=b"placeholder-bytes")
-        )
-        placeholder_handle.__exit__ = MagicMock(return_value=False)
+    # First open() (primary path) raises; second open() (placeholder)
+    # returns a readable handle with bytes.
+    placeholder_handle = MagicMock()
+    placeholder_handle.__enter__.return_value = MagicMock(
+        read=MagicMock(return_value=b"placeholder-bytes")
+    )
+    placeholder_handle.__exit__ = MagicMock(return_value=False)
 
-        with patch(
-            "custom_components.mail_and_packages.camera.Path"
-        ) as mock_path_class:
-            mock_path_class.return_value.open.side_effect = [
-                FileNotFoundError,
-                placeholder_handle,
-            ]
-            result = await cam.async_camera_image()
+    with patch("custom_components.mail_and_packages.camera.Path") as mock_path_class:
+        mock_path_class.return_value.open.side_effect = [
+            FileNotFoundError,
+            placeholder_handle,
+        ]
+        result = await cam.async_camera_image()
 
-        assert result == b"placeholder-bytes"
-        # Cache should now key off the placeholder path for cheap repeat reads.
-        assert cam._cached_image_path == placeholder_path
-        assert cam._cached_image_bytes == b"placeholder-bytes"
+    assert result == b"placeholder-bytes"
+    # Cache should now key off the placeholder path for cheap repeat reads.
+    assert cam._cached_image_path == placeholder_path
+    assert cam._cached_image_bytes == b"placeholder-bytes"
 
 
 async def test_async_camera_image_placeholder_is_primary_missing(
@@ -386,28 +373,22 @@ async def test_async_camera_image_placeholder_is_primary_missing(
     there is nothing to fall back to; re-reading the same missing file is skipped
     and the camera returns None.
     """
-    # See test_async_camera_image_file_error for why these patches are present.
-    with (
-        patch("os.path.exists", return_value=True),
-        patch("os.access", return_value=False),
-    ):
-        entry = integration
+    entry = integration
 
-        cameras = entry.runtime_data.cameras
-        cam = cameras[0]
-        # Make the primary path identical to the bundled placeholder.
-        cam._file_path = cam._default_image_path
+    cameras = entry.runtime_data.cameras
+    cam = cameras[0]
+    # Make the primary path identical to the bundled placeholder. The missing
+    # file is simulated by the open() FileNotFoundError below.
+    cam._file_path = cam._default_image_path
 
-        with patch(
-            "custom_components.mail_and_packages.camera.Path"
-        ) as mock_path_class:
-            mock_path_class.return_value.open.side_effect = FileNotFoundError
-            result = await cam.async_camera_image()
+    with patch("custom_components.mail_and_packages.camera.Path") as mock_path_class:
+        mock_path_class.return_value.open.side_effect = FileNotFoundError
+        result = await cam.async_camera_image()
 
-        assert result is None
-        # The fallback branch is skipped, so no second read is attempted.
-        assert mock_path_class.return_value.open.call_count == 1
-        assert "placeholder image also missing" not in caplog.text
+    assert result is None
+    # The fallback branch is skipped, so no second read is attempted.
+    assert mock_path_class.return_value.open.call_count == 1
+    assert "placeholder image also missing" not in caplog.text
 
 
 async def test_async_on_demand_update(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -285,6 +285,10 @@ async def test_async_camera_image_file_error(
     caplog,
 ):
     """Test async_camera_image returns None when both image and placeholder are missing."""
+    # The os.path.exists/os.access patches are integration-setup scaffolding
+    # shared by every camera test; they are not a claim about the delivery file
+    # under test. The Path(...).open FileNotFoundError below is what simulates
+    # the missing file on disk at read time.
     with (
         patch("os.path.exists", return_value=True),
         patch("os.access", return_value=False),
@@ -360,6 +364,50 @@ async def test_async_camera_image_falls_back_to_placeholder(
         # Cache should now key off the placeholder path for cheap repeat reads.
         assert cam._cached_image_path == placeholder_path
         assert cam._cached_image_bytes == b"placeholder-bytes"
+
+
+async def test_async_camera_image_placeholder_is_primary_missing(
+    hass,
+    mock_imap_no_email,
+    integration,
+    mock_osremove,
+    mock_osmakedir,
+    mock_listdir,
+    mock_update_time,
+    mock_copy_overlays,
+    mock_hash_file,
+    mock_getctime_today,
+    mock_update,
+    caplog,
+):
+    """Test async_camera_image returns None when the primary path IS the placeholder and it's missing.
+
+    For a non-custom camera the primary _file_path equals _default_image_path, so
+    there is nothing to fall back to; re-reading the same missing file is skipped
+    and the camera returns None.
+    """
+    # See test_async_camera_image_file_error for why these patches are present.
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.access", return_value=False),
+    ):
+        entry = integration
+
+        cameras = entry.runtime_data.cameras
+        cam = cameras[0]
+        # Make the primary path identical to the bundled placeholder.
+        cam._file_path = cam._default_image_path
+
+        with patch(
+            "custom_components.mail_and_packages.camera.Path"
+        ) as mock_path_class:
+            mock_path_class.return_value.open.side_effect = FileNotFoundError
+            result = await cam.async_camera_image()
+
+        assert result is None
+        # The fallback branch is skipped, so no second read is attempted.
+        assert mock_path_class.return_value.open.call_count == 1
+        assert "placeholder image also missing" not in caplog.text
 
 
 async def test_async_on_demand_update(


### PR DESCRIPTION
## Problem

`MailCam.async_camera_image` reads `self._file_path` and, on `FileNotFoundError`, logged a debug line and returned `None`. Home Assistant's camera proxy turns a `None` image response into **HTTP 500**, so the dashboard renders a broken tile.

This happens whenever a camera's `_file_path` points at a file that isn't on disk:
- the generic camera's `generic_deliveries.gif` before any generic delivery has ever been written;
- any per-shipper delivery image that was cleaned up or not yet generated.

## Fix

Every shipper already ships a bundled placeholder in the package (`no_deliveries_<base>.jpg`, `no_deliveries_generic.jpg`, or `mail_none.gif` for USPS). The camera now falls back to that placeholder instead of returning `None`, so it never 500s:

- `__init__` captures the bundled placeholder once as `self._default_image_path`, so it's always available regardless of later `_file_path` changes.
- On `FileNotFoundError` for the primary path, `async_camera_image` reads the placeholder, caches against it, and returns its bytes. It only returns `None` if the shipped placeholder is *also* unreadable (should never happen) — logged at WARNING.

The cache fast-path and successful-read caching are preserved; `update_file_path()` still invalidates the cache, so a later real delivery image refreshes correctly.

## Tests

- New `test_async_camera_image_falls_back_to_placeholder` asserts placeholder bytes are returned (not `None`) and the cache is keyed to the placeholder path.
- `test_async_camera_image_file_error` now covers the both-missing case (returns `None` + WARNING).
- Two pre-existing tests that asserted the old `None` behavior were updated to the new fallback contract (the old `None` return was the bug).

Full suite passes; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
