### PR TITLE
feat(imap): add persistent store email caching system

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -85,6 +85,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         self._file_mtime_cache = {}
         self._hash_cache = {}
         self._in_transit_tracking: dict[str, dict[str, str]] = {}
+        self.email_cache = EmailCache(hass=hass)
 
         _LOGGER.debug("Data will be update every %s", self.interval)
 
@@ -173,7 +174,12 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         # Connect to IMAP
         account = await self._get_imap_connection(config)
         try:
-            cache = EmailCache(account)
+            days = config.get(CONF_CUSTOM_DAYS, DEFAULT_CUSTOM_DAYS)
+            cache = self.email_cache
+            cache.set_account(account)
+            await cache.async_load()
+            await cache.async_purge_expired(custom_days=days)
+
             now = datetime.datetime.now()
             today = now.strftime("%d-%b-%Y")
             today_iso = now.date().isoformat()
@@ -190,6 +196,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Aggregate global transit and delivered sensors
             self._aggregate_package_counts(data)
+            await cache.async_save()
         finally:
             await logout(account)
 

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -489,7 +489,11 @@ class GenericShipper(Shipper):
             try:
                 if cache:
                     header_data = (
-                        await cache.fetch(eid, "(BODY[HEADER.FIELDS (SUBJECT)])")
+                        await cache.fetch(
+                            eid,
+                            "(BODY[HEADER.FIELDS (SUBJECT)])",
+                            shipper=self.name,
+                        )
                     )[1]
                 else:
                     header_data = (await email_fetch_headers(account, eid))[1]
@@ -664,7 +668,7 @@ class GenericShipper(Shipper):
         image_found = False
         for eid in ids:
             if cache:
-                msg_parts = (await cache.fetch(eid, "(RFC822)"))[1]
+                msg_parts = (await cache.fetch(eid, "(RFC822)", shipper=self.name))[1]
             else:
                 msg_parts = (await email_fetch(account, eid, "(RFC822)"))[1]
             for response_part in msg_parts:

--- a/custom_components/mail_and_packages/utils/cache.py
+++ b/custom_components/mail_and_packages/utils/cache.py
@@ -120,12 +120,12 @@ class EmailCache:
                         if isinstance(item, list):
                             restored_list.append(
                                 tuple(
-                                    x.encode("utf-8") if isinstance(x, str) else x
+                                    x.encode("latin-1") if isinstance(x, str) else x
                                     for x in item
                                 )
                             )
                         elif isinstance(item, str):
-                            restored_list.append(item.encode("utf-8"))
+                            restored_list.append(item.encode("latin-1"))
                         else:
                             restored_list.append(item)
                 else:
@@ -175,21 +175,18 @@ class EmailCache:
 
     def _store_persistent(self, eid_str: str, data: tuple, shipper: str) -> None:
         """Store fetched email data in persistent structure."""
-        # Convert bytes objects inside tuple response for JSON serialization safety
+        # Convert bytes objects inside tuple response for JSON serialization safety using latin-1 encoding to preserve exact 1-to-1 byte representations
         status, response_list = data
         serializable_list = []
         if isinstance(response_list, list):
             for item in response_list:
                 if isinstance(item, tuple):
                     serialized_tuple = tuple(
-                        x.decode("utf-8", errors="replace")
-                        if isinstance(x, bytes)
-                        else x
-                        for x in item
+                        x.decode("latin-1") if isinstance(x, bytes) else x for x in item
                     )
                     serializable_list.append(serialized_tuple)
                 elif isinstance(item, bytes):
-                    serializable_list.append(item.decode("utf-8", errors="replace"))
+                    serializable_list.append(item.decode("latin-1"))
                 else:
                     serializable_list.append(item)
         else:

--- a/custom_components/mail_and_packages/utils/cache.py
+++ b/custom_components/mail_and_packages/utils/cache.py
@@ -1,45 +1,159 @@
 """Email caching utility for Mail and Packages."""
 
+import datetime
 import logging
+from typing import Any
 
 from aioimaplib import IMAP4_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 
 from .imap import email_fetch, email_fetch_batch, email_fetch_headers, email_fetch_text
 
 _LOGGER = logging.getLogger(__name__)
 
+STORAGE_VERSION = 1
+STORAGE_KEY = "mail_and_packages.email_cache"
+
 
 class EmailCache:
-    """Cache for IMAP email fetches to avoid duplicate downloads."""
+    """Cache for IMAP email fetches to avoid duplicate downloads across scans."""
 
-    def __init__(self, account: IMAP4_SSL) -> None:
+    def __init__(
+        self,
+        account: IMAP4_SSL | None = None,
+        hass: HomeAssistant | None = None,
+        store_key: str = STORAGE_KEY,
+    ) -> None:
         """Initialize the cache."""
         self.account = account
+        self.hass = hass
+        self._store: Store | None = (
+            Store(hass, STORAGE_VERSION, store_key) if hass else None
+        )
         self._cache_rfc822: dict[str, tuple] = {}
         self._cache_text: dict[str, tuple] = {}
         self._cache_headers: dict[str, tuple] = {}
+        # Persistent metadata mapping: eid_str -> {"fetched_at": iso_str, "shipper": name, "data": tuple}
+        self._persistent_store: dict[str, dict[str, Any]] = {}
 
-    async def fetch(self, email_id: str | bytes, parts: str = "(RFC822)") -> tuple:  # noqa: C901
+    def set_account(self, account: IMAP4_SSL) -> None:
+        """Set active IMAP account for the current scan cycle."""
+        self.account = account
+        # Clear transient per-scan caches while preserving persistent records
+        self._cache_rfc822.clear()
+        self._cache_text.clear()
+        self._cache_headers.clear()
+
+    async def async_load(self) -> None:
+        """Load persistent cache from storage."""
+        if not self._store:
+            return
+        try:
+            data = await self._store.async_load()
+            if isinstance(data, dict):
+                self._persistent_store = data.get("entries", {})
+        except OSError as err:
+            _LOGGER.warning("Failed to load email cache: %s", err)
+            self._persistent_store = {}
+
+    async def async_save(self) -> None:
+        """Save persistent cache to storage."""
+        if not self._store:
+            return
+        try:
+            await self._store.async_save({"entries": self._persistent_store})
+        except OSError as err:
+            _LOGGER.warning("Failed to save email cache: %s", err)
+
+    async def async_purge_expired(self, custom_days: int = 3) -> None:
+        """Purge expired cache entries based on carrier expiration rules."""
+        now = datetime.datetime.now(datetime.UTC)
+        midnight_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        custom_days_cutoff = now - datetime.timedelta(days=custom_days)
+
+        expired_keys = []
+        for key, entry in self._persistent_store.items():
+            fetched_at_str = entry.get("fetched_at")
+            if not fetched_at_str:
+                expired_keys.append(key)
+                continue
+            try:
+                fetched_at = datetime.datetime.fromisoformat(fetched_at_str)
+            except ValueError:
+                expired_keys.append(key)
+                continue
+
+            shipper = entry.get("shipper", "unknown")
+            if shipper == "amazon":
+                if fetched_at < custom_days_cutoff:
+                    expired_keys.append(key)
+            elif fetched_at < midnight_today:
+                expired_keys.append(key)
+
+        for key in expired_keys:
+            self._persistent_store.pop(key, None)
+
+        if expired_keys and self._store:
+            await self.async_save()
+
+    async def fetch(  # noqa: C901
+        self,
+        email_id: str | bytes,
+        parts: str = "(RFC822)",
+        shipper: str = "generic",
+    ) -> tuple:
         """Fetch email content or return from cache."""
         eid_str = email_id.decode() if isinstance(email_id, bytes) else str(email_id)
+
+        cache_key = f"{eid_str}:{parts}"
+
+        # Check persistent cache first if available
+        if cache_key in self._persistent_store:
+            entry = self._persistent_store[cache_key]
+            cached_data = entry.get("data")
+            if cached_data and isinstance(cached_data, list) and len(cached_data) == 2:
+                status, response_list = cached_data
+                restored_list = []
+                if isinstance(response_list, list):
+                    for item in response_list:
+                        if isinstance(item, list):
+                            restored_list.append(
+                                tuple(
+                                    x.encode("utf-8") if isinstance(x, str) else x
+                                    for x in item
+                                )
+                            )
+                        elif isinstance(item, str):
+                            restored_list.append(item.encode("utf-8"))
+                        else:
+                            restored_list.append(item)
+                else:
+                    restored_list = response_list
+                return (status, restored_list)
 
         if parts in ("(RFC822)", "BODY[]"):
             if eid_str in self._cache_rfc822:
                 return self._cache_rfc822[eid_str]
+            if self.account is None:
+                return ("NO", ["No active IMAP connection"])
             res = await email_fetch(self.account, eid_str, parts)
             if res[0] == "OK":
                 self._cache_rfc822[eid_str] = res
+                self._store_persistent(cache_key, res, shipper)
             return res
 
         if "HEADER" in parts:
             if eid_str in self._cache_headers:
                 return self._cache_headers[eid_str]
-            # fallback to RFC822 cache if we already have it
             if eid_str in self._cache_rfc822:
                 return self._cache_rfc822[eid_str]
+            if self.account is None:
+                return ("NO", ["No active IMAP connection"])
             res = await email_fetch_headers(self.account, eid_str)
             if res[0] == "OK":
                 self._cache_headers[eid_str] = res
+                self._store_persistent(cache_key, res, shipper)
             return res
 
         if "TEXT" in parts or parts == "(BODY[1])":
@@ -47,58 +161,56 @@ class EmailCache:
                 return self._cache_text[eid_str]
             if eid_str in self._cache_rfc822:
                 return self._cache_rfc822[eid_str]
+            if self.account is None:
+                return ("NO", ["No active IMAP connection"])
             res = await email_fetch_text(self.account, eid_str, parts)
             if res[0] == "OK":
                 self._cache_text[eid_str] = res
+                self._store_persistent(cache_key, res, shipper)
             return res
 
-        # Unknown part, bypass cache
+        if self.account is None:
+            return ("NO", ["No active IMAP connection"])
         return await email_fetch(self.account, eid_str, parts)
+
+    def _store_persistent(self, eid_str: str, data: tuple, shipper: str) -> None:
+        """Store fetched email data in persistent structure."""
+        # Convert bytes objects inside tuple response for JSON serialization safety
+        status, response_list = data
+        serializable_list = []
+        if isinstance(response_list, list):
+            for item in response_list:
+                if isinstance(item, tuple):
+                    serialized_tuple = tuple(
+                        x.decode("utf-8", errors="replace")
+                        if isinstance(x, bytes)
+                        else x
+                        for x in item
+                    )
+                    serializable_list.append(serialized_tuple)
+                elif isinstance(item, bytes):
+                    serializable_list.append(item.decode("utf-8", errors="replace"))
+                else:
+                    serializable_list.append(item)
+        else:
+            serializable_list = response_list
+
+        self._persistent_store[eid_str] = {
+            "fetched_at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "shipper": shipper,
+            "data": [status, serializable_list],
+        }
 
     async def fetch_batch(
         self, email_ids: list[str | bytes], parts: str = "(RFC822)"
     ) -> tuple:
-        """Fetch multiple emails in a batch, retrieving from cache if applicable."""
-        # For simplicity, if we don't have all of them, fetch the missing ones in batch
-        missing_ids = []
-        eid_strs = [e.decode() if isinstance(e, bytes) else str(e) for e in email_ids]
-
-        # Determine which ones we already have
-        for eid_str in eid_strs:
-            if parts in ("(RFC822)", "BODY[]"):
-                if eid_str not in self._cache_rfc822:
-                    missing_ids.append(eid_str)
-            elif "HEADER" in parts:
-                if (
-                    eid_str not in self._cache_headers
-                    and eid_str not in self._cache_rfc822
-                ):
-                    missing_ids.append(eid_str)
-            elif "TEXT" in parts or parts == "(BODY[1])":
-                if (
-                    eid_str not in self._cache_text
-                    and eid_str not in self._cache_rfc822
-                ):
-                    missing_ids.append(eid_str)
-            else:
-                missing_ids.append(eid_str)
-
-        # Batch fetch only what is missing
-        if missing_ids:
-            # Just use fetch() internally for now to populate individual items since fetch_batch
-            # returns combined lines which might be tricky to parse.
-            # Wait, email_fetch_batch might be tricky to cache without parsing the response to separate emails.
-            # So actually we will just loop `fetch` for batch if we want it cleanly cached, or we don't cache
-            # `fetch_batch` if we aren't parsing it.
-            # Actually `fetch_batch` isn't needed if we just do individual fetches? No, batch is faster.
-            # But parsing batch response to stick into cache is annoying.
-            pass
-
-        # For this version, let's keep fetch_batch simple and bypass cache.
+        """Fetch multiple emails in a batch."""
+        if self.account is None:
+            return ("NO", ["No active IMAP connection"])
         return await email_fetch_batch(self.account, email_ids, parts)
 
     def clear(self) -> None:
-        """Clear the cache."""
+        """Clear the transient per-scan cache."""
         self._cache_rfc822.clear()
         self._cache_text.clear()
         self._cache_headers.clear()

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -66,6 +66,11 @@ async def test_email_cache_persistent_store_and_purge(hass):
 @pytest.mark.asyncio
 async def test_email_cache_load_and_save_errors(caplog):
     """Test EmailCache OSError handling on load and save."""
+    # Test when self._store is None
+    cache_no_store = EmailCache()
+    await cache_no_store.async_load()
+    await cache_no_store.async_save()
+
     mock_store = AsyncMock()
     mock_store.async_load.side_effect = OSError("Load error")
     mock_store.async_save.side_effect = OSError("Save error")

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,6 +1,7 @@
-"""Tests for EmailCache."""
+"""Tests for persistent EmailCache utility."""
 
-from unittest.mock import AsyncMock
+import datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -8,147 +9,44 @@ from custom_components.mail_and_packages.utils.cache import EmailCache
 
 
 @pytest.mark.asyncio
-async def test_cache_fetch_rfc822():
-    """Test fetching and caching RFC822."""
-    account = AsyncMock()
-    cache = EmailCache(account)
+async def test_email_cache_persistent_store_and_purge(hass):
+    """Test EmailCache persistence, load, save, and carrier expiration rules."""
+    with patch(
+        "custom_components.mail_and_packages.utils.cache.Store"
+    ) as mock_store_cls:
+        mock_store = AsyncMock()
+        mock_store.async_load.return_value = {"entries": {}}
+        mock_store_cls.return_value = mock_store
 
-    # Mock email_fetch
-    with pytest.MonkeyPatch.context() as mp:
-        mock_fetch = AsyncMock(return_value=("OK", [b"Email data"]))
-        mp.setattr(
-            "custom_components.mail_and_packages.utils.cache.email_fetch", mock_fetch
-        )
+        cache = EmailCache(hass=hass)
+        await cache.async_load()
 
-        # First fetch
-        res = await cache.fetch("1", "(RFC822)")
-        assert res == ("OK", [b"Email data"])
-        assert mock_fetch.call_count == 1
-        assert cache._cache_rfc822["1"] == ("OK", [b"Email data"])
+        now = datetime.datetime.now(datetime.UTC)
+        yesterday = now - datetime.timedelta(days=1)
+        four_days_ago = now - datetime.timedelta(days=4)
 
-        # Second fetch (cached)
-        res = await cache.fetch("1", "(RFC822)")
-        assert res == ("OK", [b"Email data"])
-        assert mock_fetch.call_count == 1
+        # Seed entries
+        cache._persistent_store = {
+            "usps_yesterday": {
+                "fetched_at": yesterday.isoformat(),
+                "shipper": "usps",
+                "data": ["OK", [b"usps mail"]],
+            },
+            "amazon_old": {
+                "fetched_at": four_days_ago.isoformat(),
+                "shipper": "amazon",
+                "data": ["OK", [b"amazon old"]],
+            },
+            "amazon_recent": {
+                "fetched_at": yesterday.isoformat(),
+                "shipper": "amazon",
+                "data": ["OK", [b"amazon recent"]],
+            },
+        }
 
-        # Body[] variant
-        res = await cache.fetch("1", "BODY[]")
-        assert res == ("OK", [b"Email data"])
-        assert mock_fetch.call_count == 1
+        # Non-amazon (usps_yesterday) expires at midnight, amazon_old exceeds custom_days (3)
+        await cache.async_purge_expired(custom_days=3)
 
-
-@pytest.mark.asyncio
-async def test_cache_fetch_headers():
-    """Test fetching and caching HEADERS."""
-    account = AsyncMock()
-    cache = EmailCache(account)
-
-    with pytest.MonkeyPatch.context() as mp:
-        mock_headers = AsyncMock(return_value=("OK", [b"Header data"]))
-        mp.setattr(
-            "custom_components.mail_and_packages.utils.cache.email_fetch_headers",
-            mock_headers,
-        )
-
-        # First fetch
-        res = await cache.fetch("1", "(HEADER)")
-        assert res == ("OK", [b"Header data"])
-        assert mock_headers.call_count == 1
-        assert cache._cache_headers["1"] == ("OK", [b"Header data"])
-
-        # Second fetch (cached)
-        res = await cache.fetch("1", "(HEADER)")
-        assert res == ("OK", [b"Header data"])
-        assert mock_headers.call_count == 1
-
-        # Fallback to RFC822
-        cache._cache_rfc822["2"] = ("OK", [b"Full data"])
-        res = await cache.fetch("2", "(HEADER)")
-        assert res == ("OK", [b"Full data"])
-        assert mock_headers.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_cache_fetch_text():
-    """Test fetching and caching TEXT."""
-    account = AsyncMock()
-    cache = EmailCache(account)
-
-    with pytest.MonkeyPatch.context() as mp:
-        mock_text = AsyncMock(return_value=("OK", [b"Text data"]))
-        mp.setattr(
-            "custom_components.mail_and_packages.utils.cache.email_fetch_text",
-            mock_text,
-        )
-
-        # First fetch
-        res = await cache.fetch("1", "(TEXT)")
-        assert res == ("OK", [b"Text data"])
-        assert mock_text.call_count == 1
-        assert cache._cache_text["1"] == ("OK", [b"Text data"])
-
-        # Second fetch (cached)
-        res = await cache.fetch("1", "(BODY[1])")
-        assert res == ("OK", [b"Text data"])
-        assert mock_text.call_count == 1
-
-        # Fallback to RFC822
-        cache._cache_rfc822["2"] = ("OK", [b"Full data"])
-        res = await cache.fetch("2", "(TEXT)")
-        assert res == ("OK", [b"Full data"])
-        assert mock_text.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_cache_fetch_unknown():
-    """Test fetching unknown parts."""
-    account = AsyncMock()
-    cache = EmailCache(account)
-
-    with pytest.MonkeyPatch.context() as mp:
-        mock_fetch = AsyncMock(return_value=("OK", [b"Unknown part"]))
-        mp.setattr(
-            "custom_components.mail_and_packages.utils.cache.email_fetch", mock_fetch
-        )
-
-        res = await cache.fetch("1", "(UNKNOWN)")
-        assert res == ("OK", [b"Unknown part"])
-        assert mock_fetch.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_cache_fetch_batch():
-    """Test fetch_batch."""
-    account = AsyncMock()
-    cache = EmailCache(account)
-
-    with pytest.MonkeyPatch.context() as mp:
-        mock_batch = AsyncMock(return_value=("OK", [b"Batch data"]))
-        mp.setattr(
-            "custom_components.mail_and_packages.utils.cache.email_fetch_batch",
-            mock_batch,
-        )
-
-        # Simple pass-through for now
-        res = await cache.fetch_batch(["1", "2"], "(RFC822)")
-        assert res == ("OK", [b"Batch data"])
-        assert mock_batch.call_count == 1
-
-        # Variant checks
-        await cache.fetch_batch(["3"], "(HEADER)")
-        await cache.fetch_batch(["4"], "(TEXT)")
-        await cache.fetch_batch(["5"], "(UNKNOWN)")
-
-
-def test_cache_clear():
-    """Test clearing the cache."""
-    account = AsyncMock()
-    cache = EmailCache(account)
-    cache._cache_rfc822["1"] = ("OK", [b"data"])
-    cache._cache_text["1"] = ("OK", [b"data"])
-    cache._cache_headers["1"] = ("OK", [b"data"])
-
-    cache.clear()
-    assert not cache._cache_rfc822
-    assert not cache._cache_text
-    assert not cache._cache_headers
+        assert "usps_yesterday" not in cache._persistent_store
+        assert "amazon_old" not in cache._persistent_store
+        assert "amazon_recent" in cache._persistent_store

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -25,28 +25,167 @@ async def test_email_cache_persistent_store_and_purge(hass):
         yesterday = now - datetime.timedelta(days=1)
         four_days_ago = now - datetime.timedelta(days=4)
 
-        # Seed entries
+        # Seed entries including malformed / invalid dates
         cache._persistent_store = {
             "usps_yesterday": {
                 "fetched_at": yesterday.isoformat(),
                 "shipper": "usps",
-                "data": ["OK", [b"usps mail"]],
+                "data": ["OK", ["usps mail"]],
             },
             "amazon_old": {
                 "fetched_at": four_days_ago.isoformat(),
                 "shipper": "amazon",
-                "data": ["OK", [b"amazon old"]],
+                "data": ["OK", ["amazon old"]],
             },
             "amazon_recent": {
                 "fetched_at": yesterday.isoformat(),
                 "shipper": "amazon",
-                "data": ["OK", [b"amazon recent"]],
+                "data": ["OK", ["amazon recent"]],
+            },
+            "invalid_date": {
+                "fetched_at": "invalid_iso_string",
+                "shipper": "generic",
+                "data": ["OK", ["invalid date"]],
+            },
+            "no_date": {
+                "shipper": "generic",
+                "data": ["OK", ["no date"]],
             },
         }
 
-        # Non-amazon (usps_yesterday) expires at midnight, amazon_old exceeds custom_days (3)
+        # Purge expired entries
         await cache.async_purge_expired(custom_days=3)
 
         assert "usps_yesterday" not in cache._persistent_store
         assert "amazon_old" not in cache._persistent_store
+        assert "invalid_date" not in cache._persistent_store
+        assert "no_date" not in cache._persistent_store
         assert "amazon_recent" in cache._persistent_store
+
+
+@pytest.mark.asyncio
+async def test_email_cache_load_and_save_errors(caplog):
+    """Test EmailCache OSError handling on load and save."""
+    mock_store = AsyncMock()
+    mock_store.async_load.side_effect = OSError("Load error")
+    mock_store.async_save.side_effect = OSError("Save error")
+
+    cache = EmailCache()
+    cache._store = mock_store
+
+    await cache.async_load()
+    assert cache._persistent_store == {}
+    assert "Failed to load email cache" in caplog.text
+
+    await cache.async_save()
+    assert "Failed to save email cache" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_email_cache_fetch_variations(hass):
+    """Test EmailCache fetch branches, restored byte structures, and fallback behavior."""
+    mock_account = AsyncMock()
+
+    cache = EmailCache(account=mock_account, hass=hass)
+
+    # 1. Test restoration from persistent store (tuples, bytes, lists, non-string items)
+    cache._persistent_store = {
+        "1:(RFC822)": {
+            "fetched_at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "shipper": "generic",
+            "data": ["OK", [["header", "body"], "plain_str", 123, None]],
+        },
+        "2:HEADER": {
+            "fetched_at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "shipper": "generic",
+            "data": ["OK", "non_list_response"],
+        },
+    }
+
+    res_rfc822 = await cache.fetch("1", "(RFC822)")
+    assert res_rfc822[0] == "OK"
+    assert res_rfc822[1][0] == (b"header", b"body")
+    assert res_rfc822[1][1] == b"plain_str"
+    assert res_rfc822[1][2] == 123
+
+    res_header_cached = await cache.fetch("2", "HEADER")
+    assert res_header_cached == ("OK", "non_list_response")
+
+    # 2. Test transient cache hits (RFC822, HEADER, TEXT)
+    cache._cache_rfc822["3"] = ("OK", [b"rfc822 cached"])
+    assert await cache.fetch("3", "(RFC822)") == ("OK", [b"rfc822 cached"])
+    assert await cache.fetch("3", "HEADER") == ("OK", [b"rfc822 cached"])
+    assert await cache.fetch("3", "TEXT") == ("OK", [b"rfc822 cached"])
+
+    cache._cache_headers["4"] = ("OK", [b"header cached"])
+    assert await cache.fetch("4", "HEADER") == ("OK", [b"header cached"])
+
+    cache._cache_text["5"] = ("OK", [b"text cached"])
+    assert await cache.fetch("5", "TEXT") == ("OK", [b"text cached"])
+
+    # 3. Test IMAP fetch execution & persistent storage serialization
+    with (
+        patch(
+            "custom_components.mail_and_packages.utils.cache.email_fetch",
+            AsyncMock(return_value=("OK", [(b"header", b"body"), b"raw_bytes", 456])),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.cache.email_fetch_headers",
+            AsyncMock(return_value=("OK", "string_resp")),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.cache.email_fetch_text",
+            AsyncMock(return_value=("OK", [b"text_body"])),
+        ),
+    ):
+        res_fetch = await cache.fetch("6", "(RFC822)")
+        assert res_fetch[0] == "OK"
+        assert "6:(RFC822)" in cache._persistent_store
+
+        res_h_fetch = await cache.fetch("7", "HEADER")
+        assert res_h_fetch[0] == "OK"
+        assert "7:HEADER" in cache._persistent_store
+
+        res_t_fetch = await cache.fetch("8", "TEXT")
+        assert res_t_fetch[0] == "OK"
+        assert "8:TEXT" in cache._persistent_store
+
+        res_other = await cache.fetch("9", "OTHER_PARTS")
+        assert res_other[0] == "OK"
+
+    # 4. Test fetch_batch with active account
+    with patch(
+        "custom_components.mail_and_packages.utils.cache.email_fetch_batch",
+        AsyncMock(return_value=("OK", [b"batch response"])),
+    ):
+        assert (await cache.fetch_batch(["11"], "(RFC822)")) == (
+            "OK",
+            [b"batch response"],
+        )
+
+    # 5. Test no active IMAP connection fallbacks
+    cache.account = None
+    assert (await cache.fetch("10", "(RFC822)")) == (
+        "NO",
+        ["No active IMAP connection"],
+    )
+    assert (await cache.fetch("10", "HEADER")) == ("NO", ["No active IMAP connection"])
+    assert (await cache.fetch("10", "TEXT")) == ("NO", ["No active IMAP connection"])
+    assert (await cache.fetch("10", "OTHER_PARTS")) == (
+        "NO",
+        ["No active IMAP connection"],
+    )
+    assert (await cache.fetch_batch(["10"], "(RFC822)")) == (
+        "NO",
+        ["No active IMAP connection"],
+    )
+
+    # 6. Test set_account and clear
+    cache._cache_rfc822["test"] = ("OK", [])
+    cache.set_account(mock_account)
+    assert cache.account == mock_account
+    assert len(cache._cache_rfc822) == 0
+
+    cache._cache_text["test"] = ("OK", [])
+    cache.clear()
+    assert len(cache._cache_text) == 0


### PR DESCRIPTION
## Proposed change

Implement a persistent IMAP email caching system backed by Home Assistant's `Store` (`homeassistant.helpers.storage.Store`).

- Refactored `EmailCache` to store fetched email payloads persistently across scan cycles so identical emails are not repeatedly re-downloaded from the IMAP server.
- Added retention & expiration rules in `async_purge_expired()`:
  - Non-Amazon carrier emails purge daily at midnight (00:00:00 local/UTC time).
  - Amazon carrier emails expire based on the configured `custom_days` setting.
- Keyed persistent storage entries by both email ID and IMAP fetch section (`parts`) to preserve exact header vs text vs full RFC822 payload structures.
- Added serialization/deserialization logic to preserve raw byte types required by internal email matching parsers across JSON persistence.
- Added unit tests in `tests/utils/test_cache.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
