### PR TITLE
feat: add fedex_exception sensor for carrier parity

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -386,6 +386,19 @@ SENSOR_DATA = {
         ],
         "subject": ["Your shipment is on the way"],
     },
+    "fedex_exception": {
+        "email": [
+            "TrackingUpdates@fedex.com",
+            "fedexcanada@fedex.com",
+            "noreply@fedex.com",
+        ],
+        # Subject confirmed against a real FedEx delivery-exception
+        # notification (From: trackingupdates@fedex.com, Subject:
+        # "FedEx Delivery Exception"). IMAP SUBJECT search is a
+        # case-insensitive substring match, mirroring usps_exception's
+        # "Delivery Exception" fragment.
+        "subject": ["FedEx Delivery Exception"],
+    },
     "fedex_tracking": {"pattern": ["\\d{12,20}"]},
     # Canada Post
     "capost_delivered": {
@@ -1066,6 +1079,12 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         native_unit_of_measurement="package(s)",
         icon="mdi:package-variant-closed",
         key="fedex_packages",
+    ),
+    "fedex_exception": SensorEntityDescription(
+        name="Mail FedEx Exception",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:archive-alert",
+        key="fedex_exception",
     ),
     # Amazon
     "amazon_packages": SensorEntityDescription(

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -239,6 +239,30 @@ async def test_generic_ups_exception(hass):
 
 
 @pytest.mark.asyncio
+async def test_generic_fedex_exception(hass):
+    """Test GenericShipper with FedEx exception (carrier parity with UPS)."""
+    shipper = GenericShipper(hass, {})
+    mock_account = AsyncMock()
+    mock_account.search.return_value = MagicMock(result="OK", lines=[b"1"])
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["123456789012"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.GenericShipper._verify_matched_subjects",
+            new_callable=AsyncMock,
+            side_effect=lambda a, b, c, d, cache=None: b,
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "fedex_exception")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["123456789012"]
+
+
+@pytest.mark.asyncio
 async def test_generic_image_extraction_no_shipper(hass):
     """Test GenericShipper image extraction logic when no shipper name is found."""
     # Test path where sensor_type doesn't map to a shipper name for image extraction


### PR DESCRIPTION
## Summary

Adds a `fedex_exception` sensor so FedEx has parity with the existing `ups_exception`, `usps_exception`, `walmart_exception`, and `amazon_exception` sensors. FedEx already had `fedex_delivered`, `fedex_delivering`, and `fedex_packages` — the exception sensor was the only one missing among the major US carriers.

## Changes

- `const.py`: new `fedex_exception` entry in `SENSOR_DATA` (the three standard FedEx senders) and a matching `SensorEntityDescription` in `SENSOR_TYPES` (`mdi:archive-alert`, "package(s)"), mirroring `ups_exception`.
- `tests/shippers/test_generic.py`: new `test_generic_fedex_exception` mirroring `test_generic_ups_exception`.

The rest of the wiring is automatic: `get_resources()` derives the config-flow Sensors List straight from `SENSOR_TYPES`, and the generic shipper + coordinator handle `*_exception` sensors generically by prefix/suffix — no FedEx-specific code required.

## Subject line

The matched subject `"FedEx Delivery Exception"` was confirmed against a real FedEx delivery-exception notification (`From: trackingupdates@fedex.com`). IMAP `SUBJECT` search is a case-insensitive substring match.

Scope note: this covers FedEx **delivery-exception** emails. If FedEx uses a distinct subject for proactive *reschedule* notifications (the way UPS does with "New Scheduled Delivery Date"), that would be a small follow-up once a sample is available.

Full suite passes; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
