### PR TITLE
fix(amazon): catch the new "has shipped" email subjects

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -173,6 +173,7 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Shipped:",
     "Enviado:",
     "Out for delivery:",
+    "has shipped",
 ]
 AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
 AMAZON_EMAIL = [

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from custom_components.mail_and_packages.const import AMAZON_SHIPMENT_SUBJECT
 from custom_components.mail_and_packages.utils.amazon import (
     _extract_hub_code,
     amazon_date_regex,
@@ -79,6 +80,33 @@ async def test_search_amazon_emails_invalid_days():
         )
         # Should default to DEFAULT_AMAZON_DAYS (3)
         assert mock_search.called
+
+
+def test_amazon_shipment_subject_matches_real_shipped_subjects():
+    """Regression: AMAZON_SHIPMENT_SUBJECT must match real 'has shipped' subjects.
+
+    The IMAP SUBJECT filter built from these keywords is a case-insensitive
+    substring match performed server-side. Amazon's current shipped-notification
+    subject looks like:
+
+        Your Amazon.com order of "<item>" and 1 more item has shipped!
+
+    which contains none of the legacy keywords ("Shipped:", etc.), so the email
+    was silently filtered out before it ever reached parsing. The existing
+    search tests mock ``email_search`` and never exercise the subject criteria,
+    so this asserts the keyword list directly against real subjects.
+    """
+    real_shipped_subjects = [
+        'Your Amazon.com order of "Lash Next Door Coquette..." and 1 more '
+        "item has shipped!",
+        "Your Amazon.com order #123-1234567-1234567 has shipped",
+        "Your Amazon order has shipped",
+    ]
+    for subject in real_shipped_subjects:
+        assert any(
+            keyword.lower() in subject.lower()
+            for keyword in AMAZON_SHIPMENT_SUBJECT
+        ), f"No AMAZON_SHIPMENT_SUBJECT keyword matches subject: {subject!r}"
 
 
 def test_extract_hub_code():


### PR DESCRIPTION
## Proposed change

Amazon now sends shipped emails with subjects like:

    Your Amazon.com order of "<item>" and 1 more item has shipped!

None of the old `AMAZON_SHIPMENT_SUBJECT` keywords (`"Shipped:"`, `"Enviado:"`, `"Out for delivery:"`) are a substring of that, so the IMAP `SUBJECT` filter built in `search_amazon_emails` silently skips these emails server-side and they never get counted as shipped packages.

This adds `"has shipped"` to `AMAZON_SHIPMENT_SUBJECT`. It's kept specific on purpose:

- A broader keyword like `"Your Amazon.com order"` would over-match the IMAP search (e.g. `"...is delayed"`).
- `AMAZON_SHIPMENT_SUBJECT` is also used as a *negative* signal in the delivered-image check (`shippers/amazon.py`), so a broad keyword would wrongly mark delivered/ordered emails as "shipped" and exclude them. `"has shipped"` doesn't appear in delivered/ordered subjects, so it's clean on both fronts.

Also adds a regression test asserting the keyword list matches real shipped subjects. The existing search tests mock `email_search` and never exercise the subject criteria, which is why this gap was not caught.

> Note: I couldn't run the suite locally (Windows — the HA test harness needs Linux). I verified the new test's logic deterministically; relying on CI for the full run.

Supersedes #1279 (couldn't be reopened after the branch was force-pushed).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
