### PR TITLE
fix(coordinator): zero delivering count when all tracked packages are delivered

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -365,9 +365,34 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
             in_transit = self._in_transit_tracking.get(prefix, {})
-            if in_transit:
+            # A carrier that reported DELIVERING/EXCEPTION tracking details
+            # this scan must have its count overridden even when the
+            # in-transit map ends up EMPTY: when every tracked package has a
+            # delivered notification, the raw IMAP count (which cannot dedup
+            # prior-day deliveries) would otherwise leak through as the
+            # sensor value. Batch-level dedup already zeroes the count for
+            # shippers that emit tracking details, so this is defense in
+            # depth at the state-machine layer. Delivered-only details must
+            # NOT trigger the override: a carrier whose delivering emails
+            # yielded no extractable tracking numbers has a legitimate
+            # email-based count that tracking-level dedup cannot verify —
+            # and carriers with no tracking details at all keep their
+            # email-count value untouched.
+            has_details = any(
+                f"{prefix}_{suffix}" in tracking_details
+                for suffix in ("delivering", "exception")
+            )
+            if in_transit or has_details:
+                if not in_transit and data.get(f"{prefix}_delivering"):
+                    _LOGGER.debug(
+                        "Prefix '%s': no tracked packages remain in transit — "
+                        "overriding delivering count %s -> 0",
+                        prefix,
+                        data.get(f"{prefix}_delivering"),
+                    )
                 data[f"{prefix}_tracking"] = list(in_transit.keys())
                 data[f"{prefix}_delivering"] = len(in_transit)
+            if in_transit:
                 delivered_count = data.get(f"{prefix}_delivered", 0)
                 data[f"{prefix}_packages"] = len(in_transit) + (
                     delivered_count if isinstance(delivered_count, int) else 0

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -297,7 +297,14 @@ class GenericShipper(Shipper):
 
             tracking = set(sensor_res.get(ATTR_TRACKING, []))
             if sensor.endswith("_delivered"):
-                shippers[prefix]["delivered"].update(tracking)
+                # ATTR_TRACKING on _delivered sensors holds only TODAY's
+                # deliveries (so the sensor resets at midnight); dedup must
+                # use the extended-window list or packages delivered on a
+                # previous day are never subtracted from _delivering.
+                extended = sensor_res.get("pre_filtered_tracking")
+                shippers[prefix]["delivered"].update(
+                    tracking if extended is None else set(extended)
+                )
             elif sensor.endswith(("_delivering", "_exception")):
                 shippers[prefix]["delivering"].update(tracking)
                 shippers[prefix]["update_targets"].append((sensor, sensor_res))

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -673,6 +673,46 @@ async def test_process_batch_deduplication(hass):
 
 
 @pytest.mark.asyncio
+async def test_process_batch_dedup_uses_extended_window_delivered(hass):
+    """Dedup subtracts packages delivered on PRIOR days, not just today.
+
+    Regression test: ATTR_TRACKING on _delivered sensors holds only
+    today's deliveries (the sensor resets at midnight); the dedup set
+    must come from pre_filtered_tracking (the extended-window list) or
+    packages delivered yesterday stay in _delivering until they age out.
+    """
+    shipper = GenericShipper(hass, {})
+    mock_account = AsyncMock()
+    mock_cache = MagicMock()
+
+    async def _mock_process(account, date, sensor, cache, **kwargs):
+        if sensor == "fedex_delivered":
+            # Delivered emails exist for F1+F2 earlier in the window; none today
+            return {
+                "fedex_delivered": 0,
+                ATTR_TRACKING: [],
+                "pre_filtered_tracking": ["F1", "F2"],
+            }
+        if sensor == "fedex_delivering":
+            return {
+                "fedex_delivering": 2,
+                ATTR_TRACKING: ["F1", "F2"],
+                ATTR_COUNT: 2,
+            }
+        return {sensor: 0, ATTR_TRACKING: []}
+
+    with patch.object(shipper, "process", side_effect=_mock_process):
+        result = await shipper.process_batch(
+            mock_account, "today", ["fedex_delivered", "fedex_delivering"], mock_cache
+        )
+
+        assert result["fedex_delivered"] == 0
+        assert result["fedex_delivering"] == 0  # F1+F2 delivered on prior days
+        assert result["_tracking_details"]["fedex_delivered"] == ["F1", "F2"]
+        assert "fedex_delivering" not in result["_tracking_details"]
+
+
+@pytest.mark.asyncio
 async def test_generic_image_reset_on_zero_count(hass):
     """Test GenericShipper camera image resets when count is zero."""
     shipper = GenericShipper(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -386,6 +386,81 @@ async def test_apply_tracking_state_removes_delivered(hass):
 
 
 @pytest.mark.asyncio
+async def test_apply_tracking_state_all_delivered_zeroes_count(hass):
+    """Delivering count is zeroed when every in-transit package is delivered.
+
+    Regression test: the override must fire even when the in-transit map
+    becomes EMPTY, otherwise the raw IMAP count (which cannot dedup
+    prior-day deliveries) leaks through as the sensor value.
+    """
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    coordinator._in_transit_tracking["fedex"] = {
+        "9261290": "2026-04-20",
+        "9261999": "2026-04-21",
+    }
+
+    # Raw IMAP counts still see both delivering emails in the window;
+    # delivered notifications exist for BOTH packages (on prior days, so
+    # the fedex_delivered today-count is 0).
+    data = {"fedex_delivering": 2, "fedex_delivered": 0, "fedex_packages": 2}
+    tracking_details = {
+        "fedex_delivering": ["9261290", "9261999"],
+        "fedex_delivered": ["9261290", "9261999"],
+    }
+    coordinator._apply_tracking_state(data, tracking_details, "2026-04-22")
+
+    assert coordinator._in_transit_tracking["fedex"] == {}
+    assert data["fedex_delivering"] == 0
+    assert data["fedex_tracking"] == []
+    # _packages is NOT recomputed when the map is empty: the batch-level
+    # dedup (which subtracts the extended-window delivered set) already
+    # made it the shipped-but-not-yet-out count, and len(in_transit) +
+    # delivered_today would wrongly zero genuinely shipped packages.
+    assert data["fedex_packages"] == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_tracking_state_delivered_only_details_keeps_count(hass):
+    """Delivered-only tracking details must NOT zero the delivering count.
+
+    Regression test: a carrier whose delivering emails yield no extractable
+    tracking numbers (no delivering entry in tracking_details) still has a
+    legitimate email-based count. A delivered notification for an unrelated
+    package must not force-override that count to len(in_transit) == 0.
+    """
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # Two delivering emails matched but tracking extraction found nothing;
+    # an unrelated package delivered earlier in the window has a number.
+    data = {"fedex_delivering": 2, "fedex_delivered": 0}
+    tracking_details = {"fedex_delivered": ["9260000"]}
+    coordinator._apply_tracking_state(data, tracking_details, "2026-04-22")
+
+    assert data["fedex_delivering"] == 2
+    assert "fedex_tracking" not in data
+
+
+@pytest.mark.asyncio
+async def test_apply_tracking_state_no_details_keeps_email_count(hass):
+    """Carriers with no tracking details keep their email-based counts."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # walmart has no tracking-number extraction this scan; its email-based
+    # count must not be clobbered by an override to zero.
+    data = {"walmart_delivering": 3, "ups_delivering": 1}
+    tracking_details = {"ups_delivering": ["1Z111"]}
+    coordinator._apply_tracking_state(data, tracking_details, "2026-04-22")
+
+    assert data["walmart_delivering"] == 3
+    assert "walmart_tracking" not in data
+    assert data["ups_delivering"] == 1
+
+
+@pytest.mark.asyncio
 async def test_apply_tracking_state_no_tracking_details(hass):
     """With empty tracking_details, data is unchanged."""
     with patch("homeassistant.helpers.frame.report_usage"):


### PR DESCRIPTION
## Proposed change

`<carrier>_delivering` sensors get stuck at the raw IMAP email count whenever **every** package in the days-back window has already been delivered — the exact case the delivered-dedup machinery exists for. Two gaps compound:

1. **Batch dedup used the today-only delivered list.** `_deduplicate_batch_tracking` builds its delivered set from the `_delivered` sensor's `ATTR_TRACKING`, which `process()` deliberately overwrites with today-only results so the sensor resets at midnight. Packages delivered on any *previous* day inside the window were therefore never subtracted from `_delivering`. It now uses `pre_filtered_tracking` (the extended-window list captured before the today-only overwrite) when present.

2. **The coordinator's count override skipped the empty-map case.** `_apply_tracking_state` only overrode `<prefix>_delivering` when the in-transit map was non-empty. When delivered notifications removed every tracking number, the override was skipped, the un-deduped batch count leaked through as the sensor value, and the `<prefix>_tracking` attribute vanished. The override now also fires for carriers that reported **delivering/exception** tracking details this scan (defense in depth at the state-machine layer). Delivered-only details deliberately do **not** trigger it: a carrier whose delivering emails yield no extractable tracking numbers has a legitimate email-based count that tracking-level dedup cannot verify, and zeroing it would be a regression.

Real-world repro (how this was found): 12 FedEx packages delivered over a week stayed "out for delivery" on the dashboard; once their delivered emails were all present in the scanned folder, the count *snapped back to the raw 12* because the emptied in-transit map skipped the override. With this change the first scan reports 0.

The all-delivered transition is logged at debug so the raw→0 override is visible in diagnostics.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Tests: 4 new regression tests — all-delivered zeroes the count (fails on `dev`), extended-window dedup subtracts prior-day deliveries at batch level (fails on `dev`), delivered-only tracking details preserve an email-based count, and carriers with no tracking details keep their email counts. Full suite passes (564), ruff/mypy/pre-commit clean.
