### PR TITLE
fix(init): defer first refresh to background to prevent startup timeouts

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -6,15 +6,11 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_RESOURCES
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
 )
 from homeassistant.helpers import (
     device_registry as dr,
-)
-from homeassistant.helpers import (
-    issue_registry as ir,
 )
 
 from . import const
@@ -146,27 +142,8 @@ async def async_setup_entry(
 
     config_entry.runtime_data = MailAndPackagesData(coordinator=coordinator, cameras=[])
 
-    # Fetch initial data so we have data when entities subscribe
-    await coordinator.async_refresh()
-
-    # Raise ConfigEntryNotReady if coordinator didn't update
-    if not coordinator.last_update_success:
-        if isinstance(coordinator.last_exception, ConfigEntryAuthFailed):
-            # Create a repairs issue for authentication failure
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "auth_failed",
-                is_fixable=True,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="auth_failed",
-                data={"entry_id": config_entry.entry_id},
-            )
-            raise coordinator.last_exception
-        exc = coordinator.last_exception
-        detail = (str(exc) or type(exc).__name__) if exc else "unknown error"
-        _LOGGER.error("Error updating sensor data: %s", detail)
-        raise ConfigEntryNotReady
+    # Fetch initial data in the background so setup doesn't block
+    hass.async_create_task(coordinator.async_refresh())
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 

--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -146,8 +146,6 @@ async def async_setup_entry(
 
     config_entry.runtime_data = MailAndPackagesData(coordinator=coordinator, cameras=[])
 
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
 
@@ -169,6 +167,8 @@ async def async_setup_entry(
         detail = (str(exc) or type(exc).__name__) if exc else "unknown error"
         _LOGGER.error("Error updating sensor data: %s", detail)
         raise ConfigEntryNotReady
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from custom_components.mail_and_packages.const import (
     CONF_FOLDER,
     CONF_FORWARDED_EMAILS,
     DOMAIN,
+    PLATFORMS,
 )
 from custom_components.mail_and_packages.coordinator import (
     MailDataUpdateCoordinator,
@@ -286,6 +287,11 @@ async def test_setup_entry_coordinator_failure():
 
         # Should load successfully
         assert await async_setup_entry(mock_hass, mock_config_entry) is True
+        mock_hass.async_create_task.assert_called_once()
+        mock_coordinator.async_refresh.assert_called_once()
+        mock_hass.config_entries.async_forward_entry_setups.assert_called_once_with(
+            mock_config_entry, PLATFORMS
+        )
 
 
 async def test_setup_entry_auth_failure():
@@ -314,6 +320,11 @@ async def test_setup_entry_auth_failure():
 
         # Should load successfully
         assert await async_setup_entry(mock_hass, mock_config_entry) is True
+        mock_hass.async_create_task.assert_called_once()
+        mock_coordinator.async_refresh.assert_called_once()
+        mock_hass.config_entries.async_forward_entry_setups.assert_called_once_with(
+            mock_config_entry, PLATFORMS
+        )
 
 
 async def test_async_remove_config_entry_device():
@@ -591,6 +602,11 @@ async def test_setup_entry_refresh_failure():
         mock_coordinator.async_refresh = AsyncMock()
         # Should load successfully
         assert await async_setup_entry(mock_hass, mock_config_entry) is True
+        mock_hass.async_create_task.assert_called_once()
+        mock_coordinator.async_refresh.assert_called_once()
+        mock_hass.config_entries.async_forward_entry_setups.assert_called_once_with(
+            mock_config_entry, PLATFORMS
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -284,9 +284,8 @@ async def test_setup_entry_coordinator_failure():
     ):
         mock_coordinator_class.return_value = mock_coordinator
 
-        # Should raise ConfigEntryNotReady
-        with pytest.raises(ConfigEntryNotReady):
-            await async_setup_entry(mock_hass, mock_config_entry)
+        # Should load successfully
+        assert await async_setup_entry(mock_hass, mock_config_entry) is True
 
 
 async def test_setup_entry_auth_failure():
@@ -313,9 +312,8 @@ async def test_setup_entry_auth_failure():
     ):
         mock_coordinator_class.return_value = mock_coordinator
 
-        # Verify that an authentication failure during setup raises ConfigEntryAuthFailed
-        with pytest.raises(ConfigEntryAuthFailed):
-            await async_setup_entry(mock_hass, mock_config_entry)
+        # Should load successfully
+        assert await async_setup_entry(mock_hass, mock_config_entry) is True
 
 
 async def test_async_remove_config_entry_device():
@@ -591,8 +589,8 @@ async def test_setup_entry_refresh_failure():
         mock_coordinator.last_update_success = False
         mock_coordinator.last_exception = "IMAP Timeout"
         mock_coordinator.async_refresh = AsyncMock()
-        with pytest.raises(ConfigEntryNotReady):
-            await async_setup_entry(mock_hass, mock_config_entry)
+        # Should load successfully
+        assert await async_setup_entry(mock_hass, mock_config_entry) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

This PR refactors the config entry setup lifecycle to prevent startup timeouts from triggering `ValueError: Config entry ... has already been setup!` crashes.

Previously, when the initial coordinator refresh during setup timed out or failed, it threw `ConfigEntryNotReady`. However, because platforms were forwarded first, they remained registered in Home Assistant. When Home Assistant retried configuration entry setup 80 seconds later, it re-ran `async_setup_entry` and crashed because those platforms were already registered.

To fix this:
- Deferred the coordinator first-update refresh to run as a background task (`hass.async_create_task(coordinator.async_refresh())`).
- Instantly forward setups to platforms and return `True` so the config entry loads immediately without blocking.
- Authentication failures continue to be caught in the background by the coordinator's main fetch loop, which registers the `"auth_failed"` repairs issue in Home Assistant.
- Updated `tests/test_init.py` setup entry failure tests to check the background refresh design.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
