### PR TITLE
fix(amazon): support tracking for German amazon.de emails

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -176,6 +176,8 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Enviado:",
     "Out for delivery:",
     "Spedito:",
+    "Versandt:",
+    "In Zustellung:",
 ]
 AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
 AMAZON_EMAIL = [
@@ -222,6 +224,7 @@ AMAZON_TIME_PATTERN = [
     "Verwachte bezorgdatum:",
     "Votre date de livraison prévue est :",
     "In arrivo",
+    "Zustellung:",
 ]
 AMAZON_TIME_PATTERN_END = [
     "Previously expected:",
@@ -243,9 +246,10 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Arriving (\\w+ \\d+)",
     "Arriving (\\w+ ?\\d*)",
     "Arriving (\\w+)",
-    "Zustellung (\\w+ \\d+) - (\\w+ \\d+)",
-    "Zustellung (\\w+ \\d+)",
-    "Zustellung (\\w+ \\d*)",
+    "Zustellung:? (\\w+ \\d+) - (\\w+ \\d+)",
+    "Zustellung:? (\\w+ \\d+)",
+    "Zustellung:? (\\w+ ?\\d*)",
+    "Zustellung:? (\\w+)",
     "Arriverà (\\w+ \\d+) - (\\w+ \\d+)",
     "Arriverà (\\w+ \\d+)",
     "Arriverà (\\w+ \\d*)",

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -42,7 +42,14 @@ _LOGGER = logging.getLogger(__name__)
 _MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 DOMAIN_LANG_MAP = {
-    "amazon.de": ["versandbestaetigung", "Geliefert:", "Zugestellt:"],
+    "amazon.de": [
+        "versandbestaetigung",
+        "Geliefert:",
+        "Zugestellt:",
+        "Versandt:",
+        "In Zustellung:",
+        "Zustellung:",
+    ],
     "amazon.it": [
         "conferma-spedizione",
         "Consegna effettuata:",

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1154,3 +1154,62 @@ async def test_is_amazon_delivered_skips_non_bytes_response_parts(hass):
 
     assert is_delivered is True
     assert isinstance(urls, list)
+
+
+@pytest.mark.asyncio
+async def test_amazon_de_emails(hass):
+    """Test that amazon.de German-language emails are parsed and counted correctly."""
+    shipper = AmazonShipper(
+        hass,
+        {
+            "amazon_fwds": "",
+            "amazon_domain": "amazon.de",
+        },
+    )
+    mock_account = AsyncMock()
+
+    # 1. Test Shipped/Versandt email with "Zustellung: Montag"
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.get_today",
+            return_value=datetime.date(2026, 7, 13),  # 2026-07-13 is a Monday
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.amazon.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1 2"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+    ):
+
+        async def _mock_fetch(account, email_id, parts):
+            if email_id == "1":
+                # Versandt email
+                content = (
+                    b"Subject: =?utf-8?Q?Versandt:_=E2=80=9Eitem=E2=80=9C_und_1_weiterer_Artikel?=\n"
+                    b"Date: Mon, 13 Jul 2026 12:00:00 +0200\n"
+                    b"Content-Type: text/plain; charset=utf-8\n\n"
+                    b"Dein Paket wurde versendet!\n"
+                    b"Zustellung: Montag\n"
+                    b"Order: 123-4567890-1234567"
+                )
+            else:
+                # In Zustellung email
+                content = (
+                    b"Subject: =?utf-8?Q?In_Zustellung:_=E2=80=9Eitem=E2=80=9C_und_1_weiterer_Artikel?=\n"
+                    b"Date: Mon, 13 Jul 2026 13:00:00 +0200\n"
+                    b"Content-Type: text/plain; charset=utf-8\n\n"
+                    b"Paket befindet sich in Zustellung!\n"
+                    b"Zustellung heute 10:00 - 11:00\n"
+                    b"Order: 123-4567890-1234567"
+                )
+            return ("OK", [b"RFC822", content])
+
+        mock_fetch.side_effect = _mock_fetch
+
+        result = await shipper.process(mock_account, "today", AMAZON_PACKAGES)
+        assert result[AMAZON_PACKAGES] == 2
+        assert result[AMAZON_ORDER] == ["123-4567890-1234567"]


### PR DESCRIPTION
## Proposed change

This PR adds support for tracking German-language Amazon (`amazon.de`) shipment emails (issue #1319). Specifically, it parses emails with the subject/body patterns:
- **Shipped**: Subject `Versandt: „item“ und 1 weiterer Artikel` / Body `Dein Paket wurde versendet! Zustellung: Montag`
- **Out for delivery**: Subject `In Zustellung: „item“ und 1 weiterer Artikel` / Body `Paket befindet sich in Zustellung!`

These changes add the new German subjects/patterns, make the colon optional in `Zustellung`, and update the `DOMAIN_LANG_MAP` filter for `amazon.de`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1319
- This PR is related to issue:
