### PR TITLE
fix: verify amazon email subject before counting as delivered

### DIFF
--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -35,6 +35,7 @@ from custom_components.mail_and_packages.const import (
     AMAZON_OTP_REGEX,
     AMAZON_OTP_SUBJECT,
     AMAZON_PACKAGES,
+    AMAZON_SHIPMENT_SUBJECT,
     ATTR_COUNT,
     CONF_AMAZON_DAYS,
     CONF_AMAZON_DOMAIN,
@@ -48,7 +49,7 @@ from custom_components.mail_and_packages.utils.amazon import (
     amazon_email_addresses,
     download_amazon_img,
     extract_order_numbers,
-    get_amazon_image_urls,
+    filter_amazon_strings,
     get_decoded_subject,
     get_email_body,
     parse_amazon_arrival_date,
@@ -330,6 +331,9 @@ class AmazonShipper(Shipper):
 
         address_list = amazon_email_addresses(fwds, amazon_domain)
         _LOGGER.debug("Amazon email search addresses: %s", address_list)
+        if amazon_domain:
+            subjects = filter_amazon_strings(subjects, amazon_domain)
+
         (server_response, data) = await email_search(
             account=account,
             address=address_list,
@@ -339,17 +343,72 @@ class AmazonShipper(Shipper):
         )
         if server_response == "OK" and data[0]:
             for email_id in data[0].split():
-                count += 1
-                urls = await get_amazon_image_urls(email_id, account, cache)
-                for url in urls:
-                    if url not in all_image_urls:
-                        all_image_urls.append(url)
+                fetch_id = (
+                    email_id.decode() if isinstance(email_id, bytes) else email_id
+                )
+                if cache:
+                    msg_data = (await cache.fetch(fetch_id, "(RFC822)"))[1]
+                else:
+                    msg_data = (await email_fetch(account, fetch_id, "(RFC822)"))[1]
+
+                is_delivered, urls = self._is_amazon_delivered(msg_data, subjects)
+                if is_delivered:
+                    count += 1
+                    for url in urls:
+                        if url not in all_image_urls:
+                            all_image_urls.append(url)
 
         await self._process_amazon_images(
             all_image_urls, image_path, amazon_image_name, count
         )
 
         return count
+
+    def _is_amazon_delivered(
+        self, msg_data: list, subjects: list[str]
+    ) -> tuple[bool, list[str]]:
+        """Verify if email is a delivered notification and return image URLs."""
+        for response_part in msg_data:
+            if not isinstance(response_part, (bytes, bytearray)):
+                continue
+            msg = email.message_from_bytes(response_part)
+            subject = get_decoded_subject(msg)
+            if not subject:
+                continue
+
+            # Check if subject contains any delivered keyword (case-insensitive)
+            has_delivered = any(s.lower() in subject.lower() for s in subjects)
+            # Check if subject contains ordered or shipped keywords (case-insensitive)
+            has_ordered = any(
+                s.lower() in subject.lower() for s in AMAZON_ORDERED_SUBJECT
+            )
+            has_shipped = any(
+                s.lower() in subject.lower() for s in AMAZON_SHIPMENT_SUBJECT
+            )
+
+            if has_delivered and not has_ordered and not has_shipped:
+                urls = self._extract_amazon_image_urls(msg)
+                return True, urls
+        return False, []
+
+    def _extract_amazon_image_urls(self, msg: email.message.Message) -> list[str]:
+        """Extract image URLs from Amazon email body."""
+        urls = []
+        pattern = re.compile(rf"{const.AMAZON_IMG_PATTERN}")
+        for part in msg.walk():
+            if part.get_content_type() != "text/html":
+                continue
+            part_payload = part.get_payload(decode=True)
+            if part_payload:
+                part_content = part_payload.decode("utf-8", "ignore")
+                found = pattern.findall(part_content)
+                for url in found:
+                    if url[1] not in const.AMAZON_IMG_LIST:
+                        continue
+                    full_url = url[0] + url[1] + url[2]
+                    if full_url not in urls:
+                        urls.append(full_url)
+        return urls
 
     async def _process_amazon_images(
         self,

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -751,7 +751,6 @@ async def test_amazon_search_multiple_images_gif(hass):
         {"image_path": "/fake/path/", "amazon_image": "amazon.gif"},
     )
     mock_account = AsyncMock()
-    urls = ["http://test.com/img1.jpg", "http://test.com/img2.jpg"]
 
     with (
         patch(
@@ -760,10 +759,9 @@ async def test_amazon_search_multiple_images_gif(hass):
             return_value=("OK", [b"1 2"]),
         ),
         patch(
-            "custom_components.mail_and_packages.shippers.amazon.get_amazon_image_urls",
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
             new_callable=AsyncMock,
-            return_value=urls,
-        ),
+        ) as mock_fetch,
         patch(
             "custom_components.mail_and_packages.shippers.amazon.download_amazon_img",
             new_callable=AsyncMock,
@@ -784,6 +782,15 @@ async def test_amazon_search_multiple_images_gif(hass):
             "custom_components.mail_and_packages.shippers.amazon.generate_delivery_gif",
         ) as mock_gif,
     ):
+
+        async def _mock_fetch(account, email_id, parts):
+            if email_id == "1":
+                content = b'Subject: Delivered: \nContent-Type: text/html\n\n<img src="https://us-prod-temp.s3.amazonaws.com/img1.jpg">'
+            else:
+                content = b'Subject: Delivered: \nContent-Type: text/html\n\n<img src="https://us-prod-temp.s3.amazonaws.com/img2.jpg">'
+            return ("OK", [b"RFC822", content])
+
+        mock_fetch.side_effect = _mock_fetch
         await shipper.process(mock_account, "today", AMAZON_DELIVERED)
         assert mock_gif.called
 
@@ -897,7 +904,10 @@ async def test_process_with_cache(hass):
     )
     cache._cache_rfc822["2"] = (
         "OK",
-        [b"RFC822", b"Content-Type: text/html\n\nNo images here"],
+        [
+            b"RFC822",
+            b"Subject: Delivered: Your Amazon order has arrived!\nContent-Type: text/html\n\nNo images here",
+        ],
     )
     with (
         patch(
@@ -989,3 +999,91 @@ async def test_amazon_forwarding_header_mode_sets_fwds_none(hass):
         await shipper.process(mock_account, "today", AMAZON_PACKAGES)
 
     assert captured_fwds["fwds"] is None
+
+
+@pytest.mark.asyncio
+async def test_amazon_search_delivered_excludes_ordered_and_shipped(hass):
+    """Test that Amazon delivered search excludes ordered and shipped emails even if returned by IMAP."""
+    shipper = AmazonShipper(
+        hass,
+        {"image_path": "/fake/path/", "amazon_image": "amazon.jpg"},
+    )
+    mock_account = AsyncMock()
+
+    # We mock search to return 3 email IDs:
+    # 1: Delivered
+    # 2: Ordered (should be ignored)
+    # 3: Shipped (should be ignored)
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1 2 3"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.download_amazon_img",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.anyio.Path.exists",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.cleanup_images",
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.copyfile",
+        ) as mock_copy,
+    ):
+
+        async def _mock_fetch(account, email_id, parts):
+            if email_id == "1":
+                content = b"Subject: Delivered: Your Amazon order has arrived!\nContent-Type: text/html\n\nNo images"
+            elif email_id == "2":
+                content = b"Subject: Ordered: Your order of python book\nContent-Type: text/html\n\nNo images"
+            else:
+                content = b"Subject: Shipped: Your package is on the way\nContent-Type: text/html\n\nNo images"
+            return ("OK", [b"RFC822", content])
+
+        mock_fetch.side_effect = _mock_fetch
+
+        result = await shipper.process(mock_account, "today", AMAZON_DELIVERED)
+        # Should only count the delivered email (1), excluding the other 2.
+        assert result[AMAZON_DELIVERED] == 1
+        assert mock_copy.called
+
+
+@pytest.mark.asyncio
+async def test_is_amazon_delivered_skips_non_bytes_response_parts(hass):
+    """Test that _is_amazon_delivered skips non-bytes items in msg_data (line 373 coverage).
+
+    IMAP fetch responses sometimes include non-bytes elements (e.g. tuples used
+    as header separators). Those parts must be skipped; the method should still
+    correctly evaluate the actual bytes payload that follows.
+    """
+    shipper = AmazonShipper(
+        hass,
+        {"image_path": "/fake/path/", "amazon_image": "amazon.jpg"},
+    )
+
+    delivered_bytes = b"Subject: Delivered: Your Amazon order has arrived!\nContent-Type: text/html\n\nNo images"
+
+    # msg_data contains a non-bytes item first, then the real bytes payload.
+    # The non-bytes item triggers the `continue` on line 373; the bytes item
+    # that follows should still be processed successfully.
+    msg_data_with_non_bytes: list = [
+        ("RFC822", delivered_bytes),  # tuple — not bytes/bytearray → continue
+        delivered_bytes,  # actual bytes payload → processed
+    ]
+
+    is_delivered, urls = shipper._is_amazon_delivered(
+        msg_data_with_non_bytes, ["Delivered"]
+    )
+
+    assert is_delivered is True
+    assert isinstance(urls, list)


### PR DESCRIPTION
## Proposed change

The `_amazon_search` method in the Amazon shipper was counting all emails returned by the IMAP search as delivered, regardless of their subject line content. This caused emails with subjects like `Ordered: <item name>` to incorrectly increment the delivered sensor (issue #1276).

This fix adds Python-level subject validation on each candidate email before counting it as a delivery. Only emails whose subject contains a recognized delivered keyword (from `AMAZON_SHIPMENT_SUBJECT`) **and** does not contain a non-delivery keyword (from `filter_amazon_strings`, e.g. `Ordered`, `Shipped`) are counted. Image URL extraction was also refactored into a separate helper (`_extract_amazon_image_urls`) to avoid redundant IMAP fetches during the validation pass.

Shipped emails continue to be parsed by the existing shipped/tracking logic — no delivery date or tracking functionality is affected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1276
- This PR is related to issue:
