### PR TITLE
fix(aliexpress): match current AliExpress transactional email formats

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -999,6 +999,8 @@ SENSOR_DATA = {
         "subject": [
             "Package delivered",
             "Your package has been delivered",
+            # 2026 format: "Package <ID> has been delivered"
+            "has been delivered",
             "Sendung zugestellt",
         ],
         "body": [
@@ -1018,16 +1020,32 @@ SENSOR_DATA = {
             "Your package is on the way",
             "Ihre Sendung ist unterwegs",
             "Sendung wird versandt",
+            # 2026 formats: "Order <N>: <status>" and "Package <ID>: <status>"
+            "order shipped",
+            "collected by the carrier",
+            "left the departure region",
+            "at customs",
+            "has cleared customs",
+            "in your country/region",
+            "in local transit",
+            "with local carrier",
         ],
         "body": [
             "on the way",
             "unterwegs",
             "wird versandt",
+            "shipped",
+            "carrier",
+            "customs",
+            "transit",
+            "departure",
         ],
     },
     "aliexpress_packages": {},
     "aliexpress_tracking": {
-        "pattern": ["(?:[A-Z]{2}[0-9]{9}[A-Z]{2}|[0-9]{13}|[0-9]{20})"],
+        "pattern": [
+            "(?:[A-Z]{2}[0-9][0-9A-Z]{13,15}|[A-Z]{2}[0-9]{9}[A-Z]{2}|[0-9]{13}|[0-9]{20})"
+        ],
     },
     # DPD Netherlands
     "dpd_nl_delivered": {
@@ -1925,6 +1943,7 @@ SENSOR_ICON = 2
 
 # For sensors with delivering and delivered statuses
 SHIPPERS = [
+    "aliexpress",
     "amazon",
     "capost",
     "dhl",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1363,3 +1363,39 @@ def mock_imap_list_result_error(mock_imap):
         lines=[b"Could not list folders"],
     )
     return mock_imap
+
+
+@pytest.fixture
+def mock_imap_aliexpress_delivered(mock_imap):
+    """Mock IMAP search with AliExpress delivered email (2026 format)."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/aliexpress_delivered.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_aliexpress_with_local_carrier(mock_imap):
+    """Mock IMAP search with AliExpress with-local-carrier email (2026 format)."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/aliexpress_with_local_carrier.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_aliexpress_order_shipped(mock_imap):
+    """Mock IMAP search with AliExpress order-shipped email (2026 format)."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/aliexpress_order_shipped.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -43,7 +43,9 @@ async def test_ups_delivered_class(hass, mock_imap_ups_delivered):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_ups_delivered,
             "today",
@@ -143,7 +145,9 @@ async def test_usps_delivered_class(hass, mock_imap_usps_delivered_individual):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_usps_delivered_individual,
             "today",
@@ -163,7 +167,9 @@ async def test_usps_exception_class(hass, mock_imap_usps_exception):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_usps_exception,
             "today",

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1,5 +1,6 @@
 """Tests for generic shipper utilities."""
 
+import re
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,8 +8,10 @@ import pytest
 
 from custom_components.mail_and_packages.const import (
     ATTR_COUNT,
+    ATTR_SUBJECT,
     ATTR_TRACKING,
     CONF_FORWARDING_HEADER,
+    SENSOR_DATA,
 )
 from custom_components.mail_and_packages.shippers import generic
 from custom_components.mail_and_packages.shippers.generic import GenericShipper
@@ -40,9 +43,7 @@ async def test_ups_delivered_class(hass, mock_imap_ups_delivered):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_ups_delivered,
             "today",
@@ -142,9 +143,7 @@ async def test_usps_delivered_class(hass, mock_imap_usps_delivered_individual):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_usps_delivered_individual,
             "today",
@@ -164,9 +163,7 @@ async def test_usps_exception_class(hass, mock_imap_usps_exception):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_usps_exception,
             "today",
@@ -1244,3 +1241,108 @@ async def test_purolator_delivering_alternate_subject(hass):
         result = await shipper.process(mock_account, "today", "purolator_delivering")
         assert result[ATTR_COUNT] == 1
         assert result[ATTR_TRACKING] == ["BVH001683614"]
+
+
+@pytest.mark.asyncio
+async def test_aliexpress_delivered_2026_format(hass, mock_imap_aliexpress_delivered):
+    """Test AliExpress delivered email parsing (2026 subject format)."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+
+    result = await shipper.process(
+        mock_imap_aliexpress_delivered,
+        "today",
+        "aliexpress_delivered",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["JY26CAA0D000551012"]
+
+
+@pytest.mark.asyncio
+async def test_aliexpress_with_local_carrier_2026_format(
+    hass, mock_imap_aliexpress_with_local_carrier
+):
+    """Test AliExpress with-local-carrier email parsing (2026 subject format)."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+
+    result = await shipper.process(
+        mock_imap_aliexpress_with_local_carrier,
+        "today",
+        "aliexpress_delivering",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["JY26CAA0D000551012"]
+
+
+@pytest.mark.asyncio
+async def test_aliexpress_order_shipped_2026_format(
+    hass, mock_imap_aliexpress_order_shipped
+):
+    """Test AliExpress order-shipped email parsing (2026 subject format)."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+
+    result = await shipper.process(
+        mock_imap_aliexpress_order_shipped,
+        "today",
+        "aliexpress_delivering",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert len(result[ATTR_TRACKING]) == 1
+
+
+@pytest.mark.parametrize(
+    ("subject", "expected_sensor"),
+    [
+        ("Order 8211968327931234: order shipped", "aliexpress_delivering"),
+        ("Order 8211968327931234: collected by the carrier", "aliexpress_delivering"),
+        (
+            "Package JY26CAA0D000551012: left the departure region",
+            "aliexpress_delivering",
+        ),
+        ("Package JY26CAA0D000551012: at customs", "aliexpress_delivering"),
+        ("Package JY26CAA0D000551012 has cleared customs", "aliexpress_delivering"),
+        ("Package JY26CAA0D000551012: in your country/region", "aliexpress_delivering"),
+        ("Package HM0000010001198611: in local transit", "aliexpress_delivering"),
+        ("Package JY26CAA0D000551012: with local carrier", "aliexpress_delivering"),
+        ("Package JY26CAA0D000551012 has been delivered", "aliexpress_delivered"),
+        # Non-shipping notifications from the same sender must not match
+        ("Order 8211968327931234: order confirmed", None),
+        ("Order 8211968327931234: awaiting confirmation", None),
+        ("Order 8211968327931234: how did it go?", None),
+        ("Your delayed delivery coupon code", None),
+    ],
+)
+def test_aliexpress_2026_subject_patterns(subject, expected_sensor):
+    """Each real 2026 AliExpress subject maps to exactly one sensor (or none)."""
+    matched = [
+        sensor
+        for sensor in ("aliexpress_delivered", "aliexpress_delivering")
+        if any(
+            expected.lower() in subject.lower()
+            for expected in SENSOR_DATA[sensor][ATTR_SUBJECT]
+        )
+    ]
+    if expected_sensor is None:
+        assert matched == []
+    else:
+        assert matched == [expected_sensor]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # 2026 package IDs (letters+digits, 16-18 chars)
+        ("Package JY26CAA0D000551012 has been delivered", "JY26CAA0D000551012"),
+        ("Package HM0000010001198611: in local transit", "HM0000010001198611"),
+        ("Package AP00823271816356: at customs", "AP00823271816356"),
+        # UPU S10 format (pre-existing) still matches
+        ("Sendung LP123456789DE zugestellt", "LP123456789DE"),
+        # Plain 13-digit numeric (pre-existing) still matches
+        ("tracking 1234567890123 status", "1234567890123"),
+    ],
+)
+def test_aliexpress_tracking_pattern(text, expected):
+    """The AliExpress tracking pattern extracts old and new tracking formats."""
+    pattern = SENSOR_DATA["aliexpress_tracking"]["pattern"][0]
+    match = re.search(pattern, text)
+    assert match is not None
+    assert match.group(0) == expected

--- a/tests/test_emails/aliexpress_delivered.eml
+++ b/tests/test_emails/aliexpress_delivered.eml
@@ -1,0 +1,43 @@
+Delivered-To: redacted@gmail.com
+Received: from us-fbcw-206.mail.aliexpress.com (us-fbcw-206.mail.aliexpress.com. [47.90.207.206])
+        by mx.google.com with ESMTPS id abc123def456
+        for <redacted@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 02 Jul 2026 04:40:56 -0700 (PDT)
+Return-Path: <transaction@notice.aliexpress.com>
+From: AliExpress <transaction@notice.aliexpress.com>
+To: redacted@gmail.com
+Subject: Package JY26CAA0D000551012 has been delivered
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <1234567890.123456789.1783424456789@notice.aliexpress.com>
+Date: Thu, 2 Jul 2026 11:40:56 +0000 (UTC)
+
+<!doctype html>
+<html xmlns=3D"http://www.w3.org/1999/xhtml">
+  <head>
+    <title>AliExpress</title>
+  </head>
+  <body style=3D"word-spacing:normal;background-color:#F5F5F5;">
+    <div style=3D"display:none;font-size:1px;">Hope you enjoy your new purc=
+hase</div>
+    <div style=3D"background-color:#F5F5F5;">
+      <h1 style=3D"font-family:Roboto;font-size:24px;">Package delivered</=
+h1>
+      <p style=3D"font-family:Roboto;font-size:14px;">Hi John Doe,</p>
+      <p style=3D"font-family:Roboto;font-size:14px;">Your package JY26CAA=
+0D000551012 has been successfully delivered! Please let us know that you'v=
+e received your package by clicking the button below. We hope you enjoy yo=
+ur new purchase!</p>
+      <a href=3D"https://www.aliexpress.com/p/order/detail.html" style=3D"=
+background:#D3031C;color:#ffffff;">Check details</a>
+      <p style=3D"font-family:Roboto;font-size:12px;">Package details</p>
+      <p style=3D"font-family:Roboto;font-size:12px;">Ship to 123 Main St.=
+ Springfield John Doe (+1) 5555555555</p>
+      <p style=3D"font-family:Roboto;font-size:10px;">Prices, deals and av=
+ailability shown in this email reflect offers at send time and are subject=
+ to change.</p>
+    </div>
+  </body>
+</html>

--- a/tests/test_emails/aliexpress_order_shipped.eml
+++ b/tests/test_emails/aliexpress_order_shipped.eml
@@ -1,0 +1,44 @@
+Delivered-To: redacted@gmail.com
+Received: from us-fbcw-206.mail.aliexpress.com (us-fbcw-206.mail.aliexpress.com. [47.90.207.206])
+        by mx.google.com with ESMTPS id abc123def458
+        for <redacted@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sat, 27 Jun 2026 17:51:43 -0700 (PDT)
+Return-Path: <transaction@notice.aliexpress.com>
+From: AliExpress <transaction@notice.aliexpress.com>
+To: redacted@gmail.com
+Subject: Order 8211968327931234: order shipped
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <1234567890.123456789.1783039903456@notice.aliexpress.com>
+Date: Sun, 28 Jun 2026 00:51:43 +0000 (UTC)
+
+<!doctype html>
+<html xmlns=3D"http://www.w3.org/1999/xhtml">
+  <head>
+    <title>AliExpress</title>
+  </head>
+  <body style=3D"word-spacing:normal;background-color:#F5F5F5;">
+    <div style=3D"display:none;font-size:1px;">Track your order</div>
+    <div style=3D"background-color:#F5F5F5;">
+      <h1 style=3D"font-family:Roboto;font-size:24px;">Track your order</h=
+1>
+      <p style=3D"font-family:Roboto;font-size:14px;">Free returns</p>
+      <p style=3D"font-family:Roboto;font-size:14px;">Hi John Doe,</p>
+      <p style=3D"font-family:Roboto;font-size:14px;">Your order 821196832=
+7931234 has shipped, and you can track its every move by clicking below.</=
+p>
+      <a href=3D"https://www.aliexpress.com/p/order/detail.html" style=3D"=
+background:#D3031C;color:#ffffff;">Track order</a>
+      <p style=3D"font-family:Roboto;font-size:12px;">Ship to 123 Main St.=
+ Springfield John Doe (+1) 5555555555</p>
+      <p style=3D"font-family:Roboto;font-size:10px;">Your package's timel=
+y arrival is our priority. We're closely tracking its progress for you.</p=
+>
+      <p style=3D"font-family:Roboto;font-size:10px;">Prices, deals and av=
+ailability shown in this email reflect offers at send time and are subject=
+ to change.</p>
+    </div>
+  </body>
+</html>

--- a/tests/test_emails/aliexpress_with_local_carrier.eml
+++ b/tests/test_emails/aliexpress_with_local_carrier.eml
@@ -1,0 +1,43 @@
+Delivered-To: redacted@gmail.com
+Received: from us-fbcw-206.mail.aliexpress.com (us-fbcw-206.mail.aliexpress.com. [47.90.207.206])
+        by mx.google.com with ESMTPS id abc123def457
+        for <redacted@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 01 Jul 2026 02:10:20 -0700 (PDT)
+Return-Path: <transaction@notice.aliexpress.com>
+From: AliExpress <transaction@notice.aliexpress.com>
+To: redacted@gmail.com
+Subject: Package JY26CAA0D000551012: with local carrier
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <1234567890.123456789.1783329020123@notice.aliexpress.com>
+Date: Wed, 1 Jul 2026 09:10:20 +0000 (UTC)
+
+<!doctype html>
+<html xmlns=3D"http://www.w3.org/1999/xhtml">
+  <head>
+    <title>AliExpress</title>
+  </head>
+  <body style=3D"word-spacing:normal;background-color:#F5F5F5;">
+    <div style=3D"display:none;font-size:1px;">Track shipping status insid=
+e</div>
+    <div style=3D"background-color:#F5F5F5;">
+      <h1 style=3D"font-family:Roboto;font-size:24px;">Collected by local =
+carrier</h1>
+      <p style=3D"font-family:Roboto;font-size:14px;">Hi John Doe,</p>
+      <p style=3D"font-family:Roboto;font-size:14px;">Your package JY26CAA=
+0D000551012 has been collected by the local carrier in the destination cou=
+ntry/region. It is now heading to the final delivery center. Track below a=
+nd get ready to welcome your purchase!</p>
+      <a href=3D"https://www.aliexpress.com/p/order/detail.html" style=3D"=
+background:#D3031C;color:#ffffff;">Track delivery</a>
+      <p style=3D"font-family:Roboto;font-size:12px;">Package details</p>
+      <p style=3D"font-family:Roboto;font-size:12px;">Ship to 123 Main St.=
+ Springfield John Doe (+1) 5555555555</p>
+      <p style=3D"font-family:Roboto;font-size:10px;">Prices, deals and av=
+ailability shown in this email reflect offers at send time and are subject=
+ to change.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## What this fixes

AliExpress transactional notifications from `transaction@notice.aliexpress.com` currently use per-status subject lines that the existing `aliexpress_*` patterns (added in #1220) don't match, so for accounts receiving this format no shipping emails are counted at all. Observed subjects over the last 12 months (real inbox, ~200 threads/yr):

- `Order <16-digit N>: order shipped` / `collected by the carrier`
- `Package <ID>: left the departure region` / `at customs` / `has cleared customs` / `in your country/region` / `in local transit` / `with local carrier`
- `Package <ID> has been delivered`

where `<ID>` looks like `JY26CAA0D000551012`, `HM0000010001198611`, or `AP00823271816356` (two letters + 14–16 alphanumerics) — not matched by the current tracking pattern either.

## Changes

- **`aliexpress_delivered`**: add `"has been delivered"` subject (the existing body term `"delivered"` is present in these emails' bodies, verified against real messages).
- **`aliexpress_delivering`**: add the transit-status subjects above, following the existing precedent of keeping all in-transit statuses in `_delivering` (as #1220 did with `"Sendung wird versandt"`); `aliexpress_packages` stays computed. Body terms extended (`shipped`, `carrier`, `customs`, `transit`, `departure`) so the new bodies pass the client-side text filter — verified against the real email bodies. Repeat status emails for the same package dedupe via the package ID in the subject (tracking extraction searches subjects first).
- **`aliexpress_tracking`**: add a `[A-Z]{2}[0-9][0-9A-Z]{13,15}` alternative for the current package-ID format; existing alternatives kept.
- **`SHIPPERS`**: add `"aliexpress"` — it was missing from the list, so `coordinator.py`'s in-transit aggregation skipped AliExpress counts entirely.
- **Tests/fixtures**: three sanitized real emails (delivered / with-local-carrier / order-shipped) under `tests/test_emails/`, exercised end-to-end through `GenericShipper.process()` (only the IMAP search mocked), plus parametrized subject-mapping tests covering the full observed corpus — including negatives from the same sender that must not match (`order confirmed`, `awaiting confirmation`, `how did it go?`, promo mails) — and tracking-pattern tests for old + new formats.

All existing German/English patterns are kept as-is; the changes are purely additive. Full suite passes (606 tests, coverage 99.9%), black + ruff clean.

Happy to adjust scope or split the `SHIPPERS` fix into its own PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4JNtf2gPw1jGNjtFy16HF