### PR TITLE
fix(imap): omit regex patterns from server-side IMAP body search

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -528,13 +528,15 @@ async def email_search(  # noqa: C901
         host_lower = account.host.lower()
         is_yahoo = "yahoo" in host_lower or "aol" in host_lower
 
-    # If there are more than 2 body patterns, do not search them server-side
-    # to prevent slow query execution and timeouts on standard IMAP servers.
+    # If there are more than 2 body patterns or if patterns contain regex metacharacters,
+    # do not search them server-side to prevent IMAP search failures and query timeouts.
     # Instead, we let the shipper's client-side text filtering handle it.
     body_search = body
     if body:
         bodies = [body] if isinstance(body, str) else body
-        if len(bodies) > 2:
+        if len(bodies) > 2 or any(
+            re.search(r"[\(\)\|\\\[\]\?\*\+\^\$]", b) for b in bodies
+        ):
             body_search = ""
 
     if len(folders) <= 1:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -534,9 +534,7 @@ async def email_search(  # noqa: C901
     body_search = body
     if body:
         bodies = [body] if isinstance(body, str) else body
-        if len(bodies) > 2 or any(
-            re.search(r"[\(\)\|\\\[\]\?\*\+\^\$]", b) for b in bodies
-        ):
+        if len(bodies) > 2 or any(re.search(r"[()|\[\]?*+^$\\]", b) for b in bodies):
             body_search = ""
 
     if len(folders) <= 1:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -967,3 +967,12 @@ async def test_migrate_version_20():
     # Options fields should be removed from data
     assert CONF_SCAN_INTERVAL not in kwargs["data"]
     assert CONF_AMAZON_DOMAIN not in kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_capost_mail_processing(hass, mock_imap_capost_mail, integration_capost):
+    """Test processing of Canada Post mail emails."""
+    entry = integration_capost
+    coordinator = entry.runtime_data.coordinator
+    await coordinator.async_refresh()
+    assert coordinator.data["capost_mail"] == 3

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1911,6 +1911,17 @@ async def test_email_search_body_threshold():
     search_query = mock_imap.search.call_args.args[0]
     assert "BODY" not in search_query
 
+    # Regex body pattern -> should NOT include BODY in search query
+    mock_imap.search.reset_mock()
+    await email_search(
+        mock_imap,
+        ["test@example.com"],
+        "25-Mar-2026",
+        body=[r"\sYou have (\d) piece|pieces of mail\s"],
+    )
+    search_query = mock_imap.search.call_args.args[0]
+    assert "BODY" not in search_query
+
 
 @pytest.mark.asyncio
 async def test_login_oauth_failed(caplog):


### PR DESCRIPTION
## Proposed change

Omit body patterns containing regular expression metacharacters (e.g. `\`, `(`, `|`, `[`, `]`, `?`, `*`, `+`, `^`, `$`) from server-side IMAP `SEARCH BODY` queries in `email_search()`.

Per IMAP RFC 3501, `BODY <string>` search criteria perform a literal substring match on the IMAP server without regex expansion. Passing regex strings (such as `\sYou have (\d) piece|pieces of mail\s` used for Canada Post mail piece count matching) causes the IMAP server to search for that exact literal string, resulting in 0 matching email UIDs and preventing Canada Post mail notifications from being processed.

By detecting regex metacharacters in `body` search strings, `email_search()` omits `BODY` criteria from server-side IMAP queries so searches succeed based on `FROM` and `SUBJECT` criteria. Client-side pattern matching in `find_text_matches` remains intact and continues to extract mail piece counts (`body_count`) accurately from fetched email bodies.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1346
- This PR is related to issue:
