### PR TITLE
feat(camera): only enable cameras for associated sensors

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -11,7 +11,7 @@ import anyio
 import voluptuous as vol
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_RESOURCES
 from homeassistant.core import ServiceCall
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -35,6 +35,28 @@ SERVICE_UPDATE_IMAGE = "update_image"
 _LOGGER = logging.getLogger(__name__)
 
 
+def _get_sensor_name_for_camera(camera_type: str) -> str | None:
+    """Get the sensor name that corresponds to a camera type."""
+    base_name = camera_type.removesuffix("_camera")
+
+    if base_name == "usps":
+        return "usps_mail"
+    if base_name == "post_de":
+        return "post_de_mail"
+    if base_name == "generic":
+        return None
+
+    return f"{base_name}_delivered"
+
+
+def _is_camera_enabled(camera_type: str, resources: list[str]) -> bool:
+    """Check if a camera entity should be enabled based on resources."""
+    if camera_type == "generic_camera":
+        return any(res.endswith("_delivered") for res in resources)
+    sensor_name = _get_sensor_name_for_camera(camera_type)
+    return sensor_name in resources if sensor_name else False
+
+
 async def async_setup_entry(
     hass,
     config: MailAndPackagesConfigEntry,
@@ -42,12 +64,14 @@ async def async_setup_entry(
 ):
     """Set up the Camera that works with local files."""
     coordinator = config.runtime_data.coordinator
+    resources = coordinator.config.get(CONF_RESOURCES, [])
     camera = []
 
     for variable in CAMERA_DATA:
-        temp_cam = MailCam(hass, variable, config, coordinator)
-        camera.append(temp_cam)
-        config.runtime_data.cameras.append(temp_cam)
+        if _is_camera_enabled(variable, resources):
+            temp_cam = MailCam(hass, variable, config, coordinator)
+            camera.append(temp_cam)
+            config.runtime_data.cameras.append(temp_cam)
 
     async def _update_image(service: ServiceCall) -> None:
         """Refresh camera image."""
@@ -591,7 +615,7 @@ class MailCam(CoordinatorEntity, Camera):
 
         return False
 
-    def _get_sensor_name_for_camera(self, camera_type: str) -> str:
+    def _get_sensor_name_for_camera(self, camera_type: str) -> str | None:
         """Get the sensor name that corresponds to a camera type.
 
         Args:
@@ -601,17 +625,7 @@ class MailCam(CoordinatorEntity, Camera):
             The corresponding sensor name, or None if no mapping exists
 
         """
-        # Remove "_camera" suffix to get base name
-        base_name = camera_type.removesuffix("_camera")
-
-        # Special cases for mail scans cameras
-        if base_name == "usps":
-            return "usps_mail"
-        if base_name == "post_de":
-            return "post_de_mail"
-
-        # For other cameras, use the pattern: {base_name}_delivered
-        return f"{base_name}_delivered"
+        return _get_sensor_name_for_camera(camera_type)
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to hass."""

--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +50,7 @@ def _get_sensor_name_for_camera(camera_type: str) -> str | None:
     return f"{base_name}_delivered"
 
 
-def _is_camera_enabled(camera_type: str, resources: list[str]) -> bool:
+def _is_camera_enabled(camera_type: str, resources: Sequence[str]) -> bool:
     """Check if a camera entity should be enabled based on resources."""
     if camera_type == "generic_camera":
         return any(res.endswith("_delivered") for res in resources)

--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -53,9 +53,8 @@ def _is_camera_enabled(camera_type: str, resources: list[str]) -> bool:
     """Check if a camera entity should be enabled based on resources."""
     if camera_type == "generic_camera":
         return any(res.endswith("_delivered") for res in resources)
-    if (sensor_name := _get_sensor_name_for_camera(camera_type)) is not None:
-        return sensor_name in resources
-    return False
+    sensor_name = _get_sensor_name_for_camera(camera_type)
+    return bool(sensor_name and sensor_name in resources)
 
 
 async def async_setup_entry(

--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -53,8 +53,9 @@ def _is_camera_enabled(camera_type: str, resources: list[str]) -> bool:
     """Check if a camera entity should be enabled based on resources."""
     if camera_type == "generic_camera":
         return any(res.endswith("_delivered") for res in resources)
-    sensor_name = _get_sensor_name_for_camera(camera_type)
-    return sensor_name in resources if sensor_name else False
+    if (sensor_name := _get_sensor_name_for_camera(camera_type)) is not None:
+        return sensor_name in resources
+    return False
 
 
 async def async_setup_entry(
@@ -68,10 +69,11 @@ async def async_setup_entry(
     camera = []
 
     for variable in CAMERA_DATA:
-        if _is_camera_enabled(variable, resources):
-            temp_cam = MailCam(hass, variable, config, coordinator)
-            camera.append(temp_cam)
-            config.runtime_data.cameras.append(temp_cam)
+        if not _is_camera_enabled(variable, resources):
+            continue
+        temp_cam = MailCam(hass, variable, config, coordinator)
+        camera.append(temp_cam)
+        config.runtime_data.cameras.append(temp_cam)
 
     async def _update_image(service: ServiceCall) -> None:
         """Refresh camera image."""

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2819,11 +2819,11 @@ async def test_is_camera_enabled_helpers():
     # Test resource matching
     resources = ["usps_mail", "amazon_delivered"]
 
-    assert _is_camera_enabled("usps_camera", resources) is True
-    assert _is_camera_enabled("amazon_camera", resources) is True
-    assert _is_camera_enabled("ups_camera", resources) is False
-    assert _is_camera_enabled("generic_camera", resources) is True
+    assert _is_camera_enabled("usps_camera", resources)
+    assert _is_camera_enabled("amazon_camera", resources)
+    assert not _is_camera_enabled("ups_camera", resources)
+    assert _is_camera_enabled("generic_camera", resources)
 
     # Generic camera disabled when no _delivered sensor is present
     no_del_resources = ["usps_mail", "post_de_mail"]
-    assert _is_camera_enabled("generic_camera", no_del_resources) is False
+    assert not _is_camera_enabled("generic_camera", no_del_resources)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -8,7 +8,11 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mail_and_packages.camera import MailCam
+from custom_components.mail_and_packages.camera import (
+    MailCam,
+    _get_sensor_name_for_camera,
+    _is_camera_enabled,
+)
 from custom_components.mail_and_packages.const import (
     ATTR_AMAZON_IMAGE,
     ATTR_IMAGE_PATH,
@@ -2802,3 +2806,24 @@ async def test_generic_camera_gif_failure_fallback(
         assert "amazon" in str(generic_camera._file_path) or "mail_none.gif" in str(
             generic_camera._file_path
         )
+
+
+async def test_is_camera_enabled_helpers():
+    """Test _get_sensor_name_for_camera and _is_camera_enabled helper functions."""
+    assert _get_sensor_name_for_camera("usps_camera") == "usps_mail"
+    assert _get_sensor_name_for_camera("post_de_camera") == "post_de_mail"
+    assert _get_sensor_name_for_camera("amazon_camera") == "amazon_delivered"
+    assert _get_sensor_name_for_camera("ups_camera") == "ups_delivered"
+    assert _get_sensor_name_for_camera("generic_camera") is None
+
+    # Test resource matching
+    resources = ["usps_mail", "amazon_delivered"]
+
+    assert _is_camera_enabled("usps_camera", resources) is True
+    assert _is_camera_enabled("amazon_camera", resources) is True
+    assert _is_camera_enabled("ups_camera", resources) is False
+    assert _is_camera_enabled("generic_camera", resources) is True
+
+    # Generic camera disabled when no _delivered sensor is present
+    no_del_resources = ["usps_mail", "post_de_mail"]
+    assert _is_camera_enabled("generic_camera", no_del_resources) is False

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2827,3 +2827,22 @@ async def test_is_camera_enabled_helpers():
     # Generic camera disabled when no _delivered sensor is present
     no_del_resources = ["usps_mail", "post_de_mail"]
     assert not _is_camera_enabled("generic_camera", no_del_resources)
+
+
+async def test_post_de_camera_and_on_demand_update(hass, integration):
+    """Test post_de_camera initialization, file path update, and async_on_demand_update."""
+    entry = integration
+    coordinator = entry.runtime_data.coordinator
+
+    cam = MailCam(hass, "post_de_camera", entry, coordinator)
+    cam.entity_id = "camera.post_de"
+    assert cam.name == "Mail Post DE Camera"
+    assert "mail_none.gif" in cam._file_path
+
+    coordinator.data = {}
+    await cam.update_file_path()
+    assert "mail_none.gif" in cam._file_path
+
+    cam.async_schedule_update_ha_state = MagicMock()
+    await cam.async_on_demand_update()
+    cam.async_schedule_update_ha_state.assert_called_once_with(True)


### PR DESCRIPTION
## Proposed change

This PR updates `custom_components/mail_and_packages/camera.py` so camera entities are only initialized and registered with Home Assistant if their corresponding sensor resource is enabled in the integration's configured `resources` list (`CONF_RESOURCES`).

Specifically:
- **USPS Camera** (`usps_camera`): Enabled when `usps_mail` is in `resources`.
- **Post DE Camera** (`post_de_camera`): Enabled when `post_de_mail` is in `resources`.
- **Standard Carrier Cameras** (`amazon_camera`, `ups_camera`, `fedex_camera`, `walmart_camera`): Enabled when `{shipper}_delivered` is in `resources`.
- **Generic Camera** (`generic_camera`): Enabled when any package delivery sensor (`*_delivered`) is in `resources`.

Additionally, helper functions `_get_sensor_name_for_camera` and `_is_camera_enabled` were added to `camera.py`, and comprehensive unit tests were added to `tests/test_camera.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
