### PR TITLE
fix(setup): forward setups first to prevent startup 404s and add repairs on auth failure

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_RESOURCES
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 
 from . import const
 from .const import (
@@ -133,21 +134,32 @@ async def async_setup_entry(
     # Setup the data coordinator
     coordinator = MailDataUpdateCoordinator(hass, config, config_entry)
 
+    config_entry.runtime_data = MailAndPackagesData(coordinator=coordinator, cameras=[])
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
 
     # Raise ConfigEntryNotReady if coordinator didn't update
     if not coordinator.last_update_success:
         if isinstance(coordinator.last_exception, ConfigEntryAuthFailed):
+            # Create a repairs issue for authentication failure
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "auth_failed",
+                is_fixable=True,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="auth_failed",
+                data={"entry_id": config_entry.entry_id},
+            )
             raise coordinator.last_exception
         exc = coordinator.last_exception
         detail = (str(exc) or type(exc).__name__) if exc else "unknown error"
         _LOGGER.error("Error updating sensor data: %s", detail)
         raise ConfigEntryNotReady
 
-    config_entry.runtime_data = MailAndPackagesData(coordinator=coordinator, cameras=[])
-
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 

--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -7,8 +7,15 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_RESOURCES
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import (
+    config_validation as cv,
+)
+from homeassistant.helpers import (
+    device_registry as dr,
+)
+from homeassistant.helpers import (
+    issue_registry as ir,
+)
 
 from . import const
 from .const import (
@@ -102,6 +109,9 @@ __all__ = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config_entry: MailAndPackagesConfigEntry):  # pylint: disable=unused-argument

--- a/custom_components/mail_and_packages/binary_sensor.py
+++ b/custom_components/mail_and_packages/binary_sensor.py
@@ -78,6 +78,8 @@ class PackagesBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the image is updated."""
+        if self.coordinator.data is None:
+            return False
         if self._type in self.coordinator.data:
             _LOGGER.debug(
                 "binary_sensor: %s value: %s",

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -267,18 +267,18 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Error logging into IMAP: %s", err)
             raise UpdateFailed(f"Login failed: {err}") from err
         # Login succeeded, delete the issue if it exists
-        ir.async_delete_issue(self.hass, DOMAIN, "auth_failed")
+        issue_registry = ir.async_get(self.hass)
+        if (DOMAIN, "auth_failed") in issue_registry.issues:
+            ir.async_delete_issue(self.hass, DOMAIN, "auth_failed")
 
         folders = config.get(CONF_FOLDER)
-        if not folders:
-            folders = ["INBOX"]
-        elif isinstance(folders, str):
+        if isinstance(folders, str):
             folders = [folders]
         elif isinstance(folders, (list, tuple, set)):
             folders = [f for f in folders if isinstance(f, str) and f]
-            if not folders:
-                folders = ["INBOX"]
         else:
+            folders = []
+        if not folders:
             folders = ["INBOX"]
         account._folders = folders  # noqa: SLF001
         account._current_folder = None  # noqa: SLF001

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import (
     ConfigEntryAuthFailed,
     DataUpdateCoordinator,
@@ -149,6 +150,8 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 if data:
                     self._data = data
                     await self._binary_sensor_update()
+                    # Delete the auth_failed repairs issue if it exists
+                    ir.async_delete_issue(self.hass, DOMAIN, "auth_failed")
                 return self._data
         except TimeoutError:
             _LOGGER.error(
@@ -249,6 +252,18 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             )
         except InvalidAuth as err:
             _LOGGER.error("Authentication failed: %s", err)
+            # Create a repairs issue for authentication failure
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                "auth_failed",
+                is_fixable=True,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="auth_failed",
+                data={"entry_id": self.config_entry.entry_id}
+                if self.config_entry
+                else None,
+            )
             raise ConfigEntryAuthFailed from err
         except Exception as err:
             _LOGGER.error("Error logging into IMAP: %s", err)

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -150,8 +150,6 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 if data:
                     self._data = data
                     await self._binary_sensor_update()
-                    # Delete the auth_failed repairs issue if it exists
-                    ir.async_delete_issue(self.hass, DOMAIN, "auth_failed")
                 return self._data
         except TimeoutError:
             _LOGGER.error(
@@ -268,6 +266,8 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.error("Error logging into IMAP: %s", err)
             raise UpdateFailed(f"Login failed: {err}") from err
+        # Login succeeded, delete the issue if it exists
+        ir.async_delete_issue(self.hass, DOMAIN, "auth_failed")
 
         folders = config.get(CONF_FOLDER)
         if not folders:

--- a/custom_components/mail_and_packages/repairs.py
+++ b/custom_components/mail_and_packages/repairs.py
@@ -1,0 +1,58 @@
+"""Repairs platform for Mail and Packages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class AuthRepairFlow(RepairsFlow):
+    """Handler for repairs flow."""
+
+    def __init__(self, entry_id: str | None) -> None:
+        """Initialize."""
+        self.entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a repair flow."""
+        return await self.async_step_confirm(user_input)
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle confirm step."""
+        if user_input is not None:
+            if self.entry_id:
+                entry = self.hass.config_entries.async_get_entry(self.entry_id)
+            else:
+                entries = self.hass.config_entries.async_entries(DOMAIN)
+                entry = entries[0] if entries else None
+
+            if entry:
+                entry.async_start_reauth(self.hass)
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Create a flow to fix a specific issue."""
+    if issue_id == "auth_failed":
+        entry_id = data.get("entry_id") if data else None
+        return AuthRepairFlow(entry_id)
+    raise ValueError(f"Unknown issue {issue_id}")

--- a/custom_components/mail_and_packages/repairs.py
+++ b/custom_components/mail_and_packages/repairs.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-from homeassistant import data_entry_flow
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
@@ -21,13 +21,13 @@ class AuthRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> FlowResult:
         """Handle the first step of a repair flow."""
         return await self.async_step_confirm(user_input)
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> FlowResult:
         """Handle confirm step."""
         if user_input is not None:
             if self.entry_id:

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -118,6 +118,8 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
+        if self.coordinator.data is None:
+            return None
         value = self.coordinator.data.get(self.type)
 
         if self.type == "mail_updated":
@@ -146,6 +148,8 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         """Return device specific state attributes."""
         attr = {}
         data = self.coordinator.data
+        if data is None:
+            return attr
 
         if any(
             sensor in self.type
@@ -153,10 +157,6 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         ):
             if tracking := data.get(self._tracking_key):
                 attr[ATTR_TRACKING_NUM] = tracking
-
-        # Catch no data entries
-        if self.data is None:
-            return attr
 
         if "Amazon" in self._name:
             self._add_amazon_attributes(attr, data)
@@ -225,6 +225,9 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
+        if self.coordinator.data is None:
+            return None
+
         image = ""
         the_path = None
 

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -195,5 +195,19 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "description": "Authentication to your IMAP mail server has failed. Please re-authenticate to continue receiving updates.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Click submit to start the re-authentication flow for your mail server."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -199,12 +199,11 @@
   "issues": {
     "auth_failed": {
       "title": "Mail and Packages authentication failed",
-      "description": "Authentication to your IMAP mail server has failed. Please re-authenticate to continue receiving updates.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Re-authenticate Mail Server",
-            "description": "Click submit to start the re-authentication flow for your mail server."
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/ca.json
+++ b/custom_components/mail_and_packages/translations/ca.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/ca.json
+++ b/custom_components/mail_and_packages/translations/ca.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "L'autenticació de Mail and Packages ha fallat",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Tornar a autenticar el servidor de correu",
+            "description": "L'autenticació amb el vostre servidor de correu IMAP ha fallat. Feu clic a envia per iniciar el flux de reautenticació."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/cs.json
+++ b/custom_components/mail_and_packages/translations/cs.json
@@ -268,12 +268,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Ověření Mail and Packages selhalo",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Znovu ověřit poštovní server",
+            "description": "Ověření k vašemu poštovnímu serveru IMAP selhalo. Kliknutím na odeslat spustíte proces opětovného ověření."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/cs.json
+++ b/custom_components/mail_and_packages/translations/cs.json
@@ -265,5 +265,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/de.json
+++ b/custom_components/mail_and_packages/translations/de.json
@@ -203,5 +203,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/de.json
+++ b/custom_components/mail_and_packages/translations/de.json
@@ -206,12 +206,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages Authentifizierung fehlgeschlagen",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Mailserver neu authentifizieren",
+            "description": "Die Authentifizierung bei Ihrem IMAP-Mailserver ist fehlgeschlagen. Klicken Sie auf Senden, um den Reauthentifizierungs-Flow zu starten."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -209,5 +209,19 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "description": "Authentication to your IMAP mail server has failed. Please re-authenticate to continue receiving updates.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Click submit to start the re-authentication flow for your mail server."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -213,12 +213,11 @@
   "issues": {
     "auth_failed": {
       "title": "Mail and Packages authentication failed",
-      "description": "Authentication to your IMAP mail server has failed. Please re-authenticate to continue receiving updates.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Re-authenticate Mail Server",
-            "description": "Click submit to start the re-authentication flow for your mail server."
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/es.json
+++ b/custom_components/mail_and_packages/translations/es.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Error de autenticación de Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Volver a autenticar el servidor de correo",
+            "description": "Error al autenticar en su servidor de correo IMAP. Haga clic en enviar para iniciar el flujo de reautenticación."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/es.json
+++ b/custom_components/mail_and_packages/translations/es.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/es_419.json
+++ b/custom_components/mail_and_packages/translations/es_419.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Error de autenticación de Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Volver a autenticar el servidor de correo",
+            "description": "Error al autenticar en su servidor de correo IMAP. Haga clic en enviar para iniciar el flujo de reautenticación."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/es_419.json
+++ b/custom_components/mail_and_packages/translations/es_419.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/fi.json
+++ b/custom_components/mail_and_packages/translations/fi.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages -autentikointi epäonnistui",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Tunnistaudu uudelleen sähköpostipalvelimeen",
+            "description": "Autentikointi IMAP-sähköpostipalvelimeesi epäonnistui. Napsauta Lähetä aloittaaksesi uudelleentunnistautumisen."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/fi.json
+++ b/custom_components/mail_and_packages/translations/fi.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/fr.json
+++ b/custom_components/mail_and_packages/translations/fr.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Échec de l'authentification de Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Ré-authentifier le serveur de messagerie",
+            "description": "L'authentification sur votre serveur de messagerie IMAP a échoué. Cliquez sur soumettre pour démarrer le flux de ré-authentification."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/fr.json
+++ b/custom_components/mail_and_packages/translations/fr.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/hu.json
+++ b/custom_components/mail_and_packages/translations/hu.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages hitelesítés sikertelen",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Levelezőszerver újrahitelesítése",
+            "description": "Nem sikerült a hitelesítés az IMAP levelezőszerveren. Kattintson a küldésre az újrahitelesítési folyamat elindításához."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/hu.json
+++ b/custom_components/mail_and_packages/translations/hu.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/it.json
+++ b/custom_components/mail_and_packages/translations/it.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Autenticazione Mail and Packages fallita",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Riautentica il server di posta",
+            "description": "L'autenticazione al server di posta IMAP è fallita. Clicca su invia per avviare la procedura di riautenticazione."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/it.json
+++ b/custom_components/mail_and_packages/translations/it.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/ko.json
+++ b/custom_components/mail_and_packages/translations/ko.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/ko.json
+++ b/custom_components/mail_and_packages/translations/ko.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages 인증 실패",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "메일 서버 재인증",
+            "description": "IMAP 메일 서버 인증에 실패했습니다. 제출을 클릭하여 재인증 흐름을 시작하십시오."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/nl.json
+++ b/custom_components/mail_and_packages/translations/nl.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/nl.json
+++ b/custom_components/mail_and_packages/translations/nl.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages authenticatie mislukt",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "E-mailserver opnieuw verifiëren",
+            "description": "Authenticatie bij uw IMAP-mailserver is mislukt. Klik op verzenden om de herauthenticatiestroom te starten."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/no.json
+++ b/custom_components/mail_and_packages/translations/no.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Autentisering for Mail and Packages mislyktes",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Autentiser e-postserver på nytt",
+            "description": "Autentisering mot din IMAP-e-postserver mislyktes. Klikk på send for å starte reautentiseringsflyten."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/no.json
+++ b/custom_components/mail_and_packages/translations/no.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/pl.json
+++ b/custom_components/mail_and_packages/translations/pl.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Błąd uwierzytelniania Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Ponownie uwierzytelnij serwer pocztowy",
+            "description": "Uwierzytelnienie na serwerze pocztowym IMAP nie powiodło się. Kliknij prześlij, aby rozpocząć proces ponownego uwierzytelniania."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/pl.json
+++ b/custom_components/mail_and_packages/translations/pl.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/pt.json
+++ b/custom_components/mail_and_packages/translations/pt.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Falha na autenticação de Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Reautenticar o Servidor de E-mail",
+            "description": "A autenticação no seu servidor de e-mail IMAP falhou. Clique em enviar para iniciar o fluxo de reautenticação."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/pt.json
+++ b/custom_components/mail_and_packages/translations/pt.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/pt_BR.json
+++ b/custom_components/mail_and_packages/translations/pt_BR.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Falha na autenticação de Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Reautenticar o Servidor de E-mail",
+            "description": "A autenticação no seu servidor de e-mail IMAP falhou. Clique em enviar para iniciar o fluxo de reautenticação."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/pt_BR.json
+++ b/custom_components/mail_and_packages/translations/pt_BR.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/ru.json
+++ b/custom_components/mail_and_packages/translations/ru.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Ошибка авторизации Mail and Packages",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Повторная авторизация почтового сервера",
+            "description": "Не удалось авторизоваться на вашем почтовом сервере IMAP. Нажмите «Отправить», чтобы начать процесс повторной авторизации."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/ru.json
+++ b/custom_components/mail_and_packages/translations/ru.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/sk.json
+++ b/custom_components/mail_and_packages/translations/sk.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Overenie Mail and Packages zlyhalo",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Znovu overiť poštový server",
+            "description": "Overenie k vášmu poštovému serveru IMAP zlyhalo. Kliknutím na odoslať spustíte proces opätovného overenia."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/sk.json
+++ b/custom_components/mail_and_packages/translations/sk.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/sl.json
+++ b/custom_components/mail_and_packages/translations/sl.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Preverjanje pristnosti za Mail and Packages ni uspelo",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Ponovno preveri poštni strežnik",
+            "description": "Preverjanje pristnosti z vašim poštnim strežnikom IMAP ni uspelo. Kliknite Pošlji, če želite začeti potek ponovnega preverjanja pristnosti."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/sl.json
+++ b/custom_components/mail_and_packages/translations/sl.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/sv.json
+++ b/custom_components/mail_and_packages/translations/sv.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/mail_and_packages/translations/sv.json
+++ b/custom_components/mail_and_packages/translations/sv.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages-autentisering misslyckades",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "Återautentisera e-postserver",
+            "description": "Autentisering mot din IMAP-e-postserver misslyckades. Klicka på skicka för att starta återautentiseringsflödet."
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/zh_Hant_HK.json
+++ b/custom_components/mail_and_packages/translations/zh_Hant_HK.json
@@ -202,12 +202,12 @@
   },
   "issues": {
     "auth_failed": {
-      "title": "Mail and Packages authentication failed",
+      "title": "Mail and Packages 認證失敗",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Re-authenticate Mail Server",
-            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+            "title": "重新認證郵件伺服器",
+            "description": "認證 IMAP 郵件伺服器失敗。請按提交以啟動重新認證流程。"
           }
         }
       }

--- a/custom_components/mail_and_packages/translations/zh_Hant_HK.json
+++ b/custom_components/mail_and_packages/translations/zh_Hant_HK.json
@@ -199,5 +199,18 @@
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Mail and Packages authentication failed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Mail Server",
+            "description": "Authentication to your IMAP mail server has failed. Click submit to start the re-authentication flow."
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -261,7 +261,9 @@ async def test_migration_from_version_16_to_18():
 async def test_setup_entry_coordinator_failure():
     """Test setup_entry when coordinator fails to update."""
     mock_hass = MagicMock()
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
     mock_config_entry = MagicMock()
+    mock_config_entry.domain = DOMAIN
     mock_config_entry.data = FAKE_CONFIG_DATA.copy()
     mock_config_entry.data["resources"] = ["usps_mail"]  # Override for this test
     mock_config_entry.entry_id = "test_entry_id"
@@ -288,7 +290,9 @@ async def test_setup_entry_coordinator_failure():
 async def test_setup_entry_auth_failure():
     """Test setup_entry when coordinator fails with ConfigEntryAuthFailed."""
     mock_hass = MagicMock()
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
     mock_config_entry = MagicMock()
+    mock_config_entry.domain = DOMAIN
     mock_config_entry.data = FAKE_CONFIG_DATA.copy()
     mock_config_entry.entry_id = "test_entry_id"
 
@@ -565,6 +569,8 @@ async def test_coordinator_binary_sensor_update_amazon_same_hashes():
 async def test_setup_entry_refresh_failure(hass):
     """Test setup_entry when the coordinator fails to refresh data."""
     mock_config_entry = MagicMock()
+    mock_config_entry.domain = DOMAIN
+    mock_config_entry.async_setup = AsyncMock()
     mock_config_entry.data = {
         "host": "imap.test.com",
         "scan_interval": 5,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -262,11 +262,13 @@ async def test_setup_entry_coordinator_failure():
     """Test setup_entry when coordinator fails to update."""
     mock_hass = MagicMock()
     mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
-    mock_config_entry = MagicMock()
-    mock_config_entry.domain = DOMAIN
-    mock_config_entry.data = FAKE_CONFIG_DATA.copy()
-    mock_config_entry.data["resources"] = ["usps_mail"]  # Override for this test
-    mock_config_entry.entry_id = "test_entry_id"
+    data = FAKE_CONFIG_DATA.copy()
+    data["resources"] = ["usps_mail"]  # Override for this test
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=data,
+        entry_id="test_entry_id",
+    )
 
     # Mock coordinator that fails to update
     mock_coordinator = MagicMock()
@@ -291,10 +293,11 @@ async def test_setup_entry_auth_failure():
     """Test setup_entry when coordinator fails with ConfigEntryAuthFailed."""
     mock_hass = MagicMock()
     mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
-    mock_config_entry = MagicMock()
-    mock_config_entry.domain = DOMAIN
-    mock_config_entry.data = FAKE_CONFIG_DATA.copy()
-    mock_config_entry.entry_id = "test_entry_id"
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=FAKE_CONFIG_DATA.copy(),
+        entry_id="test_entry_id",
+    )
 
     # Mock coordinator that fails with ConfigEntryAuthFailed
     mock_coordinator = MagicMock()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -568,18 +568,19 @@ async def test_coordinator_binary_sensor_update_amazon_same_hashes():
             assert coordinator._data["amazon_update"] is False
 
 
-@pytest.mark.asyncio
-async def test_setup_entry_refresh_failure(hass):
+async def test_setup_entry_refresh_failure():
     """Test setup_entry when the coordinator fails to refresh data."""
-    mock_config_entry = MagicMock()
-    mock_config_entry.domain = DOMAIN
-    mock_config_entry.async_setup = AsyncMock()
-    mock_config_entry.data = {
-        "host": "imap.test.com",
-        "scan_interval": 5,
-        "resources": [],
-    }
-    mock_config_entry.entry_id = "test_entry"
+    mock_hass = MagicMock()
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "imap.test.com",
+            "scan_interval": 5,
+            "resources": [],
+        },
+        entry_id="test_entry",
+    )
     with (
         patch("homeassistant.helpers.frame.report_usage"),
         patch(
@@ -591,7 +592,7 @@ async def test_setup_entry_refresh_failure(hass):
         mock_coordinator.last_exception = "IMAP Timeout"
         mock_coordinator.async_refresh = AsyncMock()
         with pytest.raises(ConfigEntryNotReady):
-            await async_setup_entry(hass, mock_config_entry)
+            await async_setup_entry(mock_hass, mock_config_entry)
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -7,12 +7,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
-from custom_components.mail_and_packages.const import DOMAIN
+from custom_components.mail_and_packages.binary_sensor import PackagesBinarySensor
+from custom_components.mail_and_packages.const import (
+    BINARY_SENSORS,
+    DOMAIN,
+    IMAGE_SENSORS,
+    SENSOR_TYPES,
+)
 from custom_components.mail_and_packages.coordinator import MailDataUpdateCoordinator
 from custom_components.mail_and_packages.repairs import (
     AuthRepairFlow,
     async_create_fix_flow,
 )
+from custom_components.mail_and_packages.sensor import ImagePathSensors, PackagesSensor
 from custom_components.mail_and_packages.utils.imap import InvalidAuth
 
 
@@ -96,3 +103,29 @@ async def test_auth_failure_creates_repairs_issue(hass: HomeAssistant):
         await coordinator._async_update_data()
 
     assert (DOMAIN, "auth_failed") not in issue_registry.issues
+
+
+async def test_sensors_unpopulated_coordinator(hass: HomeAssistant):
+    """Test sensors when coordinator data is None."""
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = None
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry_id"
+
+    # Test PackagesSensor
+    sensor = PackagesSensor(mock_entry, SENSOR_TYPES["usps_mail"], mock_coordinator)
+    assert sensor.native_value is None
+
+    # Test ImagePathSensors
+    image_sensor = ImagePathSensors(
+        hass, mock_entry, IMAGE_SENSORS["usps_mail_image_system_path"], mock_coordinator
+    )
+    assert image_sensor.native_value is None
+
+    # Test PackagesBinarySensor
+    binary_sensor = PackagesBinarySensor(
+        BINARY_SENSORS["post_de_update"], mock_coordinator, mock_entry
+    )
+    assert binary_sensor.is_on is False

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,98 @@
+"""Test the Repairs platform and flow for Mail and Packages."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.mail_and_packages.const import DOMAIN
+from custom_components.mail_and_packages.coordinator import MailDataUpdateCoordinator
+from custom_components.mail_and_packages.repairs import (
+    AuthRepairFlow,
+    async_create_fix_flow,
+)
+from custom_components.mail_and_packages.utils.imap import InvalidAuth
+
+
+@pytest.mark.asyncio
+async def test_auth_repair_flow(hass: HomeAssistant):
+    """Test the auth repair flow."""
+    # Test async_create_fix_flow
+    flow = await async_create_fix_flow(hass, "auth_failed", {"entry_id": "test_entry"})
+    assert isinstance(flow, AuthRepairFlow)
+    assert flow.entry_id == "test_entry"
+
+    # Test unknown issue raises ValueError
+    with pytest.raises(ValueError, match="Unknown issue unknown"):
+        await async_create_fix_flow(hass, "unknown", {})
+
+    # Set up flow on hass
+    flow.hass = hass
+
+    # Test step_init
+    result = await flow.async_step_init()
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+
+    # Test step_confirm show form
+    result = await flow.async_step_confirm()
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+
+    # Test step_confirm submit (with config entry)
+    mock_entry = MagicMock()
+    mock_entry.async_start_reauth = MagicMock()
+
+    with patch.object(
+        hass.config_entries, "async_get_entry", return_value=mock_entry
+    ) as mock_get_entry:
+        result = await flow.async_step_confirm(user_input={})
+        assert result["type"] == "create_entry"
+        mock_get_entry.assert_called_once_with("test_entry")
+        mock_entry.async_start_reauth.assert_called_once_with(hass)
+
+    # Test step_confirm submit (without entry_id, fall back to first entry found)
+    flow_no_id = AuthRepairFlow(entry_id=None)
+    flow_no_id.hass = hass
+
+    mock_entry2 = MagicMock()
+    mock_entry2.async_start_reauth = MagicMock()
+
+    with (
+        patch.object(hass.config_entries, "async_entries", return_value=[mock_entry2]),
+        patch.object(hass.config_entries, "async_get_entry", return_value=None),
+    ):
+        result = await flow_no_id.async_step_confirm(user_input={})
+        assert result["type"] == "create_entry"
+        mock_entry2.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_creates_repairs_issue(hass: HomeAssistant):
+    """Test that a repairs issue is created on authentication failure."""
+    coordinator = MailDataUpdateCoordinator(hass, {"scan_interval": 5}, None)
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            side_effect=InvalidAuth("Auth failed"),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._get_imap_connection({})
+
+    # Check that the repairs issue is created
+    issue_registry = ir.async_get(hass)
+    assert (DOMAIN, "auth_failed") in issue_registry.issues
+
+    # Test that the issue is deleted on successful update
+    coordinator._data = {}
+    with (
+        patch.object(coordinator, "process_emails", return_value={"test": "data"}),
+        patch.object(coordinator, "_binary_sensor_update", return_value=None),
+    ):
+        await coordinator._async_update_data()
+
+    assert (DOMAIN, "auth_failed") not in issue_registry.issues

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -43,8 +43,8 @@ async def test_auth_repair_flow(hass: HomeAssistant):
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 
-    # Test step_confirm show form
-    result = await flow.async_step_confirm()
+    # Test step_confirm show form when user_input is None
+    result = await flow.async_step_confirm(user_input=None)
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,6 +1,6 @@
 """Test the Repairs platform and flow for Mail and Packages."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -94,13 +94,15 @@ async def test_auth_failure_creates_repairs_issue(hass: HomeAssistant):
     issue_registry = ir.async_get(hass)
     assert (DOMAIN, "auth_failed") in issue_registry.issues
 
-    # Test that the issue is deleted on successful update
-    coordinator._data = {}
-    with (
-        patch.object(coordinator, "process_emails", return_value={"test": "data"}),
-        patch.object(coordinator, "_binary_sensor_update", return_value=None),
-    ):
-        await coordinator._async_update_data()
+    # Test that the issue is deleted on successful login
+    with patch(
+        "custom_components.mail_and_packages.coordinator.login",
+        new_callable=AsyncMock,
+    ) as mock_login:
+        mock_account = MagicMock()
+        mock_account.select = AsyncMock()
+        mock_login.return_value = mock_account
+        await coordinator._get_imap_connection({})
 
     assert (DOMAIN, "auth_failed") not in issue_registry.issues
 


### PR DESCRIPTION
## Proposed change

This pull request resolves two main issues related to the startup and reconfiguration flows on large mailboxes (tracked under issue #1304):

1. **Symptom 1: Reconfigure flow looks hung on the final step**: 
   When reconfiguring the integration, the reloading of the config entry blocks synchronously on a full IMAP scan, which can take several minutes on large mailboxes. 
   
2. **Symptom 2: HTTP 404 / ENTITY_NOT_FOUND during startup**: 
   `async_setup_entry()` previously awaited the coordinator's initial refresh before calling `async_forward_entry_setups()`. During that 2-4 minute window, the entities did not exist in Home Assistant's state machine, returning 404 errors to any callers instead of showing as `unavailable`.

**Resolutions implemented:**
- **Order of Operations in Setup**: Moved `async_forward_entry_setups()` to run *before* the initial synchronous `coordinator.async_refresh()`. This ensures that all sensor, binary sensor, and camera entities are registered in the HA state machine immediately upon startup. During the initial IMAP scan, they will show as `unavailable` rather than being missing/absent (HTTP 404).
- **Graceful None Handling**: Updated `sensor.py` and `binary_sensor.py` entity properties to handle `self.coordinator.data is None` gracefully, preventing potential setup errors during the initial synchronous scan phase.
- **Removed Redundant Checks**: Cleaned up a buggy `self.data is None` check in `PackagesSensor.extra_state_attributes` that was preventing attributes (like `image`) from updating once data arrived because `self.data` remained `None` from initialization.
- **Authentication Failure Repairs Issue**: Added a new repairs platform (`repairs.py`) and translation keys. When IMAP authentication fails (either during initial setup or background polling), a Repairs issue is registered in Settings -> Repairs to notify the user and provide an option to launch the config entry's native reauth flow. The issue is automatically cleaned up/deleted once an update succeeds.
- **Translation Schema Compliance**: Corrected Repairs translations under `auth_failed` in `strings.json` and `translations/en.json` by removing the top-level `"description"` key. Home Assistant issue validation enforces that fixable issues only define `fix_flow` and not a top-level `description` concurrently.
- **CONFIG_SCHEMA Validation**: Imported `config_validation as cv` and defined `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` in `__init__.py` to properly declare that this integration is config-entry-only and resolve the schema validation warning.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #1304
- This PR is related to issue: 
