### PR TITLE
fix(imap): only wrap search query OR blocks in parentheses for Yahoo

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -482,10 +482,19 @@ async def email_search(  # noqa: C901
         host_lower = account.host.lower()
         is_yahoo = "yahoo" in host_lower or "aol" in host_lower
 
+    # If there are more than 2 body patterns, do not search them server-side
+    # to prevent slow query execution and timeouts on standard IMAP servers.
+    # Instead, we let the shipper's client-side text filtering handle it.
+    body_search = body
+    if body:
+        bodies = [body] if isinstance(body, str) else body
+        if len(bodies) > 2:
+            body_search = ""
+
     if len(folders) <= 1:
         if not isinstance(subject, list) or len(subject) <= 10:
             _unused, search = build_search(
-                address, date, subject, body, header, is_yahoo=is_yahoo
+                address, date, subject, body_search, header, is_yahoo=is_yahoo
             )
             try:
                 res = await account.search(search, charset=None)
@@ -503,7 +512,7 @@ async def email_search(  # noqa: C901
         for i in range(0, len(subject), 10):
             batch = subject[i : i + 10]
             _unused, search = build_search(
-                address, date, batch, body, header, is_yahoo=is_yahoo
+                address, date, batch, body_search, header, is_yahoo=is_yahoo
             )
             try:
                 res = await account.search(search, charset=None)
@@ -522,7 +531,7 @@ async def email_search(  # noqa: C901
     # Multi-folder search logic
     if not isinstance(subject, list) or len(subject) <= 10:
         _unused, search = build_search(
-            address, date, subject, body, header, is_yahoo=is_yahoo
+            address, date, subject, body_search, header, is_yahoo=is_yahoo
         )
         try:
             uids = await _execute_single_search(account, search)
@@ -538,7 +547,7 @@ async def email_search(  # noqa: C901
     for i in range(0, len(subject), 10):
         batch = subject[i : i + 10]
         _unused, search = build_search(
-            address, date, batch, body, header, is_yahoo=is_yahoo
+            address, date, batch, body_search, header, is_yahoo=is_yahoo
         )
         try:
             uids = await _execute_single_search(account, search)

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -237,16 +237,24 @@ def build_search(  # noqa: C901
         # don't need separate configurations.
         parts = [f'OR HEADER "{header}" "{a}" FROM "{a}"' for a in address]
         if len(parts) == 1:
-            addr_clause = f"({parts[0]})"
+            addr_clause = f"({parts[0]})" if is_yahoo else parts[0]
         else:
             or_prefix = " ".join(["OR"] * (len(parts) - 1))
-            addr_clause = f"({or_prefix} {' '.join(parts)})"
+            addr_clause = (
+                f"({or_prefix} {' '.join(parts)})"
+                if is_yahoo
+                else f"{or_prefix} {' '.join(parts)}"
+            )
     elif len(address) == 1:
         addr_clause = f'FROM "{address[0]}"'
     else:
         joined = '" FROM "'.join(address)
         or_prefix = " ".join(["OR"] * (len(address) - 1))
-        addr_clause = f'({or_prefix} FROM "{joined}")'
+        addr_clause = (
+            f'({or_prefix} FROM "{joined}")'
+            if is_yahoo
+            else f'{or_prefix} FROM "{joined}"'
+        )
 
     # Handle multiple subjects
     subject_part = ""
@@ -260,7 +268,11 @@ def build_search(  # noqa: C901
         elif len(safe_subjects) > 1:
             subject_prefix = " ".join(["OR"] * (len(safe_subjects) - 1))
             subject_joined = '" SUBJECT "'.join(safe_subjects)
-            subject_part = f'({subject_prefix} SUBJECT "{subject_joined}")'
+            subject_part = (
+                f'({subject_prefix} SUBJECT "{subject_joined}")'
+                if is_yahoo
+                else f'{subject_prefix} SUBJECT "{subject_joined}"'
+            )
 
     # Handle multiple bodies
     body_part = ""
@@ -274,7 +286,11 @@ def build_search(  # noqa: C901
         elif len(safe_bodies) > 1:
             body_prefix = " ".join(["OR"] * (len(safe_bodies) - 1))
             body_joined = '" BODY "'.join(safe_bodies)
-            body_part = f'({body_prefix} BODY "{body_joined}")'
+            body_part = (
+                f'({body_prefix} BODY "{body_joined}")'
+                if is_yahoo
+                else f'{body_prefix} BODY "{body_joined}"'
+            )
 
     if is_yahoo:
         if subject_part or body_part:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -369,7 +369,7 @@ def test_build_search_no_subject():
 def test_build_search_multiple_no_subject():
     """Test build_search multiple addresses no subject."""
     utf8, search = build_search(["a@b.com", "c@d.com"], "25-Mar-2026", subject=None)
-    assert search == '(OR FROM "a@b.com" FROM "c@d.com") SINCE 25-Mar-2026'
+    assert search == 'OR FROM "a@b.com" FROM "c@d.com" SINCE 25-Mar-2026'
 
     utf8, search_yahoo = build_search(
         ["a@b.com", "c@d.com"], "25-Mar-2026", subject=None, is_yahoo=True
@@ -380,9 +380,7 @@ def test_build_search_multiple_no_subject():
 def test_build_search_prefix_subject():
     """Test build_search with multiple addresses and subject."""
     utf8, search = build_search(["a@b.com", "c@d.com"], "25-Mar-2026", "Test")
-    assert (
-        search == '(OR FROM "a@b.com" FROM "c@d.com") SUBJECT "Test" SINCE 25-Mar-2026'
-    )
+    assert search == 'OR FROM "a@b.com" FROM "c@d.com" SUBJECT "Test" SINCE 25-Mar-2026'
 
     utf8, search_yahoo = build_search(
         ["a@b.com", "c@d.com"], "25-Mar-2026", "Test", is_yahoo=True
@@ -397,8 +395,7 @@ def test_build_search_triple_address():
     """Test build_search with 3 addresses for OR prefix coverage."""
     utf8, search = build_search(["a@b.com", "c@d.com", "e@f.com"], "25-Mar-2026")
     assert (
-        search
-        == '(OR OR FROM "a@b.com" FROM "c@d.com" FROM "e@f.com") SINCE 25-Mar-2026'
+        search == 'OR OR FROM "a@b.com" FROM "c@d.com" FROM "e@f.com" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -417,7 +414,7 @@ def test_build_search_single_header():
     )
     assert (
         search
-        == '(OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") SINCE 25-Mar-2026'
+        == 'OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -441,7 +438,7 @@ def test_build_search_multiple_header():
     )
     assert (
         search
-        == '(OR OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com") SINCE 25-Mar-2026'
+        == 'OR OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -466,7 +463,7 @@ def test_build_search_header_with_subject():
     )
     assert (
         search
-        == '(OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") SUBJECT "UPS Ship Notification" SINCE 25-Mar-2026'
+        == 'OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" SUBJECT "UPS Ship Notification" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -769,7 +766,7 @@ def test_build_search_multi_subject():
     utf8, search = build_search(["test@example.com"], "25-Mar-2026", subject=subjects)
     assert (
         search
-        == 'FROM "test@example.com" (OR OR SUBJECT "One" SUBJECT "Two" SUBJECT "Three") SINCE 25-Mar-2026'
+        == 'FROM "test@example.com" OR OR SUBJECT "One" SUBJECT "Two" SUBJECT "Three" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -999,7 +996,7 @@ def test_build_search_multi_addr_multi_subject_parentheses():
     _utf8, search = build_search(addresses, "23-Apr-2026", subject=subjects)
     assert (
         search
-        == '(OR OR FROM "TrackingUpdates@fedex.com" FROM "fedexcanada@fedex.com" FROM "noreply@fedex.com") (OR OR SUBJECT "Your package has been delivered" SUBJECT "Your packages have been delivered" SUBJECT "Your shipment was delivered") SINCE 23-Apr-2026'
+        == 'OR OR FROM "TrackingUpdates@fedex.com" FROM "fedexcanada@fedex.com" FROM "noreply@fedex.com" OR OR SUBJECT "Your package has been delivered" SUBJECT "Your packages have been delivered" SUBJECT "Your shipment was delivered" SINCE 23-Apr-2026'
     )
 
     # Yahoo compatibility behavior (is_yahoo=True)

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1717,3 +1717,36 @@ async def test_email_fetch_batch_prefixed_timeout_error():
     mock_imap.uid.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_fetch_batch(mock_imap, [b"Junk/1001", b"Junk/1002"])
+
+
+@pytest.mark.asyncio
+async def test_email_search_body_threshold():
+    """Test that email_search only does server-side body search if <= 2 body patterns are specified."""
+    mock_imap = AsyncMock()
+    mock_imap._folders = ["INBOX"]
+    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+
+    # 1 body pattern -> should include BODY in search query
+    await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", body="Pattern1")
+    search_query = mock_imap.search.call_args.args[0]
+    assert 'BODY "Pattern1"' in search_query
+
+    # 2 body patterns -> should include BODY in search query
+    mock_imap.search.reset_mock()
+    await email_search(
+        mock_imap, ["test@example.com"], "25-Mar-2026", body=["Pattern1", "Pattern2"]
+    )
+    search_query = mock_imap.search.call_args.args[0]
+    assert 'BODY "Pattern1"' in search_query
+    assert 'BODY "Pattern2"' in search_query
+
+    # 3 body patterns -> should NOT include BODY in search query
+    mock_imap.search.reset_mock()
+    await email_search(
+        mock_imap,
+        ["test@example.com"],
+        "25-Mar-2026",
+        body=["Pattern1", "Pattern2", "Pattern3"],
+    )
+    search_query = mock_imap.search.call_args.args[0]
+    assert "BODY" not in search_query


### PR DESCRIPTION
## Proposed change

Only wrap search query logical `OR` segments (addresses/headers, subjects, and bodies) in parentheses when the host is Yahoo or AOL (`is_yahoo=True`). 

Parenthesizing prefix `OR` operations violates standard RFC 3501 syntax. Strictly compliant IMAP servers (like Microsoft Exchange or iCloud) interpret parenthesized groups as implicit `AND` lists of standalone search keys. Since `OR` is not a standalone search key, this results in parser errors or setup timeouts.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1278
- This PR is related to issue:
