### PR TITLE
fix(sensor): retain last state on coordinator update failure

### DIFF
--- a/custom_components/mail_and_packages/binary_sensor.py
+++ b/custom_components/mail_and_packages/binary_sensor.py
@@ -71,11 +71,6 @@ class PackagesBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return False
 
     @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.data is not None
-
-    @property
     def is_on(self) -> bool:
         """Return True if the image is updated."""
         if self.coordinator.data is None:

--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -659,11 +659,6 @@ class MailCam(CoordinatorEntity, Camera):
         """
         return False
 
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.data is not None
-
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug(

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -140,11 +140,6 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         return False
 
     @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.data is not None
-
-    @property
     def extra_state_attributes(self) -> str | None:
         """Return device specific state attributes."""
         attr = {}
@@ -265,8 +260,3 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
     def should_poll(self) -> bool:
         """No need to poll. Coordinator notifies entity of updates."""
         return False
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.data is not None


### PR DESCRIPTION
## Proposed change

Remove custom `available` property overrides from sensors, binary sensors, and cameras.

Previously, `available` returned `self.coordinator.data is not None`. Explicitly defining `available` in entities overrode Home Assistant's built-in `CoordinatorEntity.available` logic (`self.coordinator.last_update_success`), causing entities to behave unexpectedly during coordinator refresh failures or timeouts.

Removing the explicit `available` property overrides restores standard Home Assistant `CoordinatorEntity.available` behavior, ensuring sensors retain their last known state when IMAP scans fail or time out.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1337 
- This PR is related to issue:
