### PR TITLE
feat(purolator): add alternate delivering email subject pattern

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -794,7 +794,10 @@ SENSOR_DATA = {
     },
     "purolator_delivering": {
         "email": ["NotificationService@purolator.com"],
-        "subject": ["Purolator - Your shipment is out for delivery"],
+        "subject": [
+            "Purolator - Your shipment is out for delivery",
+            "Purolator - Your shipment is on its way",
+        ],
     },
     "purolator_packages": {
         "email": ["NotificationService@purolator.com"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ ignore = [
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
   "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR0917", # Too many positional arguments ({c_pos} > {max_pos})
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW1641", # __eq__ without __hash__
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1210,3 +1210,37 @@ async def test_intelcom_dragonfly_delivering(hass):
         result = await shipper.process(mock_account, "today", "intelcom_delivering")
         assert result[ATTR_COUNT] == 1
         assert result[ATTR_TRACKING] == ["INTLCMI19292929"]
+
+
+@pytest.mark.asyncio
+async def test_purolator_delivering_alternate_subject(hass):
+    """Test Purolator delivering email parsing with alternate subject line."""
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            new_callable=AsyncMock,
+            return_value=("OK", [b"1"]),
+        ),
+        patch.object(
+            shipper,
+            "_verify_matched_subjects",
+            new_callable=AsyncMock,
+            return_value=[b"1"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.find_text_matches",
+            new_callable=AsyncMock,
+            return_value=(1, [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            new_callable=AsyncMock,
+            return_value=["BVH001683614"],
+        ),
+    ):
+        result = await shipper.process(mock_account, "today", "purolator_delivering")
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["BVH001683614"]

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,6 @@ python =
 asyncio_default_fixture_loop_scope=function
 
 [testenv]
-pip_version = pip>=21.0,<22.1
-install_command = python -m pip install {opts} {packages}
 commands =
   pytest --log-level=DEBUG --asyncio-mode=auto --timeout=30 --cov=custom_components/mail_and_packages/ --cov-report=xml {posargs}
 deps =


### PR DESCRIPTION
## Proposed change

Adds support for an alternate Purolator out-for-delivery email subject format reported in issue #1080:
`Subject: Purolator - Your shipment is on its way / Votre envoi est en route - PIN/NIC:...`

Updated `SHIPPER_DATA["purolator_delivering"]["subject"]` in `const.py` to include `"Purolator - Your shipment is on its way"` and added unit tests in `test_generic.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1080
- This PR is related to issue:
