### PR TITLE
fix(sensor): use native get_url helper for image links

### DIFF
--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_RESOURCES
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MailAndPackagesConfigEntry
@@ -253,33 +254,12 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
         return the_path
 
     def _get_base_url(self) -> str | None:
-        """Return the best available base URL for building image links.
-
-        Priority: explicit external URL → HA Cloud remote URL → internal URL.
-        """
-        if self.hass.config.external_url:
-            return self.hass.config.external_url
-
-        # Try Home Assistant Cloud (Nabu Casa) — its remote URL is not exposed via
-        # hass.config.external_url when "Use Home Assistant Cloud" is selected.
+        """Return the best available base URL for building image links."""
         try:
-            from homeassistant.components.cloud import (  # noqa: PLC0415
-                CloudNotAvailable,
-                async_remote_ui_url,
-            )
-        except ImportError:
-            pass
-        else:
-            try:
-                return async_remote_ui_url(self.hass)
-            except (CloudNotAvailable, KeyError):
-                _LOGGER.debug("HA Cloud remote URL not available.")
-
-        if self.hass.config.internal_url:
-            _LOGGER.debug("Falling back to internal URL for image link.")
-            return self.hass.config.internal_url
-
-        return None
+            return get_url(self.hass, prefer_external=True)
+        except NoURLAvailableError:
+            _LOGGER.debug("No URL available for image link.")
+            return None
 
     @property
     def should_poll(self) -> bool:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -241,6 +241,8 @@ async def test_image_path_sensor_url_ha_cloud(hass):
     coordinator.data = {"usps_image": "test_image.gif", "image_path": "images/"}
     hass.config.external_url = None
     hass.config.internal_url = None
+    # Enable cloud component so get_url() can resolve Nabu Casa's remote UI URL
+    hass.config.components.add("cloud")
 
     sensor = ImagePathSensors(
         hass,
@@ -275,6 +277,8 @@ async def test_image_path_sensor_url_ha_cloud_unavailable(hass):
     coordinator.data = {"usps_image": "test_image.gif", "image_path": "images/"}
     hass.config.external_url = None
     hass.config.internal_url = "http://internal.hass.url"
+    # Enable cloud component so get_url() can resolve Nabu Casa's remote UI URL
+    hass.config.components.add("cloud")
 
     sensor = ImagePathSensors(
         hass,


### PR DESCRIPTION
## Proposed change

This PR refactors how the integration retrieves Home Assistant's base URL for image links to follow Home Assistant design standards. 

Specifically:
- Replaces the custom, deprecated fallback check logic in `_get_base_url` within `sensor.py` with the native `get_url(self.hass, prefer_external=True)` helper from `homeassistant.helpers.network`.
- Catches `NoURLAvailableError` gracefully when no URLs are configured.
- Updates unit tests in `tests/test_sensor.py` to add `"cloud"` to the active components in `hass.config.components`. This ensures the native `get_url` helper recognizes the component as loaded and queries Nabu Casa's remote UI URL mock correctly.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
