### PR TITLE
fix(amazon): retrieve amazon orders with packages count

### DIFF
--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -104,12 +104,23 @@ class AmazonShipper(Shipper):
         days = self.config.get(CONF_AMAZON_DAYS, DEFAULT_AMAZON_DAYS)
         domain = self.config.get(CONF_AMAZON_DOMAIN)
 
-        if sensor_type in [AMAZON_PACKAGES, AMAZON_ORDER]:
-            param = "count" if sensor_type == AMAZON_PACKAGES else "order"
-            result = await self._parse_amazon_emails(
-                account, param, fwds, days, domain, cache, forwarding_header
+        if sensor_type == AMAZON_PACKAGES:
+            count = await self._parse_amazon_emails(
+                account, "count", fwds, days, domain, cache, forwarding_header
             )
-            return {sensor_type: result}
+            orders = await self._parse_amazon_emails(
+                account, "order", fwds, days, domain, cache, forwarding_header
+            )
+            return {
+                AMAZON_PACKAGES: count,
+                AMAZON_ORDER: orders,
+            }
+
+        if sensor_type == AMAZON_ORDER:
+            result = await self._parse_amazon_emails(
+                account, "order", fwds, days, domain, cache, forwarding_header
+            )
+            return {AMAZON_ORDER: result}
 
         if sensor_type == AMAZON_HUB:
             return await self._amazon_hub(account, fwds, cache, forwarding_header)


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes issue #1292 where in-transit Amazon order numbers were never exposed as an attribute on `sensor.mail_amazon_packages`.

Instead of introducing a new selectable sensor option in the config flow, this PR updates the `amazon_packages` sensor processing to retrieve both the package count and the list of order numbers in the same update. This allows the `order` attribute on `sensor.mail_amazon_packages` to be automatically populated whenever the Amazon Packages sensor is enabled, while keeping the configuration options clean.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1292
- This PR is related to issue:
