### PR TITLE
fix(coordinator): retain cached data on transient scan failures or timeouts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,15 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
 
+  - repo: local
+    hooks:
+      - id: pyclean
+        name: Clean Python bytecode & __pycache__
+        entry: find . -type d -name "__pycache__" -exec rm -rf {} +
+        language: system
+        always_run: true
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
     hooks:

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -141,10 +141,12 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                             raise UpdateFailed("OAuth token refresh failed") from err
 
                     data = await self.process_emails(self.hass, config)
-                except (UpdateFailed, ConfigEntryAuthFailed):
+                except ConfigEntryAuthFailed:
                     raise
                 except Exception as error:
                     _LOGGER.error("Problem updating sensors: %s", error)
+                    if self._data:
+                        return self._data
                     raise UpdateFailed(error) from error
 
                 if data:
@@ -162,7 +164,9 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 self.timeout,
                 monotonic() - start,
             )
-            raise
+            if self._data:
+                return self._data
+            raise UpdateFailed("Scan timed out and no prior data available") from None
 
     async def process_emails(self, hass: HomeAssistant, config: dict) -> dict:
         """Process emails and update sensors."""

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -250,7 +250,7 @@ async def test_async_camera_image_cache_hit(
     mock_getctime_today,
     mock_update,
 ):
-    """Test async_camera_image returns cached bytes on second call (line 162)."""
+    """Test async_camera_image returns cached bytes on second call."""
     entry = integration
     cameras = entry.runtime_data.cameras
     cam = cameras[0]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8121,3 +8121,103 @@ async def test_get_schema_step_2_password_auth_skips_oauth_refresh(hass, caplog)
 
     mock_get_impl.assert_not_called()
     assert "Error refreshing OAuth token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reauth_flow_reauth_successful(
+    hass: HomeAssistant,
+    integration,
+    mock_imap_no_email,
+    mock_update,
+) -> None:
+    """Test reauth flow aborts with reauth_successful when source is SOURCE_REAUTH."""
+    entry = integration
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.config_flow._get_mailboxes",
+            return_value=["INBOX"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.config_flow._validate_login",
+            return_value={},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+                "unique_id": entry.unique_id,
+            },
+            data=entry.data,
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: entry.data[CONF_USERNAME],
+                CONF_PASSWORD: "newpassword",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] is FlowResultType.ABORT
+        assert result2["reason"] == "reauth_successful"
+
+
+@pytest.mark.asyncio
+async def test_get_schema_step_2_oauth_refresh_exception(hass, caplog):
+    """Test OAuth token refresh exception handling in _get_schema_step_2 (lines 535-536)."""
+    data = {
+        CONF_HOST: "imap.example.com",
+        "port": 993,
+        "username": "test@example.com",
+        "imap_security": "SSL",
+        "verify_ssl": True,
+        "auth_type": "oauth2_google",
+        "auth_implementation": "google",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+
+    mock_session = AsyncMock()
+    mock_session.async_ensure_token_valid.side_effect = Exception("Refresh failure")
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.config_flow._get_mailboxes",
+            return_value=["INBOX"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+    ):
+        await _get_schema_step_2(data, {}, {}, hass, entry=entry)
+
+    assert "Error refreshing OAuth token: Refresh failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_oauth_create_entry_reauth_successful(hass):
+    """Test async_oauth_create_entry reauth_successful abort (line 1022)."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    flow = MailAndPackagesFlowHandler()
+    flow.hass = hass
+    flow._entry = entry
+    flow.context = {"source": config_entries.SOURCE_REAUTH}
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()):
+        result = await flow.async_oauth_create_entry({"token": "fake_token"})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7945,7 +7945,7 @@ async def test_reauth_flow_oauth(
 
 @pytest.mark.asyncio
 async def test_options_amazon_empty_fwds_normalised(hass, integration):
-    """Test _show_options_amazon normalises [] CONF_AMAZON_FWDS to '(none)' (line 1380)."""
+    """Test _show_options_amazon normalises [] CONF_AMAZON_FWDS to '(none)'."""
     entry = integration
     handler = MailAndPackagesOptionsFlow(entry)
     handler.hass = hass
@@ -8170,7 +8170,7 @@ async def test_reauth_flow_reauth_successful(
 
 @pytest.mark.asyncio
 async def test_get_schema_step_2_oauth_refresh_exception(hass, caplog):
-    """Test OAuth token refresh exception handling in _get_schema_step_2 (lines 535-536)."""
+    """Test OAuth token refresh exception handling in _get_schema_step_2."""
     data = {
         CONF_HOST: "imap.example.com",
         "port": 993,
@@ -8207,7 +8207,7 @@ async def test_get_schema_step_2_oauth_refresh_exception(hass, caplog):
 
 @pytest.mark.asyncio
 async def test_async_oauth_create_entry_reauth_successful(hass):
-    """Test async_oauth_create_entry reauth_successful abort (line 1022)."""
+    """Test async_oauth_create_entry reauth_successful abort."""
     entry = MockConfigEntry(domain=DOMAIN, data={})
     entry.add_to_hass(hass)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,9 +6,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mail_and_packages.const import CONF_FOLDER
+from custom_components.mail_and_packages.const import CONF_FOLDER, DOMAIN
 from custom_components.mail_and_packages.coordinator import MailDataUpdateCoordinator
 from custom_components.mail_and_packages.utils.imap import InvalidAuth
 from tests.const import FAKE_CONFIG_DATA
@@ -815,3 +817,303 @@ async def test_process_emails_delivered_tracking_reversed_order(hass):
     # In-transit tracking should still correctly exclude the delivered ones
     assert set(data["ups_tracking"]) == {"UPS_IN_TRANSIT"}
     assert set(data["ups_delivered_tracking"]) == {"UPS_DELIVERED_TODAY"}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_file_hash_if_changed(hass):
+    """Test _get_file_hash_if_changed caching and error paths."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    with (
+        patch("os.path.getmtime", return_value=12345),
+        patch(
+            "custom_components.mail_and_packages.coordinator.hash_file",
+            return_value="hash_abc",
+        ),
+    ):
+        hash1 = await coordinator._get_file_hash_if_changed("test_file.gif")
+        assert hash1 == "hash_abc"
+
+        # Repeated call returns cached hash directly without re-hashing
+        hash2 = await coordinator._get_file_hash_if_changed("test_file.gif")
+        assert hash2 == "hash_abc"
+
+    # OSError returns None
+    with patch("os.path.getmtime", side_effect=OSError("File missing")):
+        assert (await coordinator._get_file_hash_if_changed("missing.gif")) is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_oauth_token_refresh(hass):
+    """Test _async_update_data OAuth2 token refresh success and failure paths."""
+    config = {**FAKE_CONFIG_DATA, "auth_type": "oauth2_google"}
+    entry = MockConfigEntry(domain="mail_and_packages", data=config)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+        coordinator.config_entry = entry
+
+    mock_session = AsyncMock()
+    mock_session.token = {"access_token": "refreshed_oauth_token"}
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+        patch.object(
+            coordinator, "process_emails", AsyncMock(return_value={"test": 1})
+        ),
+        patch.object(coordinator, "_binary_sensor_update", AsyncMock()),
+    ):
+        res = await coordinator._async_update_data()
+        assert res == {"test": 1}
+
+    # Error during OAuth refresh raises UpdateFailed when no cached _data exists
+    coordinator._data = {}
+    mock_session_fail = AsyncMock()
+    mock_session_fail.async_ensure_token_valid.side_effect = Exception(
+        "OAuth refresh error"
+    )
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session_fail,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_process_emails_copy_external_images_error(hass, caplog):
+    """Test process_emails handles copy_images OSError/ValueError gracefully."""
+    config = {**FAKE_CONFIG_DATA, "allow_external": True}
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.copy_images",
+            side_effect=OSError("Copy error"),
+        ),
+    ):
+        await coordinator.process_emails(hass, config)
+
+    assert "Problem creating: Copy error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_imap_connection_folder_failures(hass):
+    """Test _get_imap_connection folder selection exception and invalid folder return."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # 1. Folder selection exception
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            side_effect=Exception("IMAP select error"),
+        ),
+        pytest.raises(UpdateFailed, match="Folder selection failed: IMAP select error"),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+    # 2. Folder selection returns False
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=False,
+        ),
+        pytest.raises(UpdateFailed, match="Folder selection failed: INBOX"),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_imap_connection_deletes_auth_failed_issue(hass):
+    """Test _get_imap_connection deletes auth_failed issue if present (line 276)."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # Pre-register issue in registry
+    issue_registry = ir.async_get(hass)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "auth_failed",
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="auth_failed",
+    )
+    assert (DOMAIN, "auth_failed") in issue_registry.issues
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+    assert (DOMAIN, "auth_failed") not in issue_registry.issues
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_data_error_with_cached_data_and_auth_failed(
+    hass,
+):
+    """Test _async_update_data re-raises ConfigEntryAuthFailed and returns cached data on generic error (lines 145, 149)."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # 1. ConfigEntryAuthFailed is re-raised
+    with (
+        patch.object(
+            coordinator,
+            "process_emails",
+            AsyncMock(side_effect=ConfigEntryAuthFailed("Auth failed")),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+    # 2. Generic Exception with pre-existing cached _data returns cached _data
+    coordinator._data = {"cached": "value"}
+    with patch.object(
+        coordinator,
+        "process_emails",
+        AsyncMock(side_effect=Exception("Generic update error")),
+    ):
+        res = await coordinator._async_update_data()
+        assert res == {"cached": "value"}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_different_hash_and_post_de(hass):
+    """Test _binary_sensor_update when image hash differs from none hash for USPS and post_de (lines 529, 582, 597)."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    coordinator._data = {
+        "usps_image": "mail_123.jpg",
+        "post_de_image": "post_de_123.jpg",
+    }
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.anyio.Path.exists",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            coordinator,
+            "_get_file_hash_if_changed",
+            AsyncMock(
+                side_effect=["hash_img1", "hash_none1", "hash_img2", "hash_none2"]
+            ),
+        ),
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator._data.get("usps_update") is True
+    assert coordinator._data.get("post_de_update") is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_same_hash_and_custom_img(hass):
+    """Test _binary_sensor_update when image hash equals none hash and custom image is configured (lines 531, 546, 578)."""
+    config = {
+        **FAKE_CONFIG_DATA,
+        "amazon_custom_img": True,
+        "amazon_custom_img_file": "/custom/no_delivery.jpg",
+    }
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+
+    coordinator._data = {
+        "usps_image": "mail_123.jpg",
+        "amazon_image": "amazon_123.jpg",
+    }
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.anyio.Path.exists",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            coordinator,
+            "_get_file_hash_if_changed",
+            AsyncMock(return_value="same_hash"),
+        ),
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator._data.get("usps_update") is False
+    assert coordinator._data.get("amazon_update") is False
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_fallback_and_invalid_attr(hass):
+    """Test _binary_sensor_update fallback no_deliveries image and invalid attr skip (lines 546, 582)."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    coordinator._data = {
+        "ups_image": "ups_123.jpg",
+    }
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.const.CAMERA_DATA",
+            {"ups_camera": "ups", "invalid_camera": "invalid"},
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.anyio.Path.exists",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            coordinator,
+            "_get_file_hash_if_changed",
+            AsyncMock(side_effect=["hash_img", "hash_none"]),
+        ),
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator._data.get("ups_update") is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -254,7 +254,7 @@ async def test_aggregate_package_counts_no_resource(hass):
 
 @pytest.mark.asyncio
 async def test_get_imap_connection_selectfolder_exception(hass):
-    """Test _get_imap_connection handles exception from selectfolder (lines 229-231)."""
+    """Test _get_imap_connection handles exception from selectfolder."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
@@ -635,7 +635,6 @@ async def test_coordinator_post_de_binary_sensor_update(hass):
     }
 
     # Mock the calls inside _binary_sensor_update
-    # We want it to reach lines 520-521.
     with (
         patch(
             "custom_components.mail_and_packages.coordinator.default_image_path",
@@ -963,7 +962,7 @@ async def test_coordinator_get_imap_connection_folder_failures(hass):
 
 @pytest.mark.asyncio
 async def test_coordinator_get_imap_connection_deletes_auth_failed_issue(hass):
-    """Test _get_imap_connection deletes auth_failed issue if present (line 276)."""
+    """Test _get_imap_connection deletes auth_failed issue if present."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
@@ -1000,7 +999,7 @@ async def test_coordinator_get_imap_connection_deletes_auth_failed_issue(hass):
 async def test_coordinator_async_update_data_error_with_cached_data_and_auth_failed(
     hass,
 ):
-    """Test _async_update_data re-raises ConfigEntryAuthFailed and returns cached data on generic error (lines 145, 149)."""
+    """Test _async_update_data re-raises ConfigEntryAuthFailed and returns cached data on generic error."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
@@ -1028,7 +1027,7 @@ async def test_coordinator_async_update_data_error_with_cached_data_and_auth_fai
 
 @pytest.mark.asyncio
 async def test_coordinator_binary_sensor_update_different_hash_and_post_de(hass):
-    """Test _binary_sensor_update when image hash differs from none hash for USPS and post_de (lines 529, 582, 597)."""
+    """Test _binary_sensor_update when image hash differs from none hash for USPS and post_de."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
@@ -1058,7 +1057,7 @@ async def test_coordinator_binary_sensor_update_different_hash_and_post_de(hass)
 
 @pytest.mark.asyncio
 async def test_coordinator_binary_sensor_update_same_hash_and_custom_img(hass):
-    """Test _binary_sensor_update when image hash equals none hash and custom image is configured (lines 531, 546, 578)."""
+    """Test _binary_sensor_update when image hash equals none hash and custom image is configured."""
     config = {
         **FAKE_CONFIG_DATA,
         "amazon_custom_img": True,
@@ -1091,7 +1090,7 @@ async def test_coordinator_binary_sensor_update_same_hash_and_custom_img(hass):
 
 @pytest.mark.asyncio
 async def test_coordinator_binary_sensor_update_fallback_and_invalid_attr(hass):
-    """Test _binary_sensor_update fallback no_deliveries image and invalid attr skip (lines 546, 582)."""
+    """Test _binary_sensor_update fallback no_deliveries image and invalid attr skip."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -107,28 +107,32 @@ async def test_process_emails_invalid_return(hass):
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_timeout_logs_and_reraises(hass, caplog):
-    """When the scan exceeds its time budget, log an actionable error and re-raise."""
+async def test_async_update_data_timeout_logs_and_returns_cached_data(hass, caplog):
+    """When the scan exceeds its time budget, log an error and return cached data if available."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
-    # Shrink the whole-scan budget so the timeout fires immediately, and make
-    # process_emails outlast it so asyncio.timeout raises TimeoutError at the
-    # async-with boundary (the real path users hit on large mailboxes).
     coordinator.timeout = 0.01
 
     async def _slow_process(*args, **kwargs):
         await asyncio.sleep(1)
         return {}
 
+    # Initial scan without prior data raises UpdateFailed
     with (
         patch.object(coordinator, "process_emails", side_effect=_slow_process),
-        pytest.raises(TimeoutError),
+        pytest.raises(UpdateFailed),
     ):
         await coordinator._async_update_data()
 
     assert "scan exceeded its" in caplog.text
     assert "time budget" in caplog.text
+
+    # Scan with prior cached data returns cached data instead of raising
+    coordinator._data = {"mail_updated": "test_time", "usps_mail": 2}
+    with patch.object(coordinator, "process_emails", side_effect=_slow_process):
+        res = await coordinator._async_update_data()
+        assert res == {"mail_updated": "test_time", "usps_mail": 2}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

When IMAP scans time out or encounter transient network errors during coordinator updates, `_async_update_data()` previously re-raised `TimeoutError` or `UpdateFailed`. Home Assistant's `DataUpdateCoordinator` responds to these exceptions by setting `last_update_success = False`, causing all integration sensors to cycle `available → unavailable → available` when the next scan succeeds. This causes false positives in count-delta automations (such as `from_state: unavailable` -> `to_state: 1`).

This PR updates `_async_update_data()` in `coordinator.py` to return the last known cached data (`self._data`) when a transient error or timeout occurs if prior data exists. This retains sensor states across transient scan failures and prevents sensors from needlessly toggling to `unavailable`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1337
- This PR is related to issue:
