### PR TITLE
fix(config): skip oauth prompt on reconfigure if details unchanged

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -1212,6 +1212,16 @@ class MailAndPackagesFlowHandler(
             auth_type = self._data.get(CONF_AUTH_TYPE, AUTH_TYPE_PASSWORD)
 
             if auth_type != AUTH_TYPE_PASSWORD:
+                if (
+                    self._entry
+                    and self._entry.data.get(CONF_AUTH_TYPE) == auth_type
+                    and self._entry.data.get(CONF_HOST) == self._data.get(CONF_HOST)
+                    and self._entry.data.get(CONF_USERNAME)
+                    == self._data.get(CONF_USERNAME)
+                    and "token" in self._data
+                ):
+                    return await self.async_step_reconfig_2()
+
                 self._data[CONF_VERIFY_SSL] = True
                 self.hass.data.setdefault(DOMAIN, {})
                 self.hass.data[DOMAIN]["oauth_provider"] = auth_type

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7640,6 +7640,60 @@ async def test_oauth_reconfig_flow_selection(hass, mock_imap_no_email, integrati
 
 
 @pytest.mark.asyncio
+async def test_oauth_reconfig_flow_skip_oauth(hass, mock_imap_no_email, integration):
+    """Test that reconfigure flow skips OAuth step when details are unchanged."""
+    entry = integration
+    # Update the entry with OAuth token and type to mock an existing OAuth setup
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            "auth_type": "oauth2_google",
+            "token": {"access_token": "fake_token"},
+            "host": "imap.test.email",
+            "username": "test@test.email",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure"
+
+    # Select google oauth (unchanged)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"auth_type": "oauth2_google"},
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfig_imap"
+
+    # Configure IMAP with the exact same host/username (unchanged)
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.AbstractOAuth2FlowHandler.async_step_pick_implementation"
+    ) as mock_pick:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "imap.test.email",
+                "port": 993,
+                "username": "test@test.email",
+                "imap_security": "SSL",
+            },
+        )
+        # Should not call async_step_pick_implementation and should go to reconfig_2
+        assert mock_pick.call_count == 0
+        assert result["type"] == "form"
+        assert result["step_id"] == "reconfig_2"
+
+
+@pytest.mark.asyncio
 async def test_validate_login_oauth(hass):
     """Test _validate_login with OAuth2."""
     user_input = {"auth_type": "oauth2_google"}


### PR DESCRIPTION
## Proposed change

When using Gmail or Microsoft OAuth for IMAP access, opening the integration's Configure/Options flow triggered a full re-authentication against the OAuth provider every time (including the "Google hasn't verified this app" interstitial warning) rather than silently reusing the previously granted token. 

This PR modifies the reconfiguration flow in `config_flow.py` (`async_step_reconfig_imap`) to check if the authentication type, host, and username remain unchanged, and if a token already exists in the config entry data. If they match and the token exists, it bypasses the OAuth provider pick step (`async_step_pick_implementation`) and proceeds directly to step 2 of the reconfiguration flow (`async_step_reconfig_2`).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1323
- This PR is related to issue:
