### PR TITLE
fix(generic): run delivery-image extraction off the event loop

### DIFF
--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -662,7 +662,11 @@ class GenericShipper(Shipper):
                 msg_parts = (await email_fetch(account, eid, "(RFC822)"))[1]
             for response_part in msg_parts:
                 if isinstance(response_part, (bytes, bytearray)):
-                    if generic_delivery_image_extraction(
+                    # The extraction does blocking file I/O (the image
+                    # write) and CPU-heavy email parsing — run the whole
+                    # sync function off the event loop.
+                    if await self.hass.async_add_executor_job(
+                        generic_delivery_image_extraction,
                         response_part,
                         s_config["image_path"],
                         s_config["image_name"],

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1,5 +1,6 @@
 """Tests for generic shipper utilities."""
 
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -76,6 +77,59 @@ async def test_fedex_delivered_class(hass, mock_imap_fedex_delivered_with_photo)
         )
         assert result[ATTR_COUNT] == 1
         assert result[ATTR_TRACKING] == ["885814254426"]
+
+
+@pytest.mark.asyncio
+async def test_image_extraction_runs_off_event_loop(
+    hass, mock_imap_fedex_delivered_with_photo
+):
+    """generic_delivery_image_extraction must run in an executor thread.
+
+    Regression test: it parses the full email and writes the image with
+    blocking file I/O; calling it directly from the coordinator path
+    triggers HA's blocking-call-in-event-loop detection. The probe records
+    which thread each extraction call runs on and asserts none of them is
+    the event-loop thread.
+
+    The probe is installed with ``new=`` (a plain function, not a Mock) on
+    purpose: the test harness's ``async_add_executor_job`` wrapper runs
+    Mock targets inline on the loop, which would defeat the thread check.
+    """
+    shipper = GenericShipper(
+        hass,
+        {
+            "image_path": "test/path/fedex/",
+            "image_name": "testfilename.jpg",
+        },
+    )
+
+    loop_thread = threading.get_ident()
+    extract_threads: list[int] = []
+
+    def _extract_probe(*args):
+        extract_threads.append(threading.get_ident())
+        return True
+
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.generic_delivery_image_extraction",
+            new=_extract_probe,
+        ),
+    ):
+        result = await shipper.process(
+            mock_imap_fedex_delivered_with_photo,
+            "today",
+            "fedex_delivered",
+        )
+
+    assert result[ATTR_COUNT] == 1
+    # The fixture email yields one extraction call per bytes response part.
+    assert len(extract_threads) >= 1
+    assert all(tid != loop_thread for tid in extract_threads), (
+        "generic_delivery_image_extraction ran on the event-loop thread "
+        "instead of an executor thread"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

`generic_delivery_image_extraction` parses the full email body and writes the extracted delivery photo with blocking file I/O (`Path.open("wb")`), but is called directly from the async coordinator path. Home Assistant's blocking-call detection flags it on every image extraction:

```
Detected blocking call to open with args (PosixPath('custom_components/mail_and_packages/images/fedex/….jpg'), 'wb')
inside the event loop by custom integration 'mail_and_packages' at
custom_components/mail_and_packages/utils/shipper.py: with Path(path).open("wb") as the_file
```

This dispatches the whole sync extraction through `hass.async_add_executor_job`, matching how the surrounding code already offloads directory creation, placeholder copies, `copy_images`, and the camera's file reads. Exception semantics are unchanged (`OSError` is handled inside the sync function; anything else propagates through the awaited executor future to the same handler in `_update_shippers` as before).

One theoretical note: with the write off the loop, two config entries sharing the default image path *and* default image name could overlap writes to the same file from two executor threads (last-writer-wins becomes a torn-write window). This needs 2+ IMAP accounts with the same carrier delivering during overlapping refreshes; flagging for completeness — a temp-file + `os.replace` write would close it if desired.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Tests: a thread-identity regression test records which thread each extraction call runs on and asserts none is the event-loop thread (fails on current `dev`, passes with the fix). The probe is installed with `patch(..., new=<plain function>)` deliberately — the test harness's `async_add_executor_job` wrapper runs Mock targets inline on the loop, which would defeat the check. Full suite passes (561), ruff/mypy/pre-commit clean.
