### PR TITLE
fix(camera): never write or serve 0-byte delivery images

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -182,7 +182,13 @@ class MailCam(CoordinatorEntity, Camera):
 
         def _read_file(path: str) -> bytes:
             with Path(path).open("rb") as f:
-                return f.read()
+                data = f.read()
+            if not data:
+                # A 0-byte image (e.g. a failed extraction that wrote an empty
+                # file) is as unservable as a missing one — raise so it routes
+                # through the same placeholder fallback below.
+                raise FileNotFoundError(f"empty image file: {path}")
+            return data
 
         try:
             image_bytes = await self.hass.async_add_executor_job(

--- a/custom_components/mail_and_packages/utils/shipper.py
+++ b/custom_components/mail_and_packages/utils/shipper.py
@@ -114,8 +114,21 @@ def _find_tracking_in_body(
     return None
 
 
-def save_image_data_to_disk(shipper_name: str, path: str, image_data: bytes) -> bool:
+def save_image_data_to_disk(
+    shipper_name: str, path: str, image_data: bytes | None
+) -> bool:
     """Write image bytes to disk and verify."""
+    if not image_data:
+        # Extraction can hand us zero bytes (e.g. a bare/empty base64 data URI
+        # in the email HTML). Writing that produces a 0-byte "photo" the
+        # camera then serves as a broken image — report failure instead so
+        # the caller falls through to the next extraction pass.
+        _LOGGER.debug(
+            "%s - No image data extracted; not writing %s",
+            shipper_name,
+            path,
+        )
+        return False
     try:
         # Ensure directory exists
         directory = Path(path).parent
@@ -240,8 +253,11 @@ def _extract_from_html(
             else str(payload)
         )
 
-        # Base64 check
-        if matches := re.findall(base64_pattern, content):
+        # Base64 check. Skip empty matches: a bare "data:image/...;base64,"
+        # URI (seen in real FedEx delivered emails) matches zero characters,
+        # and taking it would discard a real photo later in the same part.
+        matches = [m for m in re.findall(base64_pattern, content) if m]
+        if matches:
             try:
                 base64_data = matches[0].replace(" ", "").replace("=3D", "=")
                 return save_image_data_to_disk(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,7 +1,7 @@
 """Tests for camera component."""
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+from unittest.mock import AsyncMock, MagicMock, call, mock_open, patch
 
 import pytest
 from homeassistant.const import ATTR_ENTITY_ID
@@ -351,6 +351,63 @@ async def test_async_camera_image_falls_back_to_placeholder(
     # Cache should now key off the placeholder path for cheap repeat reads.
     assert cam._cached_image_path == placeholder_path
     assert cam._cached_image_bytes == b"placeholder-bytes"
+
+
+async def test_async_camera_image_empty_file_falls_back_to_placeholder(
+    hass,
+    mock_imap_no_email,
+    integration,
+    mock_osremove,
+    mock_osmakedir,
+    mock_listdir,
+    mock_update_time,
+    mock_copy_overlays,
+    mock_hash_file,
+    mock_getctime_today,
+    mock_update,
+    caplog,
+):
+    """Test async_camera_image treats a 0-byte image file like a missing one.
+
+    Regression test: a failed extraction can leave a 0-byte file on disk
+    (empty base64 data URI). Serving it renders a broken image in the
+    frontend — it must fall back to the bundled placeholder instead.
+    """
+    entry = integration
+
+    cameras = entry.runtime_data.cameras
+    cam = cameras[0]
+    cam._file_path = "/exists/but/empty_delivery.jpg"
+    placeholder_path = cam._default_image_path
+
+    # First open() (primary path) reads 0 bytes; second open() (placeholder)
+    # returns real bytes.
+    empty_handle = MagicMock()
+    empty_handle.__enter__.return_value = MagicMock(read=MagicMock(return_value=b""))
+    empty_handle.__exit__ = MagicMock(return_value=False)
+    placeholder_handle = MagicMock()
+    placeholder_handle.__enter__.return_value = MagicMock(
+        read=MagicMock(return_value=b"placeholder-bytes")
+    )
+    placeholder_handle.__exit__ = MagicMock(return_value=False)
+
+    with patch("custom_components.mail_and_packages.camera.Path") as mock_path_class:
+        mock_path_class.return_value.open.side_effect = [
+            empty_handle,
+            placeholder_handle,
+        ]
+        result = await cam.async_camera_image()
+
+    assert result == b"placeholder-bytes"
+    assert cam._cached_image_path == placeholder_path
+    assert cam._cached_image_bytes == b"placeholder-bytes"
+    # The empty PRIMARY file must be read first, then the placeholder —
+    # an implementation that wrongly re-read the primary for the fallback
+    # would dispense the right handles in the wrong order.
+    assert mock_path_class.call_args_list == [
+        call(cam._file_path),
+        call(placeholder_path),
+    ]
 
 
 async def test_async_camera_image_placeholder_is_primary_missing(

--- a/tests/utils/test_shipper.py
+++ b/tests/utils/test_shipper.py
@@ -112,6 +112,53 @@ def test_save_image_data_to_disk_errors(caplog):
         assert "Error saving test delivery photo" in caplog.text
 
 
+def test_save_image_data_to_disk_rejects_empty_data(caplog):
+    """Empty image data must not be written to disk.
+
+    Regression test: a bare `data:image/jpeg;base64,` URI in email HTML
+    decodes to b"" — writing it produced a 0-byte "delivery photo" that the
+    camera then served as a broken image (HTTP 500 pre-placeholder-fallback).
+    """
+    caplog.set_level("DEBUG")
+    with patch("custom_components.mail_and_packages.utils.shipper.Path") as mock_path:
+        assert save_image_data_to_disk("fedex", "/p/fedex/photo.jpg", b"") is False
+        assert save_image_data_to_disk("fedex", "/p/fedex/photo.jpg", None) is False
+        mock_path.return_value.open.assert_not_called()
+        assert "No image data extracted" in caplog.text
+
+
+def test_extract_from_html_skips_empty_base64_before_real_image():
+    """An empty base64 data URI must not shadow a real photo after it.
+
+    Regression test: matches[0] was taken blindly, so an email whose HTML
+    contains a bare `data:image/jpeg;base64,` spacer BEFORE the actual
+    delivery photo discarded the real image (save of b"" failed and the
+    whole HTML pass returned False).
+    """
+    real_jpeg_b64 = "aGVsbG8="  # b"hello" — content is irrelevant, size isn't
+    html = (
+        '<img src="data:image/jpeg;base64," />'
+        f'<img src="data:image/jpeg;base64,{real_jpeg_b64}" />'
+    )
+    sdata = f"Content-Type: text/html\n\n{html}".encode()
+
+    with patch(
+        "custom_components.mail_and_packages.utils.shipper.save_image_data_to_disk",
+        return_value=True,
+    ) as mock_save:
+        result = generic_delivery_image_extraction(
+            sdata,
+            "/p/",
+            "photo.jpg",
+            "fedex",
+            "jpeg",
+        )
+
+    assert result is True
+    mock_save.assert_called_once()
+    assert mock_save.call_args[0][2] == b"hello"
+
+
 @pytest.mark.asyncio
 async def test_generic_image_extraction_errors(caplog):
     """Test generic_delivery_image_extraction error paths."""
@@ -355,8 +402,9 @@ async def test_get_tracking_non_bytes():
 async def test_extract_from_html_decode_error(caplog):
     """Test _extract_from_html error handling (Line 225-229)."""
     caplog.set_level("ERROR")
-    sdata = b'Content-Type: text/html\n\n<html><body><img src="data:image/jpeg;base64,bad-base64!"></body></html>'
-    # base64.b64decode will raise error for "bad-base64!" if padding is wrong or invalid chars
+    # Well-formed base64 charset so the (non-empty) match reaches b64decode,
+    # which is mocked to raise — exercising the error-handling branch.
+    sdata = b'Content-Type: text/html\n\n<html><body><img src="data:image/jpeg;base64,YWJjZA=="></body></html>'
     with patch("base64.b64decode", side_effect=TypeError("Mocked error")):
         result = generic_delivery_image_extraction(sdata, "/p/", "i.jpg", "t", "jpeg")
         assert result is False


### PR DESCRIPTION
## Proposed change

FedEx delivered notifications (and potentially other carriers' lazy-loaded HTML) can contain a **bare/empty base64 data URI** (`data:image/jpeg;base64,` with no payload). The extraction regex's capture group happily matches zero characters, `b64decode("")` returns `b""`, and a 0-byte "delivery photo" is written to disk. HA core's camera proxy treats empty bytes like a missing image and serves **HTTP 500**, so the camera entity renders as a broken image on dashboards.

Three layers, outermost first:

- **`_extract_from_html`** skips empty base64 matches, so a spacer data URI earlier in the HTML can no longer shadow a real photo later in the same part (previously `matches[0]` was taken blindly and the whole HTML pass returned `False`).
- **`save_image_data_to_disk`** rejects empty/`None` payloads and reports failure, so extraction falls through to the next pass instead of "succeeding" with nothing. This also fixes a latent `TypeError` when a CID part's `get_payload(decode=True)` returns `None` (`write(None)` was not caught by the `except OSError`).
- **The camera's `_read_file`** treats a 0-byte file like a missing one, routing through the existing bundled-placeholder fallback (#1268) — covering files already on disk from before this fix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follows up #1268 (placeholder fallback for missing images)

Tests: empty-payload rejection (fails on `dev`), 0-byte-file placeholder fallback with read-order assertions (fails on `dev`), and empty-match-before-real-photo recovery. The pre-existing decode-error test was updated to use a well-formed base64 payload so it still exercises the `b64decode` error branch now that empty matches are filtered. Full suite passes (563), ruff/mypy/pre-commit clean.
