### PR TITLE
docs(skills): add persistent email cache architecture skill and update IMAP RFC guidelines

### DIFF
--- a/.agents/skills/email_cache_architecture/SKILL.md
+++ b/.agents/skills/email_cache_architecture/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: Persistent Email Cache Architecture
+description: Architecture rules, byte-preservation serialization standards, and expiration rules for EmailCache.
+---
+
+# Persistent Email Cache Architecture
+
+This skill documents the design patterns, byte-preservation rules, and expiration lifecycle of the persistent IMAP email caching system (`EmailCache`).
+
+## Architectural Overview
+
+The `EmailCache` utility (`custom_components/mail_and_packages/utils/cache.py`) avoids duplicate IMAP email re-downloads across update cycles by leveraging Home Assistant's `Store` helper (`homeassistant.helpers.storage.Store`).
+
+- **Cache Keying**: Persistent store entries are keyed by `f"{eid_str}:{parts}"` (e.g. `"101:(RFC822)"`, `"102:HEADER"`) to store specific fetch payloads distinctly.
+- **Singleton Lifecycle**: Managed as a single persistent instance on `MailDataUpdateCoordinator.email_cache`.
+- **Transient Caches**: Cleared on every scan cycle via `set_account()` / `clear()`, while `_persistent_store` retains records across Home Assistant restarts.
+
+## Byte Preservation & Serialization Rules
+
+IMAP email responses contain raw `bytes` (MIME boundaries, binary attachments, headers) that are consumed by carrier parsing logic.
+
+1. **Serialization (`_store_persistent`)**:
+   - `bytes` instances inside response lists or tuples are converted to strings using `latin-1` encoding.
+   - **Do NOT use UTF-8 with replacement (`utf-8`, `errors="replace"`)**, as non-UTF-8 bytes will be mangled and corrupt header/subject regex matching in downstream carrier parsers.
+
+2. **Deserialization (`fetch`)**:
+   - When loading cached payloads from `_persistent_store`, `str` instances are re-encoded back to `bytes` using `latin-1` to restore original byte representations.
+
+## Expiration & Purge Lifecycle
+
+The `async_purge_expired(custom_days: int)` method enforces carrier-specific retention:
+
+- **Amazon Carrier Emails (`shipper="amazon"`)**: Retained up to `custom_days` cutoff (default 3 days).
+- **Non-Amazon Carrier Emails (`shipper != "amazon"`)**: Purged daily at midnight local/UTC time (`00:00:00`).
+- **Malformed / Missing Dates**: Purged immediately.

--- a/.agents/skills/imap_rfc_compliance/SKILL.md
+++ b/.agents/skills/imap_rfc_compliance/SKILL.md
@@ -40,3 +40,8 @@ Ensure all IMAP mock objects (such as mock connections or mock responses in `tes
 * Verify that test mocks explicitly assert that the generated search query uses correct keys (like `BODY` instead of `BODY[TEXT]`).
 * Do not write mocks that silently succeed on incorrect syntax.
 * Refer to [test_imap_email.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/tests/utils/test_imap_email.py) for examples of standard search string assertion assertions.
+
+### 6. Persistent Email Caching
+All email fetch calls (`email_fetch`, `email_fetch_headers`, `email_fetch_text`) should be routed through `EmailCache.fetch()`:
+* Cache keys store distinct payload sections via `f"{eid_str}:{parts}"`.
+* Raw byte structures must be preserved across storage operations using `latin-1` encoding (see [email_cache_architecture](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/.agents/skills/email_cache_architecture/SKILL.md)).


### PR DESCRIPTION
## Proposed change

Add a new repository skill `email_cache_architecture` and update `imap_rfc_compliance` to document standards for the persistent IMAP email caching system backed by Home Assistant's `Store`.

- Added `.agents/skills/email_cache_architecture/SKILL.md` documenting:
  - Cache keying structure (`f"{eid_str}:{parts}"`).
  - Byte-preservation rules via `latin-1` string ↔ byte serialization to prevent binary data corruption during JSON persistence.
  - Expiration and daily midnight purge rules enforced by `async_purge_expired()`.
- Updated `.agents/skills/imap_rfc_compliance/SKILL.md` to reference `EmailCache.fetch()` and `latin-1` byte preservation guidelines.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
