### PR TITLE
fix(amazon): support Italian relative delivery dates and subjects

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -173,6 +173,7 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Shipped:",
     "Enviado:",
     "Out for delivery:",
+    "Spedito:",
 ]
 AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
 AMAZON_EMAIL = [
@@ -218,6 +219,7 @@ AMAZON_TIME_PATTERN = [
     "Chega ",
     "Verwachte bezorgdatum:",
     "Votre date de livraison prévue est :",
+    "In arrivo",
 ]
 AMAZON_TIME_PATTERN_END = [
     "Previously expected:",
@@ -252,6 +254,10 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Wordt bezorgd op (\\w+ \\d+ \\w+)",
     "Wordt bezorgd op (\\w+ \\d+)",
     "Wordt (\\w+) bezorgd",
+    "In arrivo (\\w+ \\d+) - (\\w+ \\d+)",
+    "In arrivo (\\w+ \\d+)",
+    "In arrivo (\\w+ \\d*)",
+    "In arrivo (\\w+)",
 ]
 AMAZON_EXCEPTION_SUBJECT = "Delivery update:"
 AMAZON_EXCEPTION_BODY = "running late"

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -43,7 +43,12 @@ _MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 DOMAIN_LANG_MAP = {
     "amazon.de": ["versandbestaetigung", "Geliefert:", "Zugestellt:"],
-    "amazon.it": ["conferma-spedizione", "Consegna effettuata:", "Arriverà"],
+    "amazon.it": [
+        "conferma-spedizione",
+        "Consegna effettuata:",
+        "Arriverà",
+        "Spedito:",
+    ],
     "amazon.nl": [
         "update-bestelling",
         "verzending-volgen",

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -572,6 +572,16 @@ async def test_parse_amazon_arrival_date(hass):
     result_morgen = await parse_amazon_arrival_date(hass, body_morgen, email_date)
     assert result_morgen == email_date + datetime.timedelta(days=1)
 
+    # 6. Italian "domani" relative date
+    body_domani = "In arrivo domani"
+    result_domani = await parse_amazon_arrival_date(hass, body_domani, email_date)
+    assert result_domani == email_date + datetime.timedelta(days=1)
+
+    # 7. Italian "oggi" relative date
+    body_oggi = "In arrivo oggi"
+    result_oggi = await parse_amazon_arrival_date(hass, body_oggi, email_date)
+    assert result_oggi == email_date
+
 
 @pytest.mark.asyncio
 async def test_amazon_search_no_emails_found_copy(hass):


### PR DESCRIPTION
## Proposed change

This PR adds support for parsing Amazon.it shipment emails that use relative delivery dates (such as `"In arrivo domani"` / `"In arrivo oggi"`) and subjects matching `"Spedito:"`.

To achieve this:
- Added `"Spedito:"` to `AMAZON_SHIPMENT_SUBJECT` in `const.py` and mapped it under `"amazon.it"` in `DOMAIN_LANG_MAP` within `utils/amazon.py` to ensure Italian shipment emails are correctly retrieved and processed.
- Added `"In arrivo"` to `AMAZON_TIME_PATTERN` and registered its regex capture variants in `AMAZON_TIME_PATTERN_REGEX` in `const.py` to extract the relative arrival day keyword from the email body.
- Added unit tests in `tests/shippers/test_amazon.py` to verify that both `"In arrivo domani"` and `"In arrivo oggi"` resolve to the correct dates relative to the email's date header.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1309
- This PR is related to issue:
