### PR TITLE
fix(oauth): add select_account prompt to microsoft login

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -858,6 +858,12 @@ class MailAndPackagesFlowHandler(
                     "prompt": "consent",
                 }
             )
+        elif auth_type == AUTH_TYPE_OAUTH_MICROSOFT:
+            data.update(
+                {
+                    "prompt": "select_account",
+                }
+            )
         return data
 
     def __init__(self):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7561,6 +7561,7 @@ async def test_oauth_config_flow_selection(hass, mock_imap_no_email):
         if hasattr(handler, "extra_authorize_data"):
             auth_data = handler.extra_authorize_data
             assert "scope" in auth_data
+            assert auth_data.get("prompt") == "select_account"
 
         # And async_oauth_create_entry triggers config_2
         # Mock _get_mailboxes to avoid network calls
@@ -7629,6 +7630,8 @@ async def test_oauth_reconfig_flow_selection(hass, mock_imap_no_email, integrati
         if hasattr(handler, "extra_authorize_data"):
             auth_data = handler.extra_authorize_data
             assert "scope" in auth_data
+            assert auth_data.get("prompt") == "consent"
+            assert auth_data.get("access_type") == "offline"
 
         with patch(
             "custom_components.mail_and_packages.config_flow._get_mailboxes",


### PR DESCRIPTION
## Proposed change

This PR adds the `prompt=select_account` parameter to Microsoft OAuth requests. 

When attempting to configure a second Microsoft account under the same application credential, Microsoft's authorization endpoint previously detected the active browser session/cookie of the first account and automatically selected it or got stuck in a redirect loop. This resulted in an invalid/expired code error (`AADSTS70000`) during the token exchange step.

Adding `"prompt": "select_account"` forces Microsoft to display the account picker, allowing users to cleanly sign into or select a different Microsoft account. In addition, unit tests in `tests/test_config_flow.py` have been updated to assert correct prompt behaviors for both Google (`consent`) and Microsoft (`select_account`).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1316
- This PR is related to issue:
