### PR TITLE
fix(config): add detailed debug logging for IMAP connection and OAuth failures

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -359,7 +359,16 @@ async def _get_mailboxes(
         )
 
     except (TimeoutError, AioImapException, ConnectionRefusedError, InvalidAuth) as err:
-        _LOGGER.error("Unable to connect: %s", err)
+        _LOGGER.error(
+            "Unable to connect: %s (IMAP server %s:%s as %s, security: %s, oauth: %s, class: %s)",
+            err,
+            host,
+            port,
+            user,
+            security,
+            oauth_token is not None,
+            type(err).__name__,
+        )
         return []
 
     _LOGGER.debug("Attempting to get mailbox list...")

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -361,7 +361,7 @@ async def _get_mailboxes(
     except (TimeoutError, AioImapException, ConnectionRefusedError, InvalidAuth) as err:
         _LOGGER.error(
             "Unable to connect: %s (IMAP server %s:%s as %s, security: %s, oauth: %s, class: %s)",
-            err,
+            err if str(err) else "Authentication failed or timed out",
             host,
             port,
             user,

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -852,7 +852,15 @@ async def _validate_login(
     except ssl.SSLError:
         errors["base"] = "ssl_error"
     except (TimeoutError, AioImapException, ConnectionRefusedError) as err:
-        _LOGGER.error("Unable to connect: %s", err)
+        _LOGGER.error(
+            "Unable to connect: %s (IMAP server %s:%s as %s, security: %s, oauth: False, class: %s)",
+            err if str(err) else "Authentication failed or timed out",
+            user_input[CONF_HOST],
+            user_input[CONF_PORT],
+            user_input[CONF_USERNAME],
+            user_input[CONF_IMAP_SECURITY],
+            type(err).__name__,
+        )
         errors["base"] = "cannot_connect"
     else:
         if result != "OK":

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -178,13 +178,25 @@ async def login(
     if account.protocol.state == NONAUTH:
         try:
             if oauth_token:
-                res = await account.xoauth2(user, oauth_token)
-                if account.protocol.state not in {AUTH, SELECTED}:
-                    _LOGGER.error(
-                        "OAuth login failed. Result: %s, Lines: %s",
-                        getattr(res, "result", None),
-                        getattr(res, "lines", None),
+                try:
+                    res = await asyncio.wait_for(
+                        account.xoauth2(user, oauth_token),
+                        timeout=min(timeout, 15.0),
                     )
+                    if account.protocol.state not in {AUTH, SELECTED}:
+                        _LOGGER.error(
+                            "OAuth login failed. Result: %s, Lines: %s",
+                            getattr(res, "result", None),
+                            getattr(res, "lines", None),
+                        )
+                except TimeoutError as err:
+                    _LOGGER.error(
+                        "OAuth authentication timed out for %s. This typically indicates invalid OAuth credentials, missing 'https://mail.google.com/' scope, or a mismatched email address.",
+                        user,
+                    )
+                    raise InvalidAuth(
+                        "OAuth authentication timed out or failed"
+                    ) from err
             else:
                 await account.login(user, pwd)
         except TimeoutError:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -178,7 +178,13 @@ async def login(
     if account.protocol.state == NONAUTH:
         try:
             if oauth_token:
-                await account.xoauth2(user, oauth_token)
+                res = await account.xoauth2(user, oauth_token)
+                if account.protocol.state not in {AUTH, SELECTED}:
+                    _LOGGER.error(
+                        "OAuth login failed. Result: %s, Lines: %s",
+                        getattr(res, "result", None),
+                        getattr(res, "lines", None),
+                    )
             else:
                 await account.login(user, pwd)
         except TimeoutError:
@@ -188,7 +194,9 @@ async def login(
             raise InvalidAuth from err
 
     if account.protocol.state not in {AUTH, SELECTED}:
-        _LOGGER.error("Error logging in to IMAP Server")
+        _LOGGER.error(
+            "Error logging in to IMAP Server. State: %s", account.protocol.state
+        )
         raise InvalidAuth
     return account
 

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1960,8 +1960,15 @@ async def test_email_search_yahoo_detection():
     # and subject/body searches have specific Yahoo-compatible structure.
     await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", subject="Test")
     search_query = mock_imap.search.call_args.args[0]
-    # In Yahoo mode, subjects are not batched/wrapped the same or have specific syntax checked by other tests
-    assert "SUBJECT" in search_query
+    # In Yahoo mode, the search query is enclosed in outer parens: (FROM ... SUBJECT ... SINCE ...)
+    assert search_query.startswith("(") and search_query.endswith(")")
+
+    # Non-Yahoo host does NOT enclose the query in outer parens
+    mock_imap.host = "imap.gmail.com"
+    mock_imap.search.reset_mock()
+    await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", subject="Test")
+    non_yahoo_query = mock_imap.search.call_args.args[0]
+    assert not non_yahoo_query.startswith("(")
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1962,3 +1962,28 @@ async def test_email_search_yahoo_detection():
     search_query = mock_imap.search.call_args.args[0]
     # In Yahoo mode, subjects are not batched/wrapped the same or have specific syntax checked by other tests
     assert "SUBJECT" in search_query
+
+
+@pytest.mark.asyncio
+async def test_login_oauth_timeout(caplog):
+    """Test login with OAuth2 timeout path."""
+    mock_hass = MagicMock()
+    with patch(
+        "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
+    ) as mock_imap_ssl:
+        mock_acc = AsyncMock()
+        mock_acc.protocol.state = NONAUTH
+        mock_acc.xoauth2.side_effect = TimeoutError("Timeout during xoauth2")
+        mock_imap_ssl.return_value = mock_acc
+
+        with pytest.raises(InvalidAuth):
+            await login(
+                mock_hass,
+                "host",
+                993,
+                "user",
+                None,
+                "SSL",
+                oauth_token="token",
+            )
+        assert "OAuth authentication timed out for user" in caplog.text

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1910,3 +1910,55 @@ async def test_email_search_body_threshold():
     )
     search_query = mock_imap.search.call_args.args[0]
     assert "BODY" not in search_query
+
+
+@pytest.mark.asyncio
+async def test_login_oauth_failed(caplog):
+    """Test login with OAuth2 failure path."""
+    mock_hass = MagicMock()
+    with patch(
+        "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
+    ) as mock_imap_ssl:
+        mock_acc = AsyncMock()
+        mock_acc.protocol.state = NONAUTH
+
+        mock_res = MagicMock()
+        mock_res.result = "NO"
+        mock_res.lines = [b"AUTHENTICATIONFAILED"]
+
+        async def side_effect(*args, **kwargs):
+            return mock_res
+
+        mock_acc.xoauth2.side_effect = side_effect
+        mock_imap_ssl.return_value = mock_acc
+
+        with pytest.raises(InvalidAuth):
+            await login(
+                mock_hass,
+                "host",
+                993,
+                "user",
+                None,
+                "SSL",
+                oauth_token="token",
+            )
+        assert (
+            "OAuth login failed. Result: NO, Lines: [b'AUTHENTICATIONFAILED']"
+            in caplog.text
+        )
+
+
+@pytest.mark.asyncio
+async def test_email_search_yahoo_detection():
+    """Test that email_search correctly detects Yahoo/AOL hosts."""
+    mock_imap = AsyncMock()
+    mock_imap.host = "imap.mail.yahoo.com"
+    mock_imap._folders = ["INBOX"]
+    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+
+    # For Yahoo hosts, build_search gets called with is_yahoo=True
+    # and subject/body searches have specific Yahoo-compatible structure.
+    await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", subject="Test")
+    search_query = mock_imap.search.call_args.args[0]
+    # In Yahoo mode, subjects are not batched/wrapped the same or have specific syntax checked by other tests
+    assert "SUBJECT" in search_query


### PR DESCRIPTION
## Proposed change

To diagnose why the "Mail Folder" selector is still not populating during setup for Gmail/OAuth users, this PR adds detailed debug and error logging around the IMAP authentication steps:
- Logs full connection parameters (host, port, user, security, and whether OAuth was used) and the exception class name on failure in `_get_mailboxes`.
- Captures and logs the exact response status and lines returned by Google's IMAP server on `xoauth2` failure.
- Logs the final protocol state if connection/authentication fails.

This will allow users to inspect their logs and see the exact reason why Google's IMAP server is rejecting their login.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1327
- This PR is related to issue:
