### PR TITLE
fix(amazon): recognize Versendet/Ankunft and multi-domain amazon_domain

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -104,7 +104,12 @@ from .utils.imap import InvalidAuth, decode_imap_utf7, login, logout
 
 ERROR_MAILBOX_FAIL = "Problem getting mailbox listing using 'INBOX' message"
 IMAP_SECURITY = ["none", "SSL"]
-AMAZON_SENSORS = ["amazon_packages", "amazon_delivered", "amazon_exception"]
+AMAZON_SENSORS = [
+    "amazon_packages",
+    "amazon_delivering",
+    "amazon_delivered",
+    "amazon_exception",
+]
 _LOGGER = logging.getLogger(__name__)
 AMAZON_EMAIL_ERROR = (
     "Amazon domain found in email: %s, this may cause errors when searching emails."

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -253,6 +253,7 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Arriving (\\w+ \\d+)",
     "Arriving (\\w+ ?\\d*)",
     "Arriving (\\w+)",
+    "Zustellung:? (heute)",
     "Zustellung:? (\\w+ \\d+) - (\\w+ \\d+)",
     "Zustellung:? (\\w+ \\d+)",
     "Zustellung:? (\\w+ ?\\d*)",

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -178,6 +178,7 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Out for delivery:",
     "Spedito:",
     "Versandt:",
+    "Versendet:",
     "In Zustellung:",
 ]
 AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
@@ -226,6 +227,7 @@ AMAZON_TIME_PATTERN = [
     "Votre date de livraison prévue est :",
     "In arrivo",
     "Zustellung:",
+    "Ankunft",
 ]
 AMAZON_TIME_PATTERN_END = [
     "Previously expected:",
@@ -251,6 +253,10 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Zustellung:? (\\w+ \\d+)",
     "Zustellung:? (\\w+ ?\\d*)",
     "Zustellung:? (\\w+)",
+    "Ankunft:? (\\w+ \\d+) - (\\w+ \\d+)",
+    "Ankunft:? (\\w+ \\d+)",
+    "Ankunft:? (\\w+ ?\\d*)",
+    "Ankunft:? (\\w+)",
     "Arriverà (\\w+ \\d+) - (\\w+ \\d+)",
     "Arriverà (\\w+ \\d+)",
     "Arriverà (\\w+ \\d*)",

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -172,14 +172,17 @@ AMAZON_SHIPMENT_TRACKING = [
     "verzending-volgen",
     "update-bestelling",
 ]
+AMAZON_DELIVERING_SUBJECT = [
+    "Out for delivery:",
+    "In Zustellung:",
+]
 AMAZON_SHIPMENT_SUBJECT = [
     "Shipped:",
     "Enviado:",
-    "Out for delivery:",
     "Spedito:",
     "Versandt:",
     "Versendet:",
-    "In Zustellung:",
+    *AMAZON_DELIVERING_SUBJECT,
 ]
 AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
 AMAZON_EMAIL = [
@@ -192,6 +195,7 @@ AMAZON_EMAIL = [
 AMAZON_PACKAGES = "amazon_packages"
 AMAZON_ORDER = "amazon_order"
 AMAZON_DELIVERED = "amazon_delivered"
+AMAZON_DELIVERING = "amazon_delivering"
 AMAZON_IMG_LIST = [
     "us-prod-temp.s3.amazonaws.com",
     "gb-prod-temp.s3.eu-west-1.amazonaws.com",
@@ -1365,6 +1369,12 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:package",
         key="amazon_packages",
     ),
+    "amazon_delivering": SensorEntityDescription(
+        name="Mail Amazon Packages Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="amazon_delivering",
+    ),
     "amazon_delivered": SensorEntityDescription(
         name="Mail Amazon Packages Delivered",
         native_unit_of_measurement="package(s)",
@@ -1895,13 +1905,19 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         key="etsy_packages",
     ),
     ###
-    # !!! Insert new sensors above these two !!!
+    # !!! Insert new sensors above these summary sensors !!!
     ###
     "zpackages_delivered": SensorEntityDescription(
         name="Mail Packages Delivered",
         native_unit_of_measurement="package(s)",
         icon="mdi:package-variant",
         key="zpackages_delivered",
+    ),
+    "zpackages_delivering": SensorEntityDescription(
+        name="Mail Packages Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="zpackages_delivering",
     ),
     "zpackages_transit": SensorEntityDescription(
         name="Mail Packages In Transit",

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -529,6 +529,8 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         # Only update if sensors were requested in initialize_data
         if "zpackages_transit" in data:
             data["zpackages_transit"] = self._sum_transit_counts(data)
+        if "zpackages_delivering" in data:
+            data["zpackages_delivering"] = self._sum_delivering_counts(data)
         if "zpackages_delivered" in data:
             data["zpackages_delivered"] = self._sum_delivered_counts(data)
 
@@ -550,6 +552,19 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             ):
                 delivered += value
         return delivered
+
+    def _sum_delivering_counts(self, data: dict) -> int:
+        """Sum out-for-delivery packages from all shippers."""
+        delivering = 0
+        for key, value in data.items():
+            if (
+                isinstance(value, int)
+                and value > 0
+                and key.endswith("_delivering")
+                and key != "zpackages_delivering"
+            ):
+                delivering += value
+        return delivering
 
     def _sum_transit_counts(self, data: dict) -> int:
         """Sum transit and exception packages from all shippers."""

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MailAndPackagesConfigEntry
 from .const import (
+    AMAZON_DELIVERING,
     AMAZON_EXCEPTION,
     AMAZON_EXCEPTION_ORDER,
     AMAZON_HUB,
@@ -178,6 +179,9 @@ class PackagesSensor(CoordinatorEntity, RestoreSensor):
         """Add Amazon specific attributes to the sensor."""
         if self.type == AMAZON_EXCEPTION:
             if order := data.get(AMAZON_EXCEPTION_ORDER, data.get(ATTR_ORDER)):
+                attr[ATTR_ORDER] = order
+        elif self.type == AMAZON_DELIVERING:
+            if order := data.get("amazon_delivering_order"):
                 attr[ATTR_ORDER] = order
         elif order := data.get(AMAZON_ORDER):
             attr[ATTR_ORDER] = order

--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -309,19 +309,24 @@ class AmazonShipper(Shipper):
         parsed_arrival = None
         if body:
             parsed_arrival = await parse_amazon_arrival_date(self.hass, body, date)
-            if parsed_arrival == ctx["today"]:
-                if order_id:
-                    ctx["packages_arriving_today"][order_id] = (
-                        ctx["packages_arriving_today"].get(order_id, 0) + 1
-                    )
-                else:
-                    ctx["deliveries_today"].append("Amazon Order")
+
+        # OFD emails received today imply delivery today, even if the body
+        # time-window parsing fails (e.g. "Zustellung heute 15:15 - 17:15").
+        if is_delivering and date == ctx["today"] and parsed_arrival is None:
+            parsed_arrival = ctx["today"]
+
+        if parsed_arrival == ctx["today"]:
+            if order_id:
+                ctx["packages_arriving_today"][order_id] = (
+                    ctx["packages_arriving_today"].get(order_id, 0) + 1
+                )
+            else:
+                ctx["deliveries_today"].append("Amazon Order")
 
         # Out-for-delivery emails count as delivering when arriving today,
-        # or when no arrival date was parsed but the email itself is from today.
+        # or when the OFD email itself arrived today.
         if is_delivering and (
-            parsed_arrival == ctx["today"]
-            or (parsed_arrival is None and date == ctx["today"])
+            parsed_arrival == ctx["today"] or date == ctx["today"]
         ):
             if order_id:
                 ctx["packages_delivering_today"][order_id] = (

--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -19,6 +19,8 @@ from custom_components.mail_and_packages import const
 from custom_components.mail_and_packages.const import (
     AMAZON_DELIVERED,
     AMAZON_DELIVERED_SUBJECT,
+    AMAZON_DELIVERING,
+    AMAZON_DELIVERING_SUBJECT,
     AMAZON_EXCEPTION,
     AMAZON_EXCEPTION_BODY,
     AMAZON_EXCEPTION_ORDER,
@@ -116,6 +118,12 @@ class AmazonShipper(Shipper):
                 AMAZON_ORDER: orders,
             }
 
+        if sensor_type == AMAZON_DELIVERING:
+            count = await self._parse_amazon_emails(
+                account, "delivering", fwds, days, domain, cache, forwarding_header
+            )
+            return {AMAZON_DELIVERING: count}
+
         if sensor_type == AMAZON_ORDER:
             result = await self._parse_amazon_emails(
                 account, "order", fwds, days, domain, cache, forwarding_header
@@ -196,15 +204,20 @@ class AmazonShipper(Shipper):
         context = {
             "today": today_date,
             "packages_arriving_today": {},
+            "packages_delivering_today": {},
             "delivered_packages": {},
             "amazon_delivered": [],
             "deliveries_today": [],
+            "delivering_today": [],
             "all_shipped_orders": set(),
             "order_pattern": order_pattern,
         }
 
         for email_id in unique_emails:
             await self._process_amazon_email(account, email_id, context, cache)
+
+        if param == "delivering":
+            return self._calculate_delivering_count(context)
 
         final_count = self._calculate_final_count(context)
 
@@ -289,6 +302,11 @@ class AmazonShipper(Shipper):
         if order_id:
             ctx["all_shipped_orders"].add(order_id)
 
+        is_delivering = any(
+            s.lower() in subject.lower() for s in AMAZON_DELIVERING_SUBJECT
+        )
+
+        parsed_arrival = None
         if body:
             parsed_arrival = await parse_amazon_arrival_date(self.hass, body, date)
             if parsed_arrival == ctx["today"]:
@@ -298,6 +316,19 @@ class AmazonShipper(Shipper):
                     )
                 else:
                     ctx["deliveries_today"].append("Amazon Order")
+
+        # Out-for-delivery emails count as delivering when arriving today,
+        # or when no arrival date was parsed but the email itself is from today.
+        if is_delivering and (
+            parsed_arrival == ctx["today"]
+            or (parsed_arrival is None and date == ctx["today"])
+        ):
+            if order_id:
+                ctx["packages_delivering_today"][order_id] = (
+                    ctx["packages_delivering_today"].get(order_id, 0) + 1
+                )
+            else:
+                ctx["delivering_today"].append("Amazon Order")
 
     def _extract_first_order_id(
         self,
@@ -327,6 +358,19 @@ class AmazonShipper(Shipper):
             delivered_count = ctx["delivered_packages"].get(order_id, 0)
             final_count += max(0, arriving_count - delivered_count)
         return final_count + len(deliveries_today)
+
+    def _calculate_delivering_count(self, ctx: dict) -> int:
+        """Calculate packages currently out for delivery today."""
+        delivering_today = [
+            item
+            for item in ctx["delivering_today"]
+            if item not in ctx["amazon_delivered"]
+        ]
+        final_count = 0
+        for order_id, delivering_count in ctx["packages_delivering_today"].items():
+            delivered_count = ctx["delivered_packages"].get(order_id, 0)
+            final_count += max(0, delivering_count - delivered_count)
+        return final_count + len(delivering_today)
 
     async def _amazon_search(
         self,
@@ -406,8 +450,11 @@ class AmazonShipper(Shipper):
             has_shipped = any(
                 s.lower() in subject.lower() for s in AMAZON_SHIPMENT_SUBJECT
             )
+            has_delivering = any(
+                s.lower() in subject.lower() for s in AMAZON_DELIVERING_SUBJECT
+            )
 
-            if has_delivered and not has_ordered and not has_shipped:
+            if has_delivered and not has_ordered and not has_shipped and not has_delivering:
                 urls = self._extract_amazon_image_urls(msg)
                 return True, urls
         return False, []

--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -119,10 +119,13 @@ class AmazonShipper(Shipper):
             }
 
         if sensor_type == AMAZON_DELIVERING:
-            count = await self._parse_amazon_emails(
+            count, orders = await self._parse_amazon_emails(
                 account, "delivering", fwds, days, domain, cache, forwarding_header
             )
-            return {AMAZON_DELIVERING: count}
+            return {
+                AMAZON_DELIVERING: count,
+                "amazon_delivering_order": orders,
+            }
 
         if sensor_type == AMAZON_ORDER:
             result = await self._parse_amazon_emails(
@@ -217,7 +220,8 @@ class AmazonShipper(Shipper):
             await self._process_amazon_email(account, email_id, context, cache)
 
         if param == "delivering":
-            return self._calculate_delivering_count(context)
+            orders = list(context["packages_delivering_today"].keys())
+            return self._calculate_delivering_count(context), orders
 
         final_count = self._calculate_final_count(context)
 

--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -329,9 +329,7 @@ class AmazonShipper(Shipper):
 
         # Out-for-delivery emails count as delivering when arriving today,
         # or when the OFD email itself arrived today.
-        if is_delivering and (
-            parsed_arrival == ctx["today"] or date == ctx["today"]
-        ):
+        if is_delivering and (parsed_arrival == ctx["today"] or date == ctx["today"]):
             if order_id:
                 ctx["packages_delivering_today"][order_id] = (
                     ctx["packages_delivering_today"].get(order_id, 0) + 1
@@ -463,7 +461,12 @@ class AmazonShipper(Shipper):
                 s.lower() in subject.lower() for s in AMAZON_DELIVERING_SUBJECT
             )
 
-            if has_delivered and not has_ordered and not has_shipped and not has_delivering:
+            if (
+                has_delivered
+                and not has_ordered
+                and not has_shipped
+                and not has_delivering
+            ):
                 urls = self._extract_amazon_image_urls(msg)
                 return True, urls
         return False, []

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -47,8 +47,10 @@ DOMAIN_LANG_MAP = {
         "Geliefert:",
         "Zugestellt:",
         "Versandt:",
+        "Versendet:",
         "In Zustellung:",
         "Zustellung:",
+        "Ankunft",
     ],
     "amazon.it": [
         "conferma-spedizione",
@@ -245,22 +247,29 @@ def amazon_email_addresses(
     if domain is None:
         domain = "amazon.com"
 
+    domains = [d.strip() for d in str(domain).split(",") if d.strip()]
+    if not domains:
+        domains = ["amazon.com"]
+
     # Use both AMAZON_EMAIL and AMAZON_SHIPMENT_TRACKING for prefixes
-    prefixes = list(AMAZON_EMAIL)
+    base_prefixes = list(AMAZON_EMAIL)
     for p in AMAZON_SHIPMENT_TRACKING:
-        if f"{p}@" not in prefixes:
-            prefixes.append(f"{p}@")
+        if f"{p}@" not in base_prefixes:
+            base_prefixes.append(f"{p}@")
 
-    prefixes = filter_amazon_strings(prefixes, domain)
-
-    value = [f"{e}{domain}" for e in prefixes]
+    value: list[str] = []
+    for dom in domains:
+        prefixes = filter_amazon_strings(base_prefixes, dom)
+        value.extend(f"{e}{dom}" for e in prefixes)
     if fwds:
         for fwd in fwds:
             if "@" in fwd:
                 value.append(fwd)
             elif any(f in fwd for f in AMAZON_DOMAINS):
-                value.extend(f"{e}{fwd}" for e in prefixes)
-    return value
+                for dom in domains:
+                    prefixes = filter_amazon_strings(base_prefixes, dom)
+                    value.extend(f"{e}{fwd}" for e in prefixes)
+    return list(dict.fromkeys(value))
 
 
 async def search_amazon_emails(
@@ -284,7 +293,14 @@ async def search_amazon_emails(
         AMAZON_DELIVERED_SUBJECT + AMAZON_SHIPMENT_SUBJECT + AMAZON_ORDERED_SUBJECT
     )
     if domain:
-        amazon_subjects = filter_amazon_strings(amazon_subjects, domain)
+        domains = [d.strip() for d in str(domain).split(",") if d.strip()]
+        if len(domains) == 1:
+            amazon_subjects = filter_amazon_strings(amazon_subjects, domains[0])
+        else:
+            filtered: list[str] = []
+            for dom in domains:
+                filtered.extend(filter_amazon_strings(amazon_subjects, dom))
+            amazon_subjects = list(dict.fromkeys(filtered))
 
     (server_response, sdata) = await email_search(
         account=account,

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -44,8 +44,6 @@ _MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 DOMAIN_LANG_MAP = {
     "amazon.de": [
         "versandbestaetigung",
-        "shipment-tracking",
-        "order-update",
         "Geliefert:",
         "Zugestellt:",
         "Versandt:",
@@ -236,6 +234,30 @@ async def parse_amazon_arrival_date(
     return None
 
 
+def _split_amazon_domains(domain: str | None) -> list[str]:
+    """Split a possibly comma-separated amazon_domain into domain list."""
+    if domain is None:
+        domain = "amazon.com"
+    domains = [d.strip() for d in str(domain).split(",") if d.strip()]
+    return domains or ["amazon.com"]
+
+
+def _amazon_address_prefixes() -> list[str]:
+    """Build Amazon local-part prefixes used for IMAP FROM searches.
+
+    Do NOT language-filter address prefixes: amazon.de OFD mails come from
+    shipment-tracking@amazon.de (English local-part), while shipped mails use
+    versandbestaetigung@amazon.de. Filtering prefixes via DOMAIN_LANG_MAP drops
+    shipment-tracking@ for amazon.de and misses "In Zustellung" emails.
+    """
+    prefixes = list(AMAZON_EMAIL)
+    for local_part in AMAZON_SHIPMENT_TRACKING:
+        prefix = f"{local_part}@"
+        if prefix not in prefixes:
+            prefixes.append(prefix)
+    return prefixes
+
+
 def amazon_email_addresses(
     fwds: list[str] | str | None = None,
     domain: str | None = None,
@@ -246,33 +268,16 @@ def amazon_email_addresses(
     elif not isinstance(fwds, (list, tuple)):
         fwds = None
 
-    if domain is None:
-        domain = "amazon.com"
+    domains = _split_amazon_domains(domain)
+    base_prefixes = _amazon_address_prefixes()
+    value = [f"{prefix}{dom}" for dom in domains for prefix in base_prefixes]
 
-    domains = [d.strip() for d in str(domain).split(",") if d.strip()]
-    if not domains:
-        domains = ["amazon.com"]
-
-    # Use both AMAZON_EMAIL and AMAZON_SHIPMENT_TRACKING for prefixes.
-    # Do NOT language-filter address prefixes: amazon.de OFD mails come from
-    # shipment-tracking@amazon.de (English local-part), while shipped mails use
-    # versandbestaetigung@amazon.de. Filtering prefixes via DOMAIN_LANG_MAP drops
-    # shipment-tracking@ for amazon.de and misses "In Zustellung" emails.
-    base_prefixes = list(AMAZON_EMAIL)
-    for p in AMAZON_SHIPMENT_TRACKING:
-        if f"{p}@" not in base_prefixes:
-            base_prefixes.append(f"{p}@")
-
-    value: list[str] = []
-    for dom in domains:
-        value.extend(f"{prefix}{dom}" for prefix in base_prefixes)
     if fwds:
         for fwd in fwds:
             if "@" in fwd:
                 value.append(fwd)
-            elif any(f in fwd for f in AMAZON_DOMAINS):
-                for dom in domains:
-                    value.extend(f"{prefix}{fwd}" for prefix in base_prefixes)
+            elif any(amazon_domain in fwd for amazon_domain in AMAZON_DOMAINS):
+                value.extend(f"{prefix}{fwd}" for prefix in base_prefixes)
     return list(dict.fromkeys(value))
 
 
@@ -297,7 +302,7 @@ async def search_amazon_emails(
         AMAZON_DELIVERED_SUBJECT + AMAZON_SHIPMENT_SUBJECT + AMAZON_ORDERED_SUBJECT
     )
     if domain:
-        domains = [d.strip() for d in str(domain).split(",") if d.strip()]
+        domains = _split_amazon_domains(domain)
         if len(domains) == 1:
             amazon_subjects = filter_amazon_strings(amazon_subjects, domains[0])
         else:

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -44,6 +44,8 @@ _MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 DOMAIN_LANG_MAP = {
     "amazon.de": [
         "versandbestaetigung",
+        "shipment-tracking",
+        "order-update",
         "Geliefert:",
         "Zugestellt:",
         "Versandt:",
@@ -251,7 +253,11 @@ def amazon_email_addresses(
     if not domains:
         domains = ["amazon.com"]
 
-    # Use both AMAZON_EMAIL and AMAZON_SHIPMENT_TRACKING for prefixes
+    # Use both AMAZON_EMAIL and AMAZON_SHIPMENT_TRACKING for prefixes.
+    # Do NOT language-filter address prefixes: amazon.de OFD mails come from
+    # shipment-tracking@amazon.de (English local-part), while shipped mails use
+    # versandbestaetigung@amazon.de. Filtering prefixes via DOMAIN_LANG_MAP drops
+    # shipment-tracking@ for amazon.de and misses "In Zustellung" emails.
     base_prefixes = list(AMAZON_EMAIL)
     for p in AMAZON_SHIPMENT_TRACKING:
         if f"{p}@" not in base_prefixes:
@@ -259,16 +265,14 @@ def amazon_email_addresses(
 
     value: list[str] = []
     for dom in domains:
-        prefixes = filter_amazon_strings(base_prefixes, dom)
-        value.extend(f"{e}{dom}" for e in prefixes)
+        value.extend(f"{prefix}{dom}" for prefix in base_prefixes)
     if fwds:
         for fwd in fwds:
             if "@" in fwd:
                 value.append(fwd)
             elif any(f in fwd for f in AMAZON_DOMAINS):
                 for dom in domains:
-                    prefixes = filter_amazon_strings(base_prefixes, dom)
-                    value.extend(f"{e}{fwd}" for e in prefixes)
+                    value.extend(f"{prefix}{fwd}" for prefix in base_prefixes)
     return list(dict.fromkeys(value))
 
 

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1265,3 +1265,51 @@ async def test_amazon_de_versendet_ankunft_emails(hass):
             mock_account, "today", "amazon_delivering"
         )
         assert result_delivering["amazon_delivering"] == 0
+
+
+@pytest.mark.asyncio
+async def test_amazon_delivering_order_subtraction(hass):
+    """Test delivering count subtraction when an order is also delivered."""
+    shipper = AmazonShipper(hass, {})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.get_today",
+            return_value=datetime.date(2026, 7, 22),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.amazon.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1", b"2"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+    ):
+        email_delivering = (
+            b"Subject: Out for delivery: Your order\n"
+            b"Date: Wed, 22 Jul 2026 08:00:00 -0000\n"
+            b"Content-Type: text/plain\n\n"
+            b"Order #123-4567890-1234567"
+        )
+        email_delivered = (
+            b"Subject: Delivered: Your order has arrived\n"
+            b"Date: Wed, 22 Jul 2026 12:00:00 -0000\n"
+            b"Content-Type: text/plain\n\n"
+            b"Order #123-4567890-1234567"
+        )
+
+        def _mock_fetch(account, email_id, parts):
+            if email_id == b"1":
+                return ("OK", [b"RFC822", email_delivering])
+            return ("OK", [b"RFC822", email_delivered])
+
+        mock_fetch.side_effect = _mock_fetch
+
+        res_delivering = await shipper.process(
+            mock_account, "today", "amazon_delivering"
+        )
+        # Order was delivered so delivering count for order 123-4567890-1234567 should be max(0, 1 - 1) = 0
+        assert res_delivering["amazon_delivering"] == 0

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1313,3 +1313,36 @@ async def test_amazon_delivering_order_subtraction(hass):
         )
         # Order was delivered so delivering count for order 123-4567890-1234567 should be max(0, 1 - 1) = 0
         assert res_delivering["amazon_delivering"] == 0
+
+
+@pytest.mark.asyncio
+async def test_amazon_delivering_no_order_id_no_arrival_date(hass):
+    """Test OFD email received today without order ID or body arrival date (lines 320 and 338)."""
+    shipper = AmazonShipper(hass, {})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.get_today",
+            return_value=datetime.date(2026, 7, 22),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.amazon.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+    ):
+        email_ofd = (
+            b"Subject: Out for delivery: Your package\n"
+            b"Date: Wed, 22 Jul 2026 08:00:00 -0000\n"
+            b"Content-Type: text/plain\n\n"
+        )
+        mock_fetch.return_value = ("OK", [b"RFC822", email_ofd])
+
+        res = await shipper.process(mock_account, "today", "amazon_delivering")
+        assert res["amazon_delivering"] == 1
+        assert res["amazon_delivering_order"] == []

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1214,6 +1214,11 @@ async def test_amazon_de_emails(hass):
         assert result[AMAZON_PACKAGES] == 2
         assert result[AMAZON_ORDER] == ["123-4567890-1234567"]
 
+        result_delivering = await shipper.process(
+            mock_account, "today", "amazon_delivering"
+        )
+        assert result_delivering["amazon_delivering"] == 1
+
 
 @pytest.mark.asyncio
 async def test_amazon_de_versendet_ankunft_emails(hass):
@@ -1255,3 +1260,8 @@ async def test_amazon_de_versendet_ankunft_emails(hass):
         result = await shipper.process(mock_account, "today", AMAZON_PACKAGES)
         assert result[AMAZON_PACKAGES] == 1
         assert result[AMAZON_ORDER] == ["303-1873062-3277126"]
+
+        result_delivering = await shipper.process(
+            mock_account, "today", "amazon_delivering"
+        )
+        assert result_delivering["amazon_delivering"] == 0

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1213,3 +1213,45 @@ async def test_amazon_de_emails(hass):
         result = await shipper.process(mock_account, "today", AMAZON_PACKAGES)
         assert result[AMAZON_PACKAGES] == 2
         assert result[AMAZON_ORDER] == ["123-4567890-1234567"]
+
+
+@pytest.mark.asyncio
+async def test_amazon_de_versendet_ankunft_emails(hass):
+    """Test amazon.de emails using Versendet subject and Ankunft arrival wording."""
+    shipper = AmazonShipper(
+        hass,
+        {
+            "amazon_fwds": "",
+            "amazon_domain": "amazon.de",
+        },
+    )
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.get_today",
+            return_value=datetime.date(2026, 7, 22),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.amazon.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.amazon.email_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+    ):
+        content = (
+            b"Subject: =?utf-8?Q?Versendet:_=E2=80=9EHASKYY_Goldband=E2=80=9C?=\n"
+            b"Date: Wed, 22 Jul 2026 03:19:00 +0200\n"
+            b"Content-Type: text/plain; charset=utf-8\n\n"
+            b"Dein Paket wurde versendet!\n"
+            b"Ankunft heute\n"
+            b"Order: 303-1873062-3277126"
+        )
+        mock_fetch.return_value = ("OK", [b"RFC822", content])
+
+        result = await shipper.process(mock_account, "today", AMAZON_PACKAGES)
+        assert result[AMAZON_PACKAGES] == 1
+        assert result[AMAZON_ORDER] == ["303-1873062-3277126"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -202,6 +202,7 @@ async def test_aggregate_package_counts(hass):
     # Mock data to be aggregated
     test_data = {
         "zpackages_transit": 0,
+        "zpackages_delivering": 0,
         "zpackages_delivered": 0,
         "usps_delivering": 1,
         "usps_delivered": 1,
@@ -210,6 +211,7 @@ async def test_aggregate_package_counts(hass):
         "fedex_packages": 3,
         "fedex_delivered": 2,
         "amazon_packages": 5,
+        "amazon_delivering": 2,
         "amazon_delivered": 1,
         "amazon_exception": 1,
         "dhl_exception": 1,
@@ -225,6 +227,10 @@ async def test_aggregate_package_counts(hass):
     # + amazon_exception (1) + dhl_exception (1)
     # = 1 + 2 + 3 + 5 + 1 + 1 = 13
     assert test_data["zpackages_transit"] == 13
+
+    # Expected Delivering:
+    # usps_delivering (1) + ups_delivering (2) + amazon_delivering (2) = 5
+    assert test_data["zpackages_delivering"] == 5
 
     # Expected Delivered:
     # usps_delivered (1) + fedex_delivered (2) + amazon_delivered (1)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -452,6 +452,19 @@ async def test_packages_sensor_attributes_edge_cases(hass):
     attrs_otp = sensor_otp.extra_state_attributes
     assert attrs_otp["code"] == ["654321"]
 
+    # Test attributes for Amazon Delivering
+    coord_delivering = MagicMock()
+    coord_delivering.data = {"amazon_delivering_order": ["303-1873062-3277126"]}
+    sensor_delivering_desc = MagicMock(key="amazon_delivering")
+    sensor_delivering_desc.name = "Mail Amazon Packages Delivering"
+    sensor_delivering = PackagesSensor(
+        entry,
+        sensor_delivering_desc,
+        coord_delivering,
+    )
+    attrs_delivering = sensor_delivering.extra_state_attributes
+    assert attrs_delivering[ATTR_ORDER] == ["303-1873062-3277126"]
+
 
 @pytest.mark.asyncio
 async def test_image_path_sensor_grid(hass):

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -445,8 +445,6 @@ async def test_download_amazon_img_content_length_too_large(hass, tmp_path, capl
 
     assert "Amazon image too large to download" in caplog.text
 
-    assert "Amazon image exceeds size limit after download" in caplog.text
-
 
 def test_amazon_email_addresses_with_full_email_fwd():
     """Test amazon_email_addresses with explicit email address containing '@' in fwds."""

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -65,6 +65,19 @@ def test_amazon_email_addresses_str_input():
     assert "order-update@forward.com" not in result
 
 
+def test_amazon_email_addresses_comma_separated_domains():
+    """Comma-separated amazon_domain values should expand into per-domain addresses."""
+    result = amazon_email_addresses(domain="amazon.com,amazon.de")
+    assert "order-update@amazon.com" in result
+    assert "versandbestaetigung@amazon.de" in result
+    assert not any("," in address for address in result)
+
+
+def test_amazon_date_regex_ankunft():
+    """German Ankunft arrival wording should be parsed."""
+    assert amazon_date_regex("Ankunft heute") == "heute"
+
+
 @pytest.mark.asyncio
 async def test_search_amazon_emails_invalid_days():
     """Test search_amazon_emails with invalid days input."""

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -190,11 +190,15 @@ def test_get_decoded_subject_from_html_title():
 
 
 def test_amazon_email_addresses_various_fwds():
-    """Test amazon_email_addresses with various fwd types (Line 119)."""
-    # Test with None (triggers Line 119)
-    assert len(amazon_email_addresses(fwds=None)) == 3
-    # Test with non-list/tuple (triggers Line 119)
-    assert len(amazon_email_addresses(fwds=123)) == 3
+    """Test amazon_email_addresses with various fwd types."""
+    # Prefixes are not language-filtered so English + localized local-parts
+    # (AMAZON_EMAIL + AMAZON_SHIPMENT_TRACKING) are all expanded.
+    none_result = amazon_email_addresses(fwds=None)
+    assert "order-update@amazon.com" in none_result
+    assert "shipment-tracking@amazon.com" in none_result
+    assert "versandbestaetigung@amazon.com" in none_result
+    # Non-list/tuple fwds are ignored the same as None
+    assert amazon_email_addresses(fwds=123) == none_result
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -446,26 +446,35 @@ async def test_download_amazon_img_content_length_too_large(hass, tmp_path, capl
     assert "Amazon image too large to download" in caplog.text
 
 
-def test_amazon_email_addresses_with_full_email_fwd():
-    """Test amazon_email_addresses with explicit email address containing '@' in fwds."""
-    result = amazon_email_addresses(fwds=["forwarder@example.com"])
+def test_amazon_email_addresses_with_fwds_list():
+    """Test amazon_email_addresses with list containing full email and domain substring."""
+    result = amazon_email_addresses(fwds=["forwarder@example.com", "amazon.de"])
     assert "forwarder@example.com" in result
+    assert "versandbestaetigung@amazon.de" in result
 
 
 @pytest.mark.asyncio
-async def test_search_amazon_emails_multi_domain():
-    """Test search_amazon_emails with comma-separated multiple domains."""
+async def test_search_amazon_emails_single_and_multi_domain():
+    """Test search_amazon_emails with single domain and multi-domain."""
     mock_account = AsyncMock()
     with patch(
         "custom_components.mail_and_packages.utils.amazon.email_search",
         new_callable=AsyncMock,
         return_value=("OK", [b"1 2"]),
     ) as mock_search:
-        result = await search_amazon_emails(
+        res_single = await search_amazon_emails(
+            account=mock_account,
+            address_list=["order-update@amazon.de"],
+            days=3,
+            domain="amazon.de",
+        )
+        assert res_single == [b"1", b"2"]
+
+        res_multi = await search_amazon_emails(
             account=mock_account,
             address_list=["order-update@amazon.com"],
             days=3,
             domain="amazon.com,amazon.de",
         )
-        assert result == [b"1", b"2"]
-        mock_search.assert_called_once()
+        assert res_multi == [b"1", b"2"]
+        assert mock_search.call_count == 2

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -445,31 +445,29 @@ async def test_download_amazon_img_content_length_too_large(hass, tmp_path, capl
 
     assert "Amazon image too large to download" in caplog.text
 
+    assert "Amazon image exceeds size limit after download" in caplog.text
+
+
+def test_amazon_email_addresses_with_full_email_fwd():
+    """Test amazon_email_addresses with explicit email address containing '@' in fwds."""
+    result = amazon_email_addresses(fwds=["forwarder@example.com"])
+    assert "forwarder@example.com" in result
+
 
 @pytest.mark.asyncio
-async def test_download_amazon_img_data_too_large_after_download(
-    hass, tmp_path, caplog
-):
-    """Test download_amazon_img discards data exceeding size limit after download (lines 233-236)."""
-    img_url = "https://example.com/test.jpg"
-    img_path = str(tmp_path)
-    img_name = "test.jpg"
-
-    mock_resp = AsyncMock()
-    mock_resp.status = 200
-    mock_resp.headers = {"content-type": "image/jpeg", "content-length": "100"}
-    mock_resp.read.return_value = b"x" * (11 * 1024 * 1024)  # 11 MB actual data
-    mock_get = MagicMock()
-    mock_get.__aenter__.return_value = mock_resp
-    mock_get.__aexit__ = AsyncMock(return_value=False)
-
-    with (
-        patch("aiohttp.ClientSession.get", return_value=mock_get),
-        patch(
-            "custom_components.mail_and_packages.utils.amazon.io_save_file",
-        ) as mock_save,
-    ):
-        await download_amazon_img(img_url, img_path, img_name, hass)
-        mock_save.assert_not_called()
-
-    assert "Amazon image exceeds size limit after download" in caplog.text
+async def test_search_amazon_emails_multi_domain():
+    """Test search_amazon_emails with comma-separated multiple domains."""
+    mock_account = AsyncMock()
+    with patch(
+        "custom_components.mail_and_packages.utils.amazon.email_search",
+        new_callable=AsyncMock,
+        return_value=("OK", [b"1 2"]),
+    ) as mock_search:
+        result = await search_amazon_emails(
+            account=mock_account,
+            address_list=["order-update@amazon.com"],
+            days=3,
+            domain="amazon.com,amazon.de",
+        )
+        assert result == [b"1", b"2"]
+        mock_search.assert_called_once()


### PR DESCRIPTION
## Summary
- Recognize German Amazon.de shipment subjects using `Versendet:` (in addition to existing `Versandt:`) and arrival wording `Ankunft` / `Ankunft heute`.
- Split comma-separated `amazon_domain` values (e.g. `amazon.com,amazon.de`) into per-domain IMAP FROM addresses and subject filters, instead of building invalid addresses like `…@amazon.com,amazon.de`.
- Add regression tests for Versendet/Ankunft parsing and multi-domain address expansion.

## Test plan
- [ ] Unit tests for Amazon.de Versendet + Ankunft emails pass
- [ ] Unit tests for comma-separated `amazon_domain` address generation pass
- [ ] With `amazon_domain=amazon.de` (or `amazon.com,amazon.de`), German shipment emails from `versandbestaetigung@amazon.de` with subject `Versendet: …` increment `amazon_packages`