### PR TITLE
fix(amazon): handle relative arrival dates in any language

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -249,11 +249,9 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Arrivée (\\w+ \\d+)",
     "Arrivée (\\w+ \\d*)",
     "Chega ((\\w+(-\\w+)?))",
-    "Arriving (tomorrow)",
-    "Arriving (today)",
     "Wordt bezorgd op (\\w+ \\d+ \\w+)",
     "Wordt bezorgd op (\\w+ \\d+)",
-    "Wordt (vandaag) bezorgd",
+    "Wordt (\\w+) bezorgd",
 ]
 AMAZON_EXCEPTION_SUBJECT = "Delivery update:"
 AMAZON_EXCEPTION_BODY = "running late"

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -152,16 +152,39 @@ async def parse_amazon_arrival_date(
 
     # Try using regex for more precise extraction of the arrival date string
     if date_str := amazon_date_regex(email_msg):
+        base_datetime = datetime.datetime.combine(
+            email_date or today_date,
+            datetime.time(),
+        )
+
+        # 1. Try parsing without PREFER_DATES_FROM: future to handle relative terms (any language)
+        dateobj = await hass.async_add_executor_job(
+            partial(
+                dateparser.parse,
+                date_str,
+                settings={
+                    "RELATIVE_BASE": base_datetime,
+                    "RETURN_AS_TIMEZONE_AWARE": False,
+                },
+            ),
+        )
+        if dateobj:
+            parsed_date = dateobj.date()
+            base_date = email_date or today_date
+            if (
+                parsed_date == base_date
+                or parsed_date == base_date + datetime.timedelta(days=1)
+            ):
+                return parsed_date
+
+        # 2. Fall back to parsing with PREFER_DATES_FROM: future for absolute dates
         dateobj = await hass.async_add_executor_job(
             partial(
                 dateparser.parse,
                 date_str,
                 settings={
                     "PREFER_DATES_FROM": "future",
-                    "RELATIVE_BASE": datetime.datetime.combine(
-                        email_date or today_date,
-                        datetime.time(),
-                    ),
+                    "RELATIVE_BASE": base_datetime,
                     "RETURN_AS_TIMEZONE_AWARE": False,
                 },
             ),
@@ -366,7 +389,7 @@ def amazon_date_regex(email_msg: str, patterns: list[str] | None = None) -> str 
         patterns = AMAZON_TIME_PATTERN_REGEX
 
     for pattern in patterns:
-        if (found := re.compile(pattern).search(email_msg)) is not None:
+        if (found := re.compile(pattern, re.IGNORECASE).search(email_msg)) is not None:
             if found.groups():
                 return found.group(1)
     return None

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -171,6 +171,7 @@ async def parse_amazon_arrival_date(
         if dateobj:
             parsed_date = dateobj.date()
             base_date = email_date or today_date
+            # Only accept matches that resolve to email_date (today) or email_date + 1 day (tomorrow)
             if (
                 parsed_date == base_date
                 or parsed_date == base_date + datetime.timedelta(days=1)

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -546,10 +546,31 @@ async def test_amazon_search_delivered_it(hass, mock_imap_amazon_delivered_it):
 async def test_parse_amazon_arrival_date(hass):
     """Test parse_amazon_arrival_date utility."""
     email_date = datetime.date(2020, 9, 25)
+
+    # 1. Standard absolute date parsing
     body = "Your order has shipped. Arriving: Saturday, September 26."
-    # With Arriving: in pattern, it should find September 26
     result = await parse_amazon_arrival_date(hass, body, email_date)
     assert result == datetime.date(2020, 9, 26)
+
+    # 2. English "today" relative date
+    body_today = "Your order has shipped. Arriving today by 8 PM."
+    result_today = await parse_amazon_arrival_date(hass, body_today, email_date)
+    assert result_today == email_date
+
+    # 3. English "tomorrow" relative date
+    body_tomorrow = "Your order has shipped. Arriving tomorrow by 8 PM."
+    result_tomorrow = await parse_amazon_arrival_date(hass, body_tomorrow, email_date)
+    assert result_tomorrow == email_date + datetime.timedelta(days=1)
+
+    # 4. Dutch "vandaag" relative date
+    body_vandaag = "Je pakket wordt vandaag bezorgd."
+    result_vandaag = await parse_amazon_arrival_date(hass, body_vandaag, email_date)
+    assert result_vandaag == email_date
+
+    # 5. Dutch "morgen" relative date
+    body_morgen = "Je pakket wordt morgen bezorgd."
+    result_morgen = await parse_amazon_arrival_date(hass, body_morgen, email_date)
+    assert result_morgen == email_date + datetime.timedelta(days=1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes an issue where Amazon same-day and next-day packages are not counted in `sensor.mail_amazon_packages` when the shipped email contains relative arrival dates like "Arriving today", "Arriving tomorrow", or "vandaag/morgen" in the body.

This was caused by two compounding bugs:
1. **Pattern ordering**: The generic `"Arriving (\w+)"` pattern was evaluated before the specific `"Arriving (today)"` / `"Arriving (tomorrow)"` patterns, making them unreachable.
2. **dateparser bug**: `dateparser` with `PREFER_DATES_FROM: "future"` returns `None` or an incorrect date for relative terms (since "today" is ambiguous with future preferences).

**Solution**:
1. Implemented a language-independent two-pass parser fallback logic: first parse the matched date string without `PREFER_DATES_FROM` and verify if it resolves to today (email date) or tomorrow (email date + 1). If not, fall back to parsing with `PREFER_DATES_FROM: "future"` for absolute dates.
2. Removed redundant patterns `"Arriving (tomorrow)"` and `"Arriving (today)"` from `AMAZON_TIME_PATTERN_REGEX` since they are safely matched by `"Arriving (\w+)"` and correctly resolved by the new parsing strategy.
3. Generalized the Dutch pattern to `"Wordt (\w+) bezorgd"` to support all relative words in Dutch.
4. Compiled the Amazon date regexes with `re.IGNORECASE` to make pattern matching case-insensitive and more robust.
5. Added comprehensive test coverage in `tests/shippers/test_amazon.py` for relative dates in both English and Dutch.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1290
- This PR is related to issue:
