### PR TITLE
fix(imap): use standard RFC compliant BODY search key

### DIFF
--- a/.agents/skills/async_safe_executor_jobs/SKILL.md
+++ b/.agents/skills/async_safe_executor_jobs/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: Async-Safe I/O & Executor Guidelines
+description: Best practices for performing non-blocking file, image, and network I/O operations inside Home Assistant's async loop.
+---
+
+# Async-Safe I/O & Executor Guidelines
+
+This skill defines the threading and asynchronous safety rules to follow when interacting with the filesystem or network within the Home Assistant async loop.
+
+## Guidelines
+
+### 1. No Blocking I/O in the Event Loop
+* Do not call blocking synchronous functions (like `os.path.exists`, `shutil.copyfile`, or standard file `open()`) directly in async contexts (such as sensor/camera updates or setup methods). Doing so blocks the Home Assistant main thread, degrading system performance.
+
+### 2. Utilizing `async_add_executor_job`
+* Wrap synchronous operations that must run inside the main thread in an executor job:
+  ```python
+  await self.hass.async_add_executor_job(copyfile, str(src), str(dst))
+  ```
+
+### 3. Asynchronous Alternatives
+* Prefer async file/directory utilities from libraries like `anyio` or standard library wrappers where applicable. For example:
+  ```python
+  import anyio
+  if not await anyio.Path(path_str).exists():
+      # async-safe path checking
+  ```

--- a/.agents/skills/ha_modernization_standards/SKILL.md
+++ b/.agents/skills/ha_modernization_standards/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: Home Assistant Modernization Standards
+description: Guidelines for adhering to modern Home Assistant lifecycle and component structure rules (like runtime_data).
+---
+
+# Home Assistant Modernization Standards
+
+This skill ensures that all changes and additions to this integration align with modern Home Assistant development practices, lifecycle methods, and architecture requirements.
+
+## Guidelines
+
+### 1. Replaces `hass.data` with `ConfigEntry.runtime_data`
+* For Home Assistant core version compatibility, always store active runtime data (like the coordinator instance) using the typed `ConfigEntry.runtime_data` pattern instead of storing objects globally in `hass.data[DOMAIN]`.
+
+### 2. Async Lifecycle & Config Entry Setup
+* During config entry setup (`async_setup_entry`), ensure any network-dependent actions (like connecting to the IMAP server) are managed cleanly.
+* Do not perform blocking, synchronous updates directly during setup. Leverage `DataUpdateCoordinator` and handle first-refresh behavior carefully to avoid triggering Home Assistant's configuration entry setup timeouts (`CancelledError`).
+
+### 3. Graceful Property Access
+* All sensor and camera entities should handle situations where the coordinator has no data (`self.coordinator.data is None`) gracefully. Return appropriate defaults (e.g. `None` or `0`) rather than raising a `TypeError` or `AttributeError`.

--- a/.agents/skills/imap_rfc_compliance/SKILL.md
+++ b/.agents/skills/imap_rfc_compliance/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: IMAP RFC Compliance Guidelines
+description: Rules and best practices for writing RFC-compliant IMAP search queries and maintaining test mock fidelity.
+---
+
+# IMAP RFC Compliance Guidelines
+
+This skill provides guidelines and patterns to ensure that any IMAP connection, search query, or fetch command implemented in this repository is strictly compliant with the standard IMAP RFC specifications (e.g., RFC 3501).
+
+## Guidelines & Best Practices
+
+### 1. SEARCH vs. FETCH Command Syntax
+Do not confuse or mix up `SEARCH` criteria keys with section or body specifiers meant for the `FETCH` command.
+* **Incorrect (`SEARCH` query)**: `BODY[TEXT] "value"`
+* **Correct (`SEARCH` query)**: `BODY "value"` or `TEXT "value"`
+
+### 2. Valid IMAP SEARCH Keys
+The following are the standard keys defined in RFC 3501 for search criteria:
+* `BODY <string>`: Messages that contain the specified string in the body of the message.
+* `TEXT <string>`: Messages that contain the specified string in the header or body of the message.
+* `SUBJECT <string>`: Messages that contain the specified string in the Subject header.
+* `FROM <string>`: Messages that contain the specified string in the From header.
+* `HEADER <field-name> <string>`: Messages that contain the specified string in the header with the specified field-name.
+
+### 3. Parentheses & Logical Query Grouping
+* Keep grouping simple and compliant.
+* **Yahoo / AOL IMAP Exception**: Yahoo and AOL IMAP servers require the entire search criteria string to be enclosed in a single pair of outer parentheses (e.g., `(FROM "example@domain.com" SUBJECT "Delivery")`). The `build_search` utility implements this via the `is_yahoo=True` flag.
+
+### 4. Code Utilities Reference
+Always use the centralized query-building utility rather than manually constructing search queries:
+* **Function**: `build_search(address: list, date: str, subject: str | list[str] = "", body: str | list[str] = "", header: str = "", is_yahoo: bool = False)`
+* Located in: [imap.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/custom_components/mail_and_packages/utils/imap.py)
+
+#### Centralized Search String Sanitization
+Always sanitize search terms to strip double quotes and normalize non-ASCII characters to ensure compatibility with ASCII-only IMAP servers (like Microsoft Exchange):
+* Use `clean_search_string(val: str) -> str` from [imap.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/custom_components/mail_and_packages/utils/imap.py).
+
+### 5. Test Mock Fidelity
+Ensure all IMAP mock objects (such as mock connections or mock responses in `tests/`) emulate standard IMAP server behaviors:
+* Verify that test mocks explicitly assert that the generated search query uses correct keys (like `BODY` instead of `BODY[TEXT]`).
+* Do not write mocks that silently succeed on incorrect syntax.
+* Refer to [test_imap_email.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/tests/utils/test_imap_email.py) for examples of standard search string assertion assertions.

--- a/.agents/skills/shipper_integration/SKILL.md
+++ b/.agents/skills/shipper_integration/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: Shipper Integration Guidelines
+description: Rules and patterns for extending carrier email parsers, registering constants, and writing tests for shippers.
+---
+
+# Shipper Integration Guidelines
+
+This skill defines the requirements for adding or updating carrier-specific shippers (email parsers) within this integration.
+
+## Guidelines
+
+### 1. Extending the Base Shipper Class
+* All shipper implementations should reside in the `custom_components/mail_and_packages/shippers/` directory.
+* Shippers must inherit from the base `GenericShipper` class found in `generic.py`.
+* Override the `process` method to define specific parsing logic, or inherit the base email search logic by defining standard configuration keys.
+
+### 2. Configuration & Constant Registration
+* All shipper names, attributes, sensor names, and defaults must be registered in the central constants file: [const.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/custom_components/mail_and_packages/const.py).
+* Do not hardcode shipper-specific identifiers directly in the coordinator or generic files.
+
+### 3. Testing New Shippers
+* Create a corresponding test file under `tests/shippers/` (e.g. `test_new_shipper.py`).
+* Use the shared mock fixtures and mock IMAP client overrides defined in [conftest.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/tests/conftest.py).
+* Verify that email content parsing, sensor values, and edge cases (such as subject mismatches or empty bodies) are fully covered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ This repository is a **Home Assistant Custom Integration** that connects to an I
   - `conftest.py`: Shared testing fixtures and mock IMAP client overrides.
   - `test_init.py`, `test_config_flow.py`, etc.: Integration and unit tests.
 
+### IMAP Integration & Compatibility Guidelines
+- **IMAP RFC Compliance**: All IMAP query keys and arguments used in search commands (e.g. `search()`) must strictly conform to the IMAP RFC specifications (e.g., RFC 3501). Do not use FETCH-specific section/body specifiers (like `BODY[TEXT]`) inside `SEARCH` commands; instead, use standard search keys such as `BODY` or `TEXT` to prevent setup/login timeouts or parse errors on strictly compliant IMAP servers.
+- **Test Fidelity**: Keep mock IMAP structures and test assertions aligned with standard RFC query formatting so invalid query structures are not masked by test mocks.
+
 ---
 
 ## 2. Python Environment & Dependency Management
@@ -123,3 +127,33 @@ permissions:
 All pull request titles must follow the Conventional Commits specification (e.g., `feat: ...`, `fix: ...`, `ci: ...`).
 - Workflow checks: Managed via the `Semantic PR Check` action in `.github/workflows/semantic-pr.yaml`.
 - Auto-labeling: Handled automatically by the built-in autolabeler in `.github/release-drafter.yml`.
+
+---
+
+## 7. Pull Request & Contribution Guidelines
+
+To maintain code quality and ensure a smooth review process, all pull requests must follow these guidelines:
+
+### A. Pre-submission Checklist
+Before submitting a pull request, run the following verification steps locally:
+1. **Formatting & Linting**: Auto-format and resolve all fixable lint issues:
+   ```bash
+   ruff check --fix . && ruff format .
+   ```
+2. **Type Safety**: Verify that no new type errors are introduced:
+   ```bash
+   mypy custom_components/mail_and_packages/
+   ```
+3. **Unit Tests**: Ensure all tests run and pass:
+   ```bash
+   uv run pytest
+   ```
+4. **Pre-commit Hooks**: Run git hooks against all files to ensure formatting/checkers pass:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+### B. Pull Request Scope & Structure
+* **Keep PRs Atomic**: Avoid combining unrelated refactoring, styling fixes, or multiple feature requests into a single PR. Keep changes focused and small where possible.
+* **PR Templates**: Pull requests must use the repository's PR template, leaving nothing out unless the template explicitly states that it is optional or can be skipped.
+* **Commit Messages**: Write descriptive commit messages. Ensure the PR title matches the Conventional Commits specification (e.g., `fix(imap): handle body search syntax error`).

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -270,11 +270,11 @@ def build_search(  # noqa: C901
         safe_bodies = [b for b in safe_bodies if b]
 
         if len(safe_bodies) == 1:
-            body_part = f'BODY[TEXT] "{safe_bodies[0]}"'
+            body_part = f'BODY "{safe_bodies[0]}"'
         elif len(safe_bodies) > 1:
             body_prefix = " ".join(["OR"] * (len(safe_bodies) - 1))
-            body_joined = '" BODY[TEXT] "'.join(safe_bodies)
-            body_part = f'({body_prefix} BODY[TEXT] "{body_joined}")'
+            body_joined = '" BODY "'.join(safe_bodies)
+            body_part = f'({body_prefix} BODY "{body_joined}")'
 
     if is_yahoo:
         if subject_part or body_part:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -798,7 +798,7 @@ def test_build_search_with_body():
     utf8, search = build_search(
         ["test@example.com"], "25-Mar-2026", body="Tracking 1Z1234567890"
     )
-    assert 'BODY[TEXT] "Tracking 1Z1234567890"' in search
+    assert 'BODY "Tracking 1Z1234567890"' in search
 
     # Multiple body strings
     utf8, search = build_search(
@@ -806,14 +806,14 @@ def test_build_search_with_body():
         "25-Mar-2026",
         body=["Tracking 1Z1234567890", "Order #12345"],
     )
-    assert 'BODY[TEXT] "Tracking 1Z1234567890"' in search
-    assert 'BODY[TEXT] "Order #12345"' in search
+    assert 'BODY "Tracking 1Z1234567890"' in search
+    assert 'BODY "Order #12345"' in search
 
     # Yahoo IMAP with body
     utf8, search_yahoo = build_search(
         ["test@example.com"], "25-Mar-2026", body="Tracking 1Z1234567890", is_yahoo=True
     )
-    assert 'BODY[TEXT] "Tracking 1Z1234567890"' in search_yahoo
+    assert 'BODY "Tracking 1Z1234567890"' in search_yahoo
 
     # Yahoo IMAP with multiple bodies
     utf8, search_yahoo_multi = build_search(
@@ -822,10 +822,7 @@ def test_build_search_with_body():
         body=["Tracking 1Z1234567890", "Order #12345"],
         is_yahoo=True,
     )
-    assert (
-        '(OR BODY[TEXT] "Tracking 1Z1234567890" BODY[TEXT] "Order #12345")'
-        in search_yahoo_multi
-    )
+    assert '(OR BODY "Tracking 1Z1234567890" BODY "Order #12345")' in search_yahoo_multi
 
     # Body with subject
     utf8, search = build_search(
@@ -835,7 +832,7 @@ def test_build_search_with_body():
         body="Tracking 1Z1234567890",
     )
     assert 'SUBJECT "Test"' in search
-    assert 'BODY[TEXT] "Tracking 1Z1234567890"' in search
+    assert 'BODY "Tracking 1Z1234567890"' in search
 
     # Body with subject and Yahoo
     utf8, search_yahoo = build_search(
@@ -846,21 +843,21 @@ def test_build_search_with_body():
         is_yahoo=True,
     )
     assert 'SUBJECT "Test"' in search_yahoo
-    assert 'BODY[TEXT] "Tracking 1Z1234567890"' in search_yahoo
+    assert 'BODY "Tracking 1Z1234567890"' in search_yahoo
 
 
 def test_build_search_with_body_and_empty_body():
     """Test build_search with empty body string."""
     utf8, search = build_search(["test@example.com"], "25-Mar-2026", body="")
-    assert "BODY[TEXT]" not in search
+    assert "BODY" not in search
 
     # Empty list of bodies
     utf8, search = build_search(["test@example.com"], "25-Mar-2026", body=[])
-    assert "BODY[TEXT]" not in search
+    assert "BODY" not in search
 
     # None body
     utf8, search = build_search(["test@example.com"], "25-Mar-2026", body=None)
-    assert "BODY[TEXT]" not in search
+    assert "BODY" not in search
 
 
 def test_build_search_with_body_and_non_ascii():
@@ -869,7 +866,7 @@ def test_build_search_with_body_and_non_ascii():
     utf8, search = build_search(
         ["test@example.com"], "25-Mar-2026", body="Tracking émojis 🎉"
     )
-    assert 'BODY[TEXT] "Tracking emojis "' in search
+    assert 'BODY "Tracking emojis "' in search
 
 
 def test_build_search_unicode_normalization():
@@ -878,7 +875,7 @@ def test_build_search_unicode_normalization():
     assert 'SUBJECT "Livre"' in search
 
     utf8, search2 = build_search(["test@example.com"], "25-Mar-2026", body="Café")
-    assert 'BODY[TEXT] "Cafe"' in search2
+    assert 'BODY "Cafe"' in search2
 
 
 def test_build_search_quotes_removed():
@@ -891,13 +888,13 @@ def test_build_search_quotes_removed():
     utf8, search2 = build_search(
         ["test@example.com"], "25-Mar-2026", body='order "123"'
     )
-    assert 'BODY[TEXT] "order 123"' in search2
+    assert 'BODY "order 123"' in search2
 
     # Mixed ASCII and non-ASCII
     utf8, search = build_search(
         ["test@example.com"], "25-Mar-2026", body="Tracking 1Z1234567890 émojis"
     )
-    assert 'BODY[TEXT] "Tracking 1Z1234567890 emojis"' in search
+    assert 'BODY "Tracking 1Z1234567890 emojis"' in search
 
 
 def test_clean_search_string_empty():


### PR DESCRIPTION
## Proposed change

Fixes the integration failing to load / timing out during setup due to invalid IMAP search query syntax (`BODY[TEXT]`), which is a FETCH section specifier and not a valid SEARCH query key. It has been corrected to use the standard RFC-compliant `BODY` key.

Also introduces developer/AI agent guidelines in `AGENTS.md` and defines a workspace-level skill for compliance and testing mock standards.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1278
- This PR is related to issue:
