### PR TITLE
fix(intelcom): support Dragonfly rebranding email addresses and formats

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -808,6 +808,7 @@ SENSOR_DATA = {
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
             "notifications@nl.dragonflyinternational.com",
+            "notifications@ca.dragonflyinternational.com",
         ],
         "subject": [
             "Your order has been delivered!",
@@ -816,6 +817,7 @@ SENSOR_DATA = {
             "Votre commande a été livrée!",
             "Votre colis a été livré!",
             "We hebben je pakket bezorgd!",
+            "Hooray! Your package was delivered!",
         ],
     },
     "intelcom_delivering": {
@@ -824,6 +826,7 @@ SENSOR_DATA = {
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
             "notifications@nl.dragonflyinternational.com",
+            "notifications@ca.dragonflyinternational.com",
         ],
         "subject": [
             "Your package is on the way!",
@@ -831,6 +834,8 @@ SENSOR_DATA = {
             "Votre colis est en chemin!",
             "package is on its way",
             "Vandaag bezorgen we je pakket",
+            "Your delivery is scheduled for today",
+            "Your package will be there in the next hour!",
         ],
     },
     "intelcom_packages": {
@@ -839,6 +844,7 @@ SENSOR_DATA = {
             "notifications@dragonflyshipping.ca",
             "notifications@dragonflyshipping.com",
             "notifications@nl.dragonflyinternational.com",
+            "notifications@ca.dragonflyinternational.com",
         ],
         "subject": [
             "Your package has been received!",
@@ -847,7 +853,9 @@ SENSOR_DATA = {
             "Je pakket is bij ons aangekomen",
         ],
     },
-    "intelcom_tracking": {"pattern": ["(NSPRSO[0-9]{10}|AMZNL[0-9]{12})"]},
+    "intelcom_tracking": {
+        "pattern": ["(NSPRSO[0-9]{10}|AMZNL[0-9]{12}|INTLCMI[0-9]+)"]
+    },
     # Walmart
     "walmart_delivering": {
         "email": ["help@walmart.com"],

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1142,3 +1142,71 @@ async def test_aliexpress_delivered_class(hass):
         result = await shipper.process(mock_account, "today", "aliexpress_delivered")
         assert result[ATTR_COUNT] == 1
         assert result[ATTR_TRACKING] == ["LP123456789DE"]
+
+
+@pytest.mark.asyncio
+async def test_intelcom_dragonfly_delivered(hass):
+    """Test Dragonfly (Intelcom) delivered email parsing."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch.object(
+            shipper,
+            "_verify_matched_subjects",
+            new_callable=AsyncMock,
+            return_value=[b"1"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(1, [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["INTLCMI19292929"],
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "intelcom_delivered")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["INTLCMI19292929"]
+
+
+@pytest.mark.asyncio
+async def test_intelcom_dragonfly_delivering(hass):
+    """Test Dragonfly (Intelcom) delivering email parsing."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch.object(
+            shipper,
+            "_verify_matched_subjects",
+            new_callable=AsyncMock,
+            return_value=[b"1"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(1, [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["INTLCMI19292929"],
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "intelcom_delivering")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["INTLCMI19292929"]


### PR DESCRIPTION
## Proposed change

This PR updates the generic shipper configurations for Intelcom to support the Dragonfly rebranding (issue #1315).

Specifically, it adds:
- The new sender address `notifications@ca.dragonflyinternational.com`.
- New delivered/delivering subjects:
  - `Hooray! Your package was delivered!`
  - `Your delivery is scheduled for today`
  - `Your package will be there in the next hour!`
- Support for the new tracking number format matching `INTLCMI[0-9]+`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1315
- This PR is related to issue:
