### PR TITLE
chore(deps): floor test requirements so uv and pip resolve the same stack

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,14 @@ pytest
 pytest-aiohttp
 pytest-asyncio
 pytest-cov
-pytest-homeassistant-custom-component
+# Floor pytest-homeassistant-custom-component so the test stack resolves
+# deterministically across pip and uv. Without a floor, a highest-version
+# resolver (e.g. `uv pip install -r requirements_test.txt`) backtracks the
+# whole set to a 2016-era stack (homeassistant 0.31, pytest 6) that will not
+# import on modern Python; this pin drags a matching modern homeassistant +
+# pytest ecosystem (and the `homeassistant` line below) via phcc's exact
+# dependency pins, matching CI.
+pytest-homeassistant-custom-component>=0.13.300
 homeassistant
 freezegun
 cython


### PR DESCRIPTION
## Proposed change

`requirements_test.txt` leaves `homeassistant`, `pytest`, and `pytest-homeassistant-custom-component` unpinned. That is a resolver-dependent footgun:

- **A highest-version resolver** — e.g. a contributor running the documented `uv pip install -r requirements_test.txt` — backtracks the whole set to a **2016-era stack**: `homeassistant==0.31.1`, `pytest==6.2.2`, `pytest-homeassistant-custom-component==0.2.1`. That stack can't even import on the project's Python 3.14 / modern-HA target, so the documented setup produces a broken test environment.
- **CI dodges this only by luck of resolver**: tox installs the same unpinned file with pip, which lands a modern stack, so CI is green while a uv user is dead in the water on the identical file.

Fix: floor `pytest-homeassistant-custom-component`. phcc exact-pins a coherent `homeassistant` + pytest ecosystem as its own dependencies, so flooring it alone drags every resolver onto the same modern, CI-validated stack — `homeassistant` and the `pytest-*` plugins listed in the file are transitively constrained by it (the `homeassistant` line is kept, now determined by phcc's pin). No other line needed changing.

Verified by reproduction:
- Before (dev, unpinned) under `uv ... --python-version 3.14`: HA 0.31.1 / pytest 6.2.2 / phcc 0.2.1.
- After (this branch): a fresh `uv pip install -r requirements_test.txt` on Python 3.14 resolves to HA 2026.1.x / pytest 9.0.0 / phcc 0.13.30x and runs the full suite green (**561 passed**, coverage 99.89%).
- pip / CI resolution is unchanged (pip already lands the modern stack; the floor is ≤ what it picks), so this is a no-op for CI and a fix for every other resolver.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Scope is intentionally minimal — one floored line plus an explanatory comment. The `pycares>=4.11.0,<5.0.0` pin already present in the file is what caps the upper end of the resolution, so the floor and that ceiling together pin the stack to a narrow modern range without needing exact `==` pins.
