### PR TITLE
fix(shippers): resolve relative placeholder image paths against config directory

### DIFF
--- a/custom_components/mail_and_packages/shippers/post_de.py
+++ b/custom_components/mail_and_packages/shippers/post_de.py
@@ -207,6 +207,8 @@ class PostDEShipper(Shipper):
             if target.is_file():
                 cleanup_images(path + "/", name)
             src = custom_img or str(Path(__file__).parent.parent / "mail_none.gif")
+            if not Path(src).is_absolute():
+                src = self.hass.config.path(src)
             shutil.copyfile(src, str(target))
 
         _LOGGER.debug("No Post DE mail found.")

--- a/custom_components/mail_and_packages/shippers/usps.py
+++ b/custom_components/mail_and_packages/shippers/usps.py
@@ -262,6 +262,8 @@ class USPSShipper(Shipper):
             if target.is_file():
                 cleanup_images(path, name)
             src = custom_img or str(Path(__file__).parent.parent / "mail_none.gif")
+            if not Path(src).is_absolute():
+                src = self.hass.config.path(src)
             shutil.copyfile(src, str(target))
 
         _LOGGER.debug("No mail found.")

--- a/tests/shippers/test_post_de.py
+++ b/tests/shippers/test_post_de.py
@@ -698,3 +698,24 @@ async def test_post_de_unidentified_format(hass):
     ):
         result = await shipper.process(mock_account, "today", "post_de_mail")
         assert result["post_de_mail"] == 0
+
+
+@pytest.mark.asyncio
+async def test_post_de_copy_nomail_image_relative_path(hass):
+    """Test _copy_nomail_image resolves relative path relative to config directory for Post DE."""
+    shipper = PostDEShipper(hass, {})
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_file", return_value=False),
+        patch(
+            "custom_components.mail_and_packages.shippers.post_de.cleanup_images",
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.post_de.shutil.copyfile",
+        ) as mock_copy,
+    ):
+        relative_path = "custom_components/mail_and_packages/mail_none.gif"
+        expected_resolved_path = hass.config.path(relative_path)
+
+        await shipper._copy_nomail_image("test_dir", "test.gif", relative_path)
+        mock_copy.assert_called_once_with(expected_resolved_path, "test_dir/test.gif")

--- a/tests/shippers/test_usps.py
+++ b/tests/shippers/test_usps.py
@@ -827,3 +827,28 @@ async def test_usps_placeholder_disabled(hass, mock_imap_usps_informed_digest_mi
         # But the generated GIF images should NOT include the placeholder
         called_images = mock_generate_gif.call_args[0][0]
         assert not any("image-no-mailpieces700.jpg" in img for img in called_images)
+
+
+@pytest.mark.asyncio
+async def test_copy_nomail_image_relative_path(hass):
+    """Test _copy_nomail_image resolves relative path relative to config directory."""
+    shipper = USPSShipper(hass, {})
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.usps.Path.exists",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.usps.Path.is_file",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.usps.shutil.copyfile"
+        ) as mock_copyfile,
+        patch("custom_components.mail_and_packages.shippers.usps.cleanup_images"),
+    ):
+        relative_path = "custom_components/mail_and_packages/mail_none.gif"
+        expected_resolved_path = hass.config.path(relative_path)
+
+        await shipper._copy_nomail_image("test/", "test.gif", relative_path)
+        mock_copyfile.assert_called_once_with(expected_resolved_path, "test/test.gif")


### PR DESCRIPTION
## Proposed change

This PR resolves relative paths of placeholder images (such as `"custom_components/mail_and_packages/mail_none.gif"`) to absolute paths relative to the Home Assistant configuration directory using `self.hass.config.path()`. 

Previously, when the integration attempted to copy default placeholders (like the "no mail" image for USPS or Post DE), Python tried to resolve these relative paths against the current working directory of the process. In environments where the working directory was not the configuration directory (such as certain Docker containers or systemd environments), it resulted in a `FileNotFoundError`.

### Changes:
- Updated `_copy_nomail_image` in both `USPSShipper` (`usps.py`) and `PostDEShipper` (`post_de.py`) to convert relative source paths to absolute paths via `self.hass.config.path()`.
- Added new test cases `test_copy_nomail_image_relative_path` and `test_post_de_copy_nomail_image_relative_path` to assert that relative image paths resolve correctly.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1306
- This PR is related to issue:
