### PR TITLE
feat(shopify): add Shopify shipper for standard order-notification templates

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -928,6 +928,33 @@ SENSOR_DATA = {
         "subject": ["delivery is delayed"],
     },
     "walmart_tracking": {"pattern": [r"\b#?[0-9]{7}-[0-9]{7,8}\b"]},
+    # Shopify (standard order-notification templates). Sender varies per
+    # store; these cover Shopify's shared sending infrastructure. Stores
+    # sending from their own domain need their sender added here.
+    "shopify_delivered": {
+        "email": [
+            "t.shopifyemail.com",
+            "no-reply@parcelpanel.net",
+        ],
+        "subject": ["has been delivered"],
+    },
+    "shopify_delivering": {
+        "email": [
+            "t.shopifyemail.com",
+            "no-reply@parcelpanel.net",
+        ],
+        "subject": ["is out for delivery"],
+    },
+    "shopify_packages": {
+        "email": [
+            "t.shopifyemail.com",
+            "no-reply@parcelpanel.net",
+        ],
+        "subject": ["is on the way"],
+    },
+    "shopify_tracking": {
+        "pattern": ["shipment from order #?([A-Za-z0-9()\\-]+)"],
+    },
     # BuildingLink
     "buildinglink_delivered": {
         "email": ["notify@buildinglink.com"],
@@ -1688,6 +1715,25 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:archive-alert",
         key="walmart_exception",
     ),
+    # Shopify
+    "shopify_delivered": SensorEntityDescription(
+        name="Mail Shopify Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="shopify_delivered",
+    ),
+    "shopify_delivering": SensorEntityDescription(
+        name="Mail Shopify Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="shopify_delivering",
+    ),
+    "shopify_packages": SensorEntityDescription(
+        name="Mail Shopify Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="shopify_packages",
+    ),
     # BuildingLink
     "buildinglink_delivered": SensorEntityDescription(
         name="Mail BuildingLink Delivered",
@@ -2043,6 +2089,7 @@ SHIPPERS = [
     "postnord",
     "bring",
     "db_schenker",
+    "shopify",
 ]
 
 # Authentication types

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -2054,6 +2054,7 @@ SENSOR_ICON = 2
 # the carrier tracking number.
 MARKETPLACE_CARRIER_TRACKING = {
     "etsy": r"tracking number:?\s*#?([A-Za-z0-9]{8,34})",
+    "shopify": r"tracking number:?\s*#?([A-Za-z0-9]{8,34})",
 }
 
 # For sensors with delivering and delivered statuses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1447,3 +1447,27 @@ def mock_imap_etsy_on_the_way(mock_imap):
     )
     mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
     return mock_imap
+
+
+@pytest.fixture
+def mock_imap_shopify_on_the_way(mock_imap):
+    """Mock IMAP search with a standard Shopify on-the-way email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/shopify_on_the_way.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_shopify_delivered(mock_imap):
+    """Mock IMAP search with a standard Shopify delivered email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/shopify_delivered.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1841,3 +1841,32 @@ def test_shopify_tracking_pattern(text, expected):
     match = re.search(pattern, text)
     assert match is not None
     assert match.group(1) == expected
+
+
+@pytest.mark.asyncio
+async def test_shopify_carrier_tracking_extraction(hass, mock_imap_shopify_on_the_way):
+    """The carrier tracking number embedded in a Shopify email is mapped."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    result = await shipper.process(
+        mock_imap_shopify_on_the_way, "today", "shopify_packages"
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result["shopify_carrier_tracking"] == {"MC1605": "9443743716845537"}
+
+
+@pytest.mark.asyncio
+async def test_shopify_no_carrier_tracking_is_noop(hass, mock_imap):
+    """Shopify emails without a carrier tracking number map nothing."""
+    email_file = await hass.async_add_executor_job(
+        Path("tests/test_emails/shopify_on_the_way.eml").read_text
+    )
+    email_file = email_file.replace(
+        "Canada post tracking number: 9443743716845537", "Track your shipment"
+    )
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    result = await shipper.process(mock_imap, "today", "shopify_packages")
+    assert result[ATTR_COUNT] == 1
+    assert "shopify_carrier_tracking" not in result

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -45,9 +45,7 @@ async def test_ups_delivered_class(hass, mock_imap_ups_delivered):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_ups_delivered,
             "today",
@@ -147,9 +145,7 @@ async def test_usps_delivered_class(hass, mock_imap_usps_delivered_individual):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_usps_delivered_individual,
             "today",
@@ -169,9 +165,7 @@ async def test_usps_exception_class(hass, mock_imap_usps_exception):
         },
     )
 
-    with (
-        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
-    ):
+    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
         result = await shipper.process(
             mock_imap_usps_exception,
             "today",
@@ -1357,6 +1351,34 @@ async def test_etsy_on_the_way_class(hass, mock_imap_etsy_on_the_way):
     assert result[ATTR_TRACKING] == ["3869977574"]
 
 
+@pytest.mark.asyncio
+async def test_shopify_on_the_way_class(hass, mock_imap_shopify_on_the_way):
+    """Test standard Shopify on-the-way email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+
+    result = await shipper.process(
+        mock_imap_shopify_on_the_way,
+        "today",
+        "shopify_packages",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["MC1605"]
+
+
+@pytest.mark.asyncio
+async def test_shopify_delivered_class(hass, mock_imap_shopify_delivered):
+    """Test standard Shopify delivered email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+
+    result = await shipper.process(
+        mock_imap_shopify_delivered,
+        "today",
+        "shopify_delivered",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["53495"]
+
+
 @pytest.mark.parametrize(
     ("subject", "expected_sensor"),
     [
@@ -1522,6 +1544,36 @@ def test_etsy_subject_patterns(subject, expected_sensor):
     matched = [
         sensor
         for sensor in ("etsy_delivered", "etsy_delivering")
+        if any(
+            expected.lower() in subject.lower()
+            for expected in SENSOR_DATA[sensor][ATTR_SUBJECT]
+        )
+    ]
+    if expected_sensor is None:
+        assert matched == []
+    else:
+        assert matched == [expected_sensor]
+
+
+@pytest.mark.parametrize(
+    ("subject", "expected_sensor"),
+    [
+        ("A shipment from order MC1605 is on the way", "shopify_packages"),
+        ("A shipment from order #24498 is on the way", "shopify_packages"),
+        ("A shipment from order BAK(2)-563319 is on the way", "shopify_packages"),
+        ("A shipment from order MC1605 is out for delivery", "shopify_delivering"),
+        ("A shipment from order #53495 has been delivered", "shopify_delivered"),
+        # Non-shipping mail from Shopify's shared senders must not match
+        ("Order #77220 confirmed", None),
+        ("Your GreenPan cart? Saved ✅ over on Shop.", None),
+        ("Customer account confirmation", None),
+    ],
+)
+def test_shopify_subject_patterns(subject, expected_sensor):
+    """Each standard Shopify template subject maps to exactly one sensor."""
+    matched = [
+        sensor
+        for sensor in ("shopify_delivered", "shopify_delivering", "shopify_packages")
         if any(
             expected.lower() in subject.lower()
             for expected in SENSOR_DATA[sensor][ATTR_SUBJECT]
@@ -1766,3 +1818,20 @@ async def test_collect_carrier_tracking_with_cache_and_empty_tracking(hass):
 
     assert res == {"etsy_carrier_tracking": {"3869977574": "9999888877776666"}}
     mock_cache.fetch.assert_called_once_with(b"2", "(RFC822)")
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("A shipment from order #53495 has been delivered", "53495"),
+        ("A shipment from order MC1605 is on the way", "MC1605"),
+        ("A shipment from order BAK(2)-563319 is on the way", "BAK(2)-563319"),
+        ("A shipment from order PP3024 is on the way", "PP3024"),
+    ],
+)
+def test_shopify_tracking_pattern(text, expected):
+    """The Shopify tracking pattern extracts the order id from the subject."""
+    pattern = SENSOR_DATA["shopify_tracking"]["pattern"][0]
+    match = re.search(pattern, text)
+    assert match is not None
+    assert match.group(1) == expected

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -45,7 +45,9 @@ async def test_ups_delivered_class(hass, mock_imap_ups_delivered):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_ups_delivered,
             "today",
@@ -145,7 +147,9 @@ async def test_usps_delivered_class(hass, mock_imap_usps_delivered_individual):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_usps_delivered_individual,
             "today",
@@ -165,7 +169,9 @@ async def test_usps_exception_class(hass, mock_imap_usps_exception):
         },
     )
 
-    with (patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),):
+    with (
+        patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"),
+    ):
         result = await shipper.process(
             mock_imap_usps_exception,
             "today",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -816,8 +816,8 @@ async def test_process_emails_delivered_tracking_reversed_order(hass):
     assert set(data["ups_delivered_tracking"]) == {"UPS_DELIVERED_TODAY"}
 
 
-def test_dedupe_marketplace_duplicates():
-    """Marketplace packages already counted by a carrier shipper are dropped."""
+def test_dedupe_marketplace_duplicates_etsy():
+    """Marketplace packages already counted by a carrier shipper are dropped (Etsy)."""
     data = {
         "etsy_delivering": 2,
         "etsy_delivered": 0,
@@ -843,6 +843,31 @@ def test_dedupe_marketplace_duplicates():
     # carrier side untouched; mapping consumed
     assert data["capost_delivering"] == 1
     assert "etsy_carrier_tracking" not in data
+
+
+def test_dedupe_marketplace_duplicates_shopify():
+    """Marketplace packages already counted by a carrier shipper are dropped (Shopify)."""
+    data = {
+        "shopify_delivering": 2,
+        "shopify_delivered": 0,
+        "shopify_carrier_tracking": {
+            "MC1605": "9443743716845537",
+            "PP3024": "YT2434221266046281",
+        },
+    }
+    tracking_details = {
+        "shopify_delivering": ["MC1605", "PP3024"],
+        "capost_delivering": ["9443743716845537"],
+    }
+
+    MailDataUpdateCoordinator._dedupe_marketplace_duplicates(data, tracking_details)
+
+    # MC1605's carrier number is counted by Canada Post -> dropped
+    assert data["shopify_delivering"] == 1
+    assert tracking_details["shopify_delivering"] == ["PP3024"]
+    # carrier side untouched; mapping consumed
+    assert tracking_details["capost_delivering"] == ["9443743716845537"]
+    assert "shopify_carrier_tracking" not in data
 
 
 def test_dedupe_marketplace_no_carriers_is_noop():

--- a/tests/test_emails/shopify_delivered.eml
+++ b/tests/test_emails/shopify_delivered.eml
@@ -1,0 +1,30 @@
+Delivered-To: redacted@gmail.com
+Received: from mail.parcelpanel.net (mail.parcelpanel.net. [192.0.2.81])
+        by mx.google.com with ESMTPS id shopify123abc457
+        for <redacted@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 02 Apr 2026 11:20:19 -0700 (PDT)
+Return-Path: <no-reply@parcelpanel.net>
+From: Example Store <no-reply@parcelpanel.net>
+To: redacted@gmail.com
+Subject: A shipment from order #53495 has been delivered
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <20260402182019.shopify.delivered@parcelpanel.net>
+Date: Thu, 2 Apr 2026 18:20:19 +0000
+
+<!doctype html>
+<html>
+  <body>
+    <p>Order #53495</p>
+    <h1>The last item in your order has been delivered</h1>
+    <p>Haven't received your package yet? Let us know</p>
+    <a href=3D"https://examplestore.com/orders/track">View your order</a> =
+or <a href=3D"https://examplestore.com">Visit our store</a>
+    <p>ICS tracking number: ND6EV0V3JWBEYVK1B3B7</p>
+    <p>Items in this shipment</p>
+    <p>Example Widget x1</p>
+    <p>Ship to: John Doe, 123 Main St. Springfield</p>
+  </body>
+</html>

--- a/tests/test_emails/shopify_on_the_way.eml
+++ b/tests/test_emails/shopify_on_the_way.eml
@@ -1,0 +1,31 @@
+Delivered-To: redacted@gmail.com
+Received: from mail-sor-f65.shopifyemail.com (mail-sor-f65.shopifyemail.com. [192.0.2.80])
+        by mx.google.com with ESMTPS id shopify123abc456
+        for <redacted@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Mon, 22 Sep 2025 10:59:05 -0700 (PDT)
+Return-Path: <store+57302155461@t.shopifyemail.com>
+From: Example Store <store+57302155461@t.shopifyemail.com>
+To: redacted@gmail.com
+Subject: A shipment from order MC1605 is on the way
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <20250922175905.shopify.ontheway@t.shopifyemail.com>
+Date: Mon, 22 Sep 2025 17:59:05 +0000
+
+<!doctype html>
+<html>
+  <body>
+    <p>Order MC1605</p>
+    <h1>Your order is on the way</h1>
+    <p>Your order is on the way. Track your shipment to see the delivery s=
+tatus.</p>
+    <a href=3D"https://examplestore.com/orders/track">View your order</a> =
+or <a href=3D"https://examplestore.com">Visit our store</a>
+    <p>Canada post tracking number: 9443743716845537</p>
+    <p>Items in this shipment</p>
+    <p>Example Widget x1</p>
+    <p>Ship to: John Doe, 123 Main St. Springfield</p>
+  </body>
+</html>


### PR DESCRIPTION
## Why

Shopify stores send shipping notifications using a standard template that has been stable for years — observed unchanged across six different stores in a real mailbox from 2024 through 2026:

- `A shipment from order <ID> is on the way`
- `A shipment from order <ID> is out for delivery`
- `A shipment from order <ID> has been delivered`

The sender varies per store, so nothing currently counts these. This adds a `shopify` shipper scoped to Shopify's shared sending infrastructure: `store+*@t.shopifyemail.com` (the default when a store hasn't configured its own domain — matched via IMAP FROM substring `t.shopifyemail.com`) and `no-reply@parcelpanel.net` (the widely-used ParcelPanel tracking app). Stores that send from their own domain are a documented limitation — their sender can be appended to the lists.

## Design

- **`shopify_packages` / `shopify_delivering` / `shopify_delivered`** keyed on the three template status phrases (`"is on the way"` / `"is out for delivery"` / `"has been delivered"`), sender-scoped.
- **`shopify_tracking`**: `shipment from order #?([A-Za-z0-9()\-]+)` — extracts the order id from the subject. Observed formats: `#53495`, `MC1605`, `BAK(2)-563319`, `PP3024`. The id is identical across a shipment's three status emails, so delivered deduplicates against delivering/packages regardless of which carrier the store used (bodies show Canada Post, UPS, YunExpress, ICS...).
- `"shopify"` added to `SHIPPERS`; three `SENSOR_TYPES` entries.

## Tests

Two sanitized real-email fixtures (one `t.shopifyemail.com` sender, one ParcelPanel) run end-to-end through `GenericShipper.process()` with only the IMAP search mocked; parametrized subject tests over the observed corpus including negatives from the same senders (`Order #N confirmed`, cart/marketing mail); tracking-pattern tests for all four observed order-id formats.

All changes additive; full suite passes, black + ruff clean. Running live on my instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4JNtf2gPw1jGNjtFy16HF