### PR TITLE
fix(amazon): filter out delivered orders from shipped orders list

### DIFF
--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -210,7 +210,17 @@ class AmazonShipper(Shipper):
 
         if param == "count":
             return final_count
-        return list(context["all_shipped_orders"])
+
+        return [
+            order_id
+            for order_id in context["all_shipped_orders"]
+            if context["packages_arriving_today"].get(order_id, 0)
+            > context["delivered_packages"].get(order_id, 0)
+            or (
+                context["packages_arriving_today"].get(order_id, 0) == 0
+                and context["delivered_packages"].get(order_id, 0) == 0
+            )
+        ]
 
     async def _process_amazon_email(
         self,

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -648,6 +648,42 @@ async def test_amazon_order_list(hass, mock_imap_amazon_shipped):
 
 
 @pytest.mark.asyncio
+async def test_amazon_order_list_filtering(hass, mock_imap_amazon_shipped):
+    """Test Amazon order list filtering when delivered."""
+    shipper = AmazonShipper(hass, {})
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+            side_effect=[
+                (
+                    "OK",
+                    [
+                        b"Header",
+                        b"Subject: Shipped:\n\nYour order 111-1234567-1234567 has shipped.",
+                    ],
+                ),
+                (
+                    "OK",
+                    [
+                        b"Header",
+                        b"Subject: Delivered: Your Amazon order has arrived!\n\nYour order 111-1234567-1234567 was delivered.",
+                    ],
+                ),
+            ],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.search_amazon_emails",
+            new_callable=AsyncMock,
+            return_value=[b"1", b"2"],
+        ),
+    ):
+        result = await shipper.process(mock_imap_amazon_shipped, "today", AMAZON_ORDER)
+        # The order was shipped and delivered, so it should be filtered out
+        assert "111-1234567-1234567" not in result[AMAZON_ORDER]
+
+
+@pytest.mark.asyncio
 async def test_amazon_hub_multi(hass, mock_imap_amazon_the_hub):
     """Test Amazon Hub with multiple codes and deduplication."""
     shipper = AmazonShipper(hass, {})


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the `order` attribute on `sensor.mail_amazon_packages` lists all Amazon order numbers found in shipped emails within the lookback window, including orders that have already been delivered.

This PR filters the returned order list against `context["delivered_packages"]` so that only in-transit orders (either arriving today and not yet delivered, or shipped and not yet delivered) are displayed, matching the package count logic and resolving the inconsistency.

## Type of change

<!--
  What type of change does your PR introduce?
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1296
- This PR is related to issue:
