### PR TITLE
fix(dhl): add missing subject for German DHL delivered emails

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -461,6 +461,7 @@ SENSOR_DATA = {
             "DHL Shipment Notification",
             "liegt am gewünschten Ablageort",
             "Ihre Sendung liegt im Briefkasten",
+            "Sendung liegt im Briefkasten",
             "Zustellung an Ablageort",
             "Ablageort",
             "Sendung zugestellt",


### PR DESCRIPTION
## Proposed change

German DHL (`noreply@dhl.de`) delivery notification emails insert the merchant name into the subject line (e.g. `Ihre Musterhaus Elektronik GmbH Sendung liegt im Briefkasten`).

While the IMAP search query successfully matches the email body phrase (`"liegt im Briefkasten"`), `_verify_matched_subjects()` in `shippers/generic.py` performs subject verification against the `subject` list under `dhl_delivered`. Because the list previously only contained exact phrases like `"Ihre Sendung liegt im Briefkasten"`, verification failed when merchant names were present between `"Ihre"` and `"Sendung"`.

Adding `"Sendung liegt im Briefkasten"` to the `dhl_delivered` subject list allows substring subject matching to pass when merchant names are inserted into the subject line.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1339
- This PR is related to issue:
