### PR TITLE
fix(config): retrieve and refresh oauth token in step 2

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -493,6 +493,7 @@ async def _get_schema_step_2(
     user_input: list,
     default_dict: list,
     hass: HomeAssistant,
+    entry: config_entries.ConfigEntry | None = None,
 ) -> Any:
     """Get a schema using the default_dict as a backup."""
     if user_input is None:
@@ -502,6 +503,31 @@ async def _get_schema_step_2(
         """Get default value for key."""
         return user_input.get(key, default_dict.get(key, fallback_default))
 
+    oauth_token = None
+    if entry:
+        try:
+            implementation = (
+                await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                    hass,
+                    entry,
+                )
+            )
+            session = config_entry_oauth2_flow.OAuth2Session(
+                hass,
+                entry,
+                implementation,
+            )
+            await session.async_ensure_token_valid()
+            oauth_token = session.token.get("access_token")
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Error refreshing OAuth token: %s", err)
+
+    if not oauth_token:
+        if "token" in data and isinstance(data["token"], dict):
+            oauth_token = data["token"].get("access_token")
+        else:
+            oauth_token = data.get("access_token")
+
     mailboxes = await _get_mailboxes(
         hass,
         data[CONF_HOST],
@@ -510,7 +536,7 @@ async def _get_schema_step_2(
         data.get(CONF_PASSWORD, ""),
         data[CONF_IMAP_SECURITY],
         data[CONF_VERIFY_SSL],
-        data.get("token", {}).get("access_token"),
+        oauth_token,
     )
 
     default_folder = _get_default(CONF_FOLDER)
@@ -1071,6 +1097,7 @@ class MailAndPackagesFlowHandler(
                 user_input,
                 defaults,
                 self.hass,
+                getattr(self, "_entry", None),
             ),
             errors=self._errors,
         )
@@ -1348,7 +1375,7 @@ class MailAndPackagesOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=await _get_schema_step_2(
-                self._data, user_input, self._data, self.hass
+                self._data, user_input, self._data, self.hass, self._entry
             ),
             errors=self._errors,
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8001,3 +8001,87 @@ async def test_options_flow_init_reads_merged_data_and_options(hass, integration
     handler = MailAndPackagesOptionsFlow(entry)
     # _data must contain CONF_FOLDER from options, not just IMAP keys from data
     assert handler._data.get(CONF_FOLDER) == "TestFolder"
+
+
+@pytest.mark.asyncio
+async def test_get_schema_step_2_oauth_token_sources(hass):
+    """Test that _get_schema_step_2 extracts oauth token from various sources correctly."""
+    # Mock _get_mailboxes to inspect the token argument
+    with patch(
+        "custom_components.mail_and_packages.config_flow._get_mailboxes",
+        AsyncMock(return_value=["INBOX"]),
+    ) as mock_get_mailboxes:
+        # Case 1: Flat token (e.g. from initial config flow)
+        data = {
+            "host": "imap.test.email",
+            "port": 993,
+            "username": "test@test.email",
+            "imap_security": "SSL",
+            "verify_ssl": True,
+            "access_token": "flat_access_token",
+        }
+        await _get_schema_step_2(data, None, {}, hass)
+        mock_get_mailboxes.assert_called_with(
+            hass,
+            "imap.test.email",
+            993,
+            "test@test.email",
+            "",
+            "SSL",
+            True,
+            "flat_access_token",
+        )
+
+        mock_get_mailboxes.reset_mock()
+
+        # Case 2: Nested token (e.g. stored in config entry data)
+        data = {
+            "host": "imap.test.email",
+            "port": 993,
+            "username": "test@test.email",
+            "imap_security": "SSL",
+            "verify_ssl": True,
+            "token": {"access_token": "nested_access_token"},
+        }
+        await _get_schema_step_2(data, None, {}, hass)
+        mock_get_mailboxes.assert_called_with(
+            hass,
+            "imap.test.email",
+            993,
+            "test@test.email",
+            "",
+            "SSL",
+            True,
+            "nested_access_token",
+        )
+
+        mock_get_mailboxes.reset_mock()
+
+        # Case 3: Token refresh from ConfigEntry (e.g. in OptionsFlow)
+        mock_entry = MagicMock()
+        mock_session = MagicMock()
+        mock_session.async_ensure_token_valid = AsyncMock()
+        mock_session.token = {"access_token": "refreshed_access_token"}
+
+        with (
+            patch(
+                "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+                AsyncMock(),
+            ),
+            patch(
+                "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session",
+                return_value=mock_session,
+            ),
+        ):
+            await _get_schema_step_2(data, None, {}, hass, entry=mock_entry)
+            mock_session.async_ensure_token_valid.assert_called_once()
+            mock_get_mailboxes.assert_called_with(
+                hass,
+                "imap.test.email",
+                993,
+                "test@test.email",
+                "",
+                "SSL",
+                True,
+                "refreshed_access_token",
+            )


### PR DESCRIPTION
## Proposed change

This PR resolves upstream issue #1327 where the **Mail Folder** input/selection field was completely missing from the Step 2 configuration form during Gmail/OAuth setup or Options configuration.

### Cause of the issue:
1. **Initial Setup (Config Flow)**: After the Google OAuth2 login flow completes, `async_oauth_create_entry` receives the token dictionary and updates `self._data` via `self._data.update(data)`. This places the OAuth keys (such as `access_token`) flat at the root of `self._data`. In Step 2, `_get_schema_step_2` attempted to retrieve the token via `data.get("token", {}).get("access_token")`, which evaluated to `None`. This caused the IMAP validation logic to connect with an empty password, failing with `Unable to connect`.
2. **Options Flow**: The token dict is nested under the `"token"` key in the config entry data, but if the token has expired, accessing `access_token` directly without refreshing caused authentication failure.
3. **Result**: In both cases, because authentication failed, `_get_mailboxes` returned `[]`. Since the mailbox list was empty, the `multi_folder_select` schema element had no choices to render, resulting in the control disappearing from the configuration card.

### Solution implemented:
- Updated `_get_schema_step_2` to accept the optional config `entry` parameter.
- Implemented a robust token resolver that:
  - If a config entry is present (e.g. options flow), refreshes/verifies the token using `config_entry_oauth2_flow.OAuth2Session`.
  - Fallback checks both the nested `data["token"]["access_token"]` and the flat `data["access_token"]` structures.
- Updated Calls in `_show_config_2` and `_show_options_2` to pass `self._entry` (via `getattr(self, "_entry", None)` in config flow).
- Added `test_get_schema_step_2_oauth_token_sources` to test suite to ensure all three scenarios are fully verified.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1327
- This PR is related to issue:
