### PR TITLE
fix: validate Amazon delivery-image host to prevent SSRF

### DIFF
--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -15,6 +15,7 @@ from datetime import timezone
 from email.header import decode_header
 from shutil import copyfile, copytree, which
 from typing import Any, List, Optional, Type, Union
+from urllib.parse import urlparse
 
 import aiohttp
 import imageio as io
@@ -1063,9 +1064,18 @@ def get_amazon_image(
                     pattern = re.compile(rf"{AMAZON_IMG_PATTERN}")
                     found = pattern.findall(part)
                     for url in found:
-                        if url[1] != "us-prod-temp.s3.amazonaws.com":
+                        candidate = url[0] + url[1] + url[2]
+                        # Only fetch the delivery photo from Amazon's S3 bucket.
+                        # Parse the assembled URL and compare the *real* host so a
+                        # crafted "https://<bucket>@attacker/..." (userinfo) URL
+                        # can't smuggle the request to another host (SSRF).
+                        parsed = urlparse(candidate)
+                        if (
+                            parsed.hostname != "us-prod-temp.s3.amazonaws.com"
+                            or parsed.username is not None
+                        ):
                             continue
-                        img_url = url[0] + url[1] + url[2]
+                        img_url = candidate
                         _LOGGER.debug("Amazon img URL: %s", img_url)
                         break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -680,6 +680,33 @@ def mock_imap_amazon_delivered():
 
 
 @pytest.fixture()
+def mock_imap_amazon_delivered_ssrf():
+    """Mock imap with an Amazon email whose delivery image URL smuggles a
+    non-Amazon host via userinfo (https://<bucket>@attacker/...)."""
+    with patch(
+        "custom_components.mail_and_packages.helpers.imaplib"
+    ) as mock_imap_amazon_delivered_ssrf:
+        mock_conn = mock.Mock(spec=imaplib.IMAP4_SSL)
+        mock_imap_amazon_delivered_ssrf.IMAP4_SSL.return_value = mock_conn
+
+        mock_conn.login.return_value = (
+            "OK",
+            [b"user@fake.email authenticated (Success)"],
+        )
+        mock_conn.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"'],
+        )
+        mock_conn.search.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = ("OK", [b"1"])
+        f = open("tests/test_emails/amazon_delivered_ssrf.eml", "r")
+        email_file = f.read()
+        mock_conn.fetch.return_value = ("OK", [(b"", email_file.encode("utf-8"))])
+        mock_conn.select.return_value = ("OK", [])
+        yield mock_conn
+
+
+@pytest.fixture()
 def mock_imap_amazon_delivered_it():
     """Mock imap class values."""
     with patch(

--- a/tests/test_emails/amazon_delivered_ssrf.eml
+++ b/tests/test_emails/amazon_delivered_ssrf.eml
@@ -1,0 +1,13 @@
+From: "auto-confirm@amazon.com" <auto-confirm@amazon.com>
+To: test@example.com
+Subject: Delivered: Your Amazon.com order
+Date: Fri, 11 Sep 2020 18:51:19 +0000
+MIME-Version: 1.0
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<a href="https://www.amazon.com/gp/css/shiptrack/view.html">
+<img class="largeImage" src="https://us-prod-temp.s3.amazonaws.com@evil.example/imageId-abc123?X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Signature=deadbeefdeadbeefdeadbeefdeadbeef" alt="A photo of your delivery location" style="border: 0" />
+</a>
+</body></html>

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -801,6 +801,15 @@ async def test_amazon_search_delivered(
     assert mock_download_img.called
 
 
+async def test_amazon_search_delivered_ssrf(
+    hass, mock_imap_amazon_delivered_ssrf, mock_download_img
+):
+    # The delivery image URL points at "https://<s3-bucket>@evil.example/...".
+    # The real host is evil.example, so the image must NOT be downloaded.
+    amazon_search(mock_imap_amazon_delivered_ssrf, "test/path", hass, "testfilename.jpg")
+    assert not mock_download_img.called
+
+
 async def test_amazon_search_delivered_it(
     hass, mock_imap_amazon_delivered_it, mock_download_img
 ):


### PR DESCRIPTION
### Summary

`get_amazon_image()` extracts the delivery-photo URL from email HTML and restricts the download to Amazon's S3 bucket. The host is validated using a regex capture group, but that group stops at an `@`. Because email content is attacker-influenced, a crafted `src` such as:

```
https://us-prod-temp.s3.amazonaws.com@example.org/imageId-…?X-Amz-Signature=…
```

passes the check (the captured group equals the bucket) while `aiohttp` actually connects to the host **after** the `@` (the part before `@` is URL *userinfo*, not the host). That lets a delivery email steer the fetch to an arbitrary host — an SSRF from the Home Assistant instance.

### Fix

Parse the assembled URL with `urllib.parse.urlparse` and compare the **real** `hostname`, and reject any URL that carries userinfo. Legit S3 URLs are unaffected; only the smuggled-host case is blocked. One-line-ish change in `helpers.py`, no behavior change for normal emails.

### Tests

- `test_amazon_search_delivered_ssrf` + sample `amazon_delivered_ssrf.eml`: a delivery email whose image URL uses `…s3.amazonaws.com@evil.example/…` must **not** trigger a download.
- The existing `test_amazon_search_delivered` (legit S3 image *does* download) still passes.

Verified locally that the sample email matches the existing `AMAZON_IMG_PATTERN` (so it exercises the vulnerable path) and that the new host check rejects it while accepting the legitimate S3 URL.