### PR TITLE
fix(config): resolve double /config prefixing and fix path validation

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -279,7 +279,7 @@ class MailCam(CoordinatorEntity, Camera):
         if required_keys.issubset(self.coordinator.data):
             image = self.coordinator.data[ATTR_USPS_IMAGE]
             path = self.coordinator.data[ATTR_IMAGE_PATH]
-            self._file_path = f"{self.hass.config.path()}/{path}{image}"
+            self._file_path = self.hass.config.path(path, image)
             self._is_generic = not self.coordinator.data.get("usps_update", False)
             _LOGGER.debug(
                 "usps_camera camera - file path set to: %s",
@@ -319,7 +319,7 @@ class MailCam(CoordinatorEntity, Camera):
             return
 
         image_path = self.coordinator.data.get(ATTR_IMAGE_PATH, "")
-        full_storage_path = Path(f"{self.hass.config.path()}/{image_path}")
+        full_storage_path = Path(self.hass.config.path(image_path))
         gif_path = str(full_storage_path / "generic_deliveries.gif")
 
         resized_images = await self.hass.async_add_executor_job(
@@ -389,7 +389,7 @@ class MailCam(CoordinatorEntity, Camera):
 
             image = self.coordinator.data[image_attr]
             path = f"{self.coordinator.data[ATTR_IMAGE_PATH]}{path_suffix}"
-            delivery_file_path = f"{self.hass.config.path()}/{path}{image}"
+            delivery_file_path = self.hass.config.path(path, image)
 
             is_no_mail = image.startswith(
                 no_mail_check,
@@ -454,7 +454,7 @@ class MailCam(CoordinatorEntity, Camera):
         image = self.coordinator.data[image_attr]
         image_path = self.coordinator.data[ATTR_IMAGE_PATH].rstrip("/") + "/"
         path = f"{image_path}{base_name}/"
-        coordinator_file_path = f"{self.hass.config.path()}/{path}{image}"
+        coordinator_file_path = self.hass.config.path(path, image)
 
         _LOGGER.debug(
             "=== %s CAMERA UPDATE === coordinator %s = '%s'",

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -198,7 +198,9 @@ async def _check_forwarded_emails(user_input: dict[str, Any]) -> list[str]:
     return errors
 
 
-def _validate_path_input(user_input: dict, errors: dict) -> None:
+def _validate_path_input(
+    user_input: dict, errors: dict, hass: HomeAssistant | None = None
+) -> None:
     """Validate path and file inputs."""
     # List of (Toggle Key, File Key, Error Key)
     file_checks = [
@@ -233,11 +235,17 @@ def _validate_path_input(user_input: dict, errors: dict) -> None:
 
     for toggle, file_key, error_key in file_checks:
         if user_input.get(toggle) and file_key in user_input:
-            if not Path(user_input[file_key]).is_file():
+            path = user_input[file_key]
+            if hass:
+                path = hass.config.path(path)
+            if not Path(path).is_file():
                 errors[error_key] = "file_not_found"
 
     if CONF_STORAGE in user_input:
-        if not Path(user_input[CONF_STORAGE]).exists():
+        path = user_input[CONF_STORAGE]
+        if hass:
+            path = hass.config.path(path)
+        if not Path(path).exists():
             errors[CONF_STORAGE] = "path_not_found"
 
 
@@ -275,7 +283,9 @@ async def _validate_forwarded_emails(user_input: dict, errors: dict) -> None:
         errors[CONF_FORWARDED_EMAILS] = status[0]
 
 
-async def _validate_user_input(user_input: dict) -> tuple:
+async def _validate_user_input(
+    user_input: dict, hass: HomeAssistant | None = None
+) -> tuple:
     """Validate user input from config flow.
 
     Returns tuple with error messages and modified user_input
@@ -303,7 +313,7 @@ async def _validate_user_input(user_input: dict) -> tuple:
             errors[CONF_GENERATE_MP4] = "ffmpeg_not_found"
 
     # Validate file paths
-    _validate_path_input(user_input, errors)
+    _validate_path_input(user_input, errors, hass)
 
     # Normalize CONF_FOLDER: if it has exactly 1 folder, store as string
     if CONF_FOLDER in user_input:
@@ -975,7 +985,7 @@ class MailAndPackagesFlowHandler(
         """Configure form step 2."""
         self._errors = {}
         if user_input is not None:
-            self._errors, user_input = await _validate_user_input(user_input)
+            self._errors, user_input = await _validate_user_input(user_input, self.hass)
             self._data.update(user_input)
             _LOGGER.debug("RESOURCES: %s", self._data[CONF_RESOURCES])
             if len(self._errors) == 0:
@@ -1012,7 +1022,7 @@ class MailAndPackagesFlowHandler(
             CONF_FOLDER: DEFAULT_FOLDER,
             CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
             CONF_CUSTOM_DAYS: DEFAULT_CUSTOM_DAYS,
-            CONF_PATH: self.hass.config.path() + DEFAULT_PATH,
+            CONF_PATH: self.hass.config.path(DEFAULT_PATH),
             CONF_DURATION: DEFAULT_GIF_DURATION,
             CONF_IMAGE_SECURITY: DEFAULT_IMAGE_SECURITY,
             CONF_IMAP_TIMEOUT: DEFAULT_IMAP_TIMEOUT,
@@ -1045,7 +1055,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 return await self.async_step_config_storage()
             return await self._show_config_3(user_input)
@@ -1076,7 +1086,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 if (
                     self._data.get(CONF_CUSTOM_IMG)
@@ -1117,7 +1127,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 if any(
                     sensor in self._data[CONF_RESOURCES] for sensor in AMAZON_SENSORS
@@ -1150,7 +1160,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 return self.async_create_entry(
                     title=f"Mail and Packages ({self._data[CONF_HOST]})",
@@ -1254,7 +1264,7 @@ class MailAndPackagesFlowHandler(
         _LOGGER.debug("Loading step 2...")
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(user_input)
+            self._errors, user_input = await _validate_user_input(user_input, self.hass)
             if len(self._errors) == 0:
                 if self._data.get(CONF_ALLOW_FORWARDED_EMAILS, False):
                     return await self.async_step_reconfig_forwarded_emails()
@@ -1300,7 +1310,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 return await self.async_step_reconfig_storage()
 
@@ -1332,7 +1342,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 has_custom_image = (
                     self._data.get(CONF_CUSTOM_IMG)
@@ -1375,7 +1385,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 if any(
                     sensor in self._data.get(CONF_RESOURCES, [])
@@ -1404,7 +1414,7 @@ class MailAndPackagesFlowHandler(
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            self._errors, user_input = await _validate_user_input(self._data)
+            self._errors, user_input = await _validate_user_input(self._data, self.hass)
             if len(self._errors) == 0:
                 self.hass.config_entries.async_update_entry(
                     self._entry,

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -563,7 +563,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 path = f"{image_path}{base_name}/"
                 # Use absolute path for file existence check
                 delivery_image_relative = f"{path}{image}"
-                delivery_image = f"{self.hass.config.path()}/{delivery_image_relative}"
+                delivery_image = self.hass.config.path(delivery_image_relative)
                 _LOGGER.debug(
                     "Full %s image path: %s",
                     base_name.title(),

--- a/custom_components/mail_and_packages/helpers.py
+++ b/custom_components/mail_and_packages/helpers.py
@@ -114,7 +114,7 @@ def get_resources(hass: HomeAssistant | None = None) -> dict:
 
 def copy_images(hass: HomeAssistant, config: ConfigEntry) -> None:
     """Copy processed images to www directory."""
-    image_path = Path(hass.config.path()) / default_image_path(hass, config)
+    image_path = Path(hass.config.path(default_image_path(hass, config)))
     www_path = Path(hass.config.path()) / "www" / "mail_and_packages"
 
     if not www_path.is_dir():

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -242,10 +242,10 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
 
         if self.type == "usps_mail_image_system_path" and image:
             _LOGGER.debug("Updating system image path to: %s", path)
-            the_path = f"{self.hass.config.path()}/{path}{image}"
+            the_path = self.hass.config.path(path, image)
         elif self.type == "usps_mail_grid_image_path" and grid_image:
             _LOGGER.debug("Updating grid image path to: %s", path)
-            the_path = f"{self.hass.config.path()}/{path}{grid_image}"
+            the_path = self.hass.config.path(path, grid_image)
         elif self.type == "usps_mail_image_url" and image:
             url = self._get_base_url()
             if url:

--- a/custom_components/mail_and_packages/utils/image.py
+++ b/custom_components/mail_and_packages/utils/image.py
@@ -374,7 +374,7 @@ def _get_courier_info(
         ),
     ]
 
-    base_path = f"{hass.config.path()}/{default_image_path(hass, config)}"
+    base_path = hass.config.path(default_image_path(hass, config))
 
     for (
         active,


### PR DESCRIPTION
## Proposed change

This PR resolves upstream issue #1306, where using an absolute image storage path (e.g., `/config/custom_components/mail_and_packages/images/`) resulted in double `/config` prepending (`/config//config/...`) in image path strings generated for cameras, sensors, and helpers, causing errors in the log and broken images.

This was caused by unconditionally prepending the configuration path using string interpolation (`f"{self.hass.config.path()}/{path}"`). To fix this, all path constructions have been migrated to use the native `hass.config.path(*paths)` helper, which correctly resolves relative paths relative to the config directory and leaves absolute paths unmodified.

In addition, relative image paths (e.g. `custom_components/mail_and_packages/images/`) previously failed setup validation in `config_flow.py` because `Path(path).exists()` was evaluated relative to the current working directory. The signatures of `_validate_user_input` and `_validate_path_input` were refactored to accept an optional `hass` parameter (`hass: HomeAssistant | None = None`) at the end, so that paths can be validated relative to the Home Assistant config directory when available, while preserving compatibility with direct calls in the unit test suite.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1306
- This PR is related to issue:
