### PR TITLE
fix(imap): percent-encode folder names in multi-folder composite IDs

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -5,6 +5,7 @@ import binascii
 import logging
 import re
 import unicodedata
+from urllib.parse import quote, unquote
 
 import aioimaplib
 from aioimaplib import (
@@ -113,6 +114,30 @@ def quote_folder(folder: str) -> str:
     if folder.startswith('"') and folder.endswith('"'):
         return folder
     return folder if _is_imap_atom(folder) else f'"{folder}"'
+
+
+def encode_folder_ref(folder: str) -> str:
+    """Percent-encode a folder name for use in a composite ``folder/uid`` ID.
+
+    Multi-folder searches tag each UID with its source folder as
+    ``folder/uid``. Those composite IDs are space-joined and re-split on
+    whitespace at several call sites, and split on ``/`` to recover the
+    folder — so the folder component must contain neither whitespace nor
+    ``/``. A folder named ``# - Projects`` would otherwise shatter into
+    ``#``, ``-``, ``Projects/55`` when the joined ID list is ``.split()``.
+    ``quote(..., safe="")`` escapes both (and ``%`` itself, keeping the
+    round-trip lossless for any folder name).
+    """
+    return quote(folder, safe="")
+
+
+def decode_folder_ref(folder: str) -> str:
+    """Decode the percent-encoded folder component of a composite ID.
+
+    Takes the already-split folder component (everything before the final
+    ``/`` of a ``folder/uid`` ID), not the full composite ID.
+    """
+    return unquote(folder)
 
 
 class InvalidAuth(HomeAssistantError):
@@ -382,7 +407,7 @@ def _parse_esearch_line(line_bytes: bytes) -> list[bytes]:
                 pass
         else:
             uids.append(part)
-    return [f"{mailbox}/{uid}".encode() for uid in uids]
+    return [f"{encode_folder_ref(mailbox)}/{uid}".encode() for uid in uids]
 
 
 async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[bytes]:  # noqa: C901
@@ -446,7 +471,8 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
                 if res.result == "OK" and res.lines:
                     parsed = parse_search_response(res.lines)
                     all_uids.extend(
-                        f"{folder}/{uid.decode()}".encode() for uid in parsed
+                        f"{encode_folder_ref(folder)}/{uid.decode()}".encode()
+                        for uid in parsed
                     )
             except TimeoutError:
                 raise
@@ -570,7 +596,7 @@ async def email_fetch(account: IMAP4_SSL, num, parts: str = "(RFC822)") -> tuple
     num_str = num.decode() if isinstance(num, bytes) else str(num)
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
-        await selectfolder(account, folder)
+        await selectfolder(account, decode_folder_ref(folder))
         try:
             res = await account.uid("FETCH", num_str, parts)
         except TimeoutError:
@@ -597,7 +623,7 @@ async def email_fetch_headers(account: IMAP4_SSL, num) -> tuple:
     num_str = num.decode() if isinstance(num, bytes) else str(num)
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
-        await selectfolder(account, folder)
+        await selectfolder(account, decode_folder_ref(folder))
         try:
             res = await account.uid("FETCH", num_str, "(BODY[HEADER.FIELDS (SUBJECT)])")
         except TimeoutError:
@@ -627,7 +653,7 @@ async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") ->
     num_str = num.decode() if isinstance(num, bytes) else str(num)
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
-        await selectfolder(account, folder)
+        await selectfolder(account, decode_folder_ref(folder))
         try:
             res = await account.uid("FETCH", num_str, parts)
         except TimeoutError:
@@ -688,6 +714,7 @@ async def email_fetch_batch(  # noqa: C901
         num_str = num.decode() if isinstance(num, bytes) else str(num)
         if "/" in num_str:
             folder, actual_num = num_str.rsplit("/", 1)
+            folder = decode_folder_ref(folder)
         else:
             folder, actual_num = None, num_str
         folder_to_nums.setdefault(folder, []).append(actual_num)

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -18,12 +18,14 @@ from custom_components.mail_and_packages.utils.imap import (
     _parse_esearch_line,
     build_search,
     clean_search_string,
+    decode_folder_ref,
     decode_imap_utf7,
     email_fetch,
     email_fetch_batch,
     email_fetch_headers,
     email_fetch_text,
     email_search,
+    encode_folder_ref,
     encode_imap_utf7,
     login,
     logout,
@@ -1122,6 +1124,164 @@ async def test_email_fetch_folder_prefix():
     # Verify selectfolder was called for Junk and uid fetch executed
     mock_account.select.assert_called_once_with("Junk")
     mock_account.uid.assert_called_once_with("FETCH", "2001", "(RFC822)")
+
+
+def test_folder_ref_roundtrip():
+    """encode_folder_ref/decode_folder_ref round-trip any folder name.
+
+    The encoded form must contain no whitespace and no '/', because
+    composite folder/uid IDs are space-joined then .split() at several
+    call sites and rsplit('/', 1) to recover the folder.
+    """
+    for folder in [
+        "INBOX",
+        "# - Projects",
+        "0 - Pending Orders",
+        "# - For Family",
+        "50% discount codes",
+        "a/b nested",
+        "tab\tname",
+        "Boîte aux lettres",
+    ]:
+        encoded = encode_folder_ref(folder)
+        assert " " not in encoded
+        assert "/" not in encoded
+        assert "\t" not in encoded
+        assert decode_folder_ref(encoded) == folder
+
+
+@pytest.mark.asyncio
+async def test_email_search_sequential_fallback_spaced_folder():
+    """Folder names with spaces survive the space-join/.split() round-trip.
+
+    Regression test: multi-folder composite IDs are returned space-joined
+    (mimicking a raw IMAP SEARCH response) and later .split() by consumers —
+    an unencoded 'folder with spaces/uid' shatters into garbage IDs.
+    """
+    mock_account = AsyncMock()
+    mock_account._folders = ["INBOX", "# - Projects"]
+    mock_account.has_capability.return_value = False
+
+    mock_res1 = MagicMock(result="OK", lines=[b"1001 1002"])
+    mock_res2 = MagicMock(result="OK", lines=[b"55"])
+    mock_account.uid_search.side_effect = [mock_res1, mock_res2]
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+
+    result = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject="Test"
+    )
+
+    assert result[0] == "OK"
+    # The joined blob must re-split into exactly one ID per matched email.
+    ids = result[1][0].split()
+    assert ids == [b"INBOX/1001", b"INBOX/1002", b"%23%20-%20Projects/55"]
+    # And each ID's folder component must decode back to the real name.
+    folder, uid = ids[2].decode().rsplit("/", 1)
+    assert decode_folder_ref(folder) == "# - Projects"
+    assert uid == "55"
+
+
+@pytest.mark.asyncio
+async def test_email_search_multisearch_spaced_folder():
+    """ESEARCH responses with spaced mailbox names produce encoded IDs."""
+    mock_account = AsyncMock()
+    mock_account._folders = ["INBOX", "0 - Pending Orders"]
+    mock_account.has_capability = MagicMock(return_value=True)
+
+    mock_res = MagicMock()
+    mock_res.result = "OK"
+    mock_res.lines = [
+        b'* ESEARCH (TAG "1" MAILBOX "0 - Pending Orders" UIDVALIDITY 123) UID ALL 2001',
+    ]
+    mock_protocol = AsyncMock()
+    mock_protocol.execute.return_value = mock_res
+    mock_protocol.new_tag.return_value = "1"
+    mock_protocol.loop = asyncio.get_running_loop()
+    mock_account.protocol = mock_protocol
+
+    result = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject="Test"
+    )
+
+    assert result[0] == "OK"
+    assert result[1][0].split() == [b"0%20-%20Pending%20Orders/2001"]
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_spaced_folder_selects_decoded_name():
+    """email_fetch on an encoded composite ID selects the REAL folder name."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"RFC822", b"body"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch(mock_account, b"%23%20-%20Projects/55")
+
+    assert result[0] == "OK"
+    # selectfolder must receive the decoded name (then IMAP-quote it since
+    # it contains spaces).
+    mock_account.select.assert_called_once_with('"# - Projects"')
+    mock_account.uid.assert_called_once_with("FETCH", "55", "(RFC822)")
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_batch_spaced_folder_groups_decoded():
+    """email_fetch_batch groups encoded IDs by their decoded folder."""
+    mock_account = AsyncMock()
+    mock_account.host = "imap.gmail.com"
+    mock_account._current_folder = None
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"RFC822", b"body"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch_batch(
+        mock_account, [b"%23%20-%20Projects/55", b"%23%20-%20Projects/56"]
+    )
+
+    assert result[0] == "OK"
+    mock_account.select.assert_called_once_with('"# - Projects"')
+    mock_account.uid.assert_called_once_with("FETCH", "55,56", "(RFC822)")
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_headers_spaced_folder_selects_decoded_name():
+    """email_fetch_headers on an encoded composite ID selects the REAL folder."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"Subject: hi", b")"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch_headers(mock_account, b"%23%20-%20Projects/55")
+
+    assert result[0] == "OK"
+    mock_account.select.assert_called_once_with('"# - Projects"')
+    mock_account.uid.assert_called_once_with(
+        "FETCH", "55", "(BODY[HEADER.FIELDS (SUBJECT)])"
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_text_spaced_folder_selects_decoded_name():
+    """email_fetch_text on an encoded composite ID selects the REAL folder."""
+    mock_account = AsyncMock()
+    mock_account.host = "imap.gmail.com"
+    mock_account._current_folder = "INBOX"
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"body text", b")"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch_text(mock_account, b"%23%20-%20Projects/55")
+
+    assert result[0] == "OK"
+    mock_account.select.assert_called_once_with('"# - Projects"')
+    mock_account.uid.assert_called_once_with("FETCH", "55", "(BODY[1])")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

Multi-folder searches tag each UID with its source folder as a composite `folder/uid` ID. Those composite IDs are space-joined (mimicking a raw IMAP SEARCH response) and re-split on whitespace by every consumer — so a folder name containing spaces, which is entirely legal in IMAP, **shatters into garbage IDs**: `My Folder/55` becomes `My`, `Folder/55`. Subject verification then drops the fragments, tracking extraction misses those emails, and delivered-dedup silently degrades for anything filed outside single-token folders.

This percent-encodes the folder component (`urllib.parse.quote(..., safe="")`) at both producers (`_parse_esearch_line` for the ESEARCH path, and the sequential per-folder fallback in `_execute_single_search`) and decodes it at all four consumers (`email_fetch`, `email_fetch_headers`, `email_fetch_text`, `email_fetch_batch`). The encoded form contains no whitespace and no `/`, so both the `.split()` and the `rsplit("/", 1)` round-trips are lossless for any folder name — including names containing literal `%` sequences, `/`, tabs, or non-ASCII (UTF-7 wire names are decoded to real Unicode *before* encoding, and `selectfolder` re-encodes at select time, unchanged).

Kept as an internal ID-format change rather than restructuring the space-joined format itself: that format is consumed at ~14 call sites across the shippers and would balloon the diff.

Note: debug logs of matched email IDs now show the percent-encoded folder form.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Tests: encode/decode round-trip property test (spaces, `%`, `/`, tabs, non-ASCII), spaced-folder end-to-end tests for both search paths (ESEARCH and sequential fallback) proving the joined blob re-splits into exactly one ID per email (fail on `dev`), and decoded-folder-selection tests for all four fetch consumers. Full suite passes (567), ruff/mypy/pre-commit clean.
