### PR TITLE
fix(cache): support bytearray serialization in persistent store

### DIFF
--- a/custom_components/mail_and_packages/utils/cache.py
+++ b/custom_components/mail_and_packages/utils/cache.py
@@ -117,7 +117,7 @@ class EmailCache:
                 restored_list = []
                 if isinstance(response_list, list):
                     for item in response_list:
-                        if isinstance(item, list):
+                        if isinstance(item, (list, tuple)):
                             restored_list.append(
                                 tuple(
                                     x.encode("latin-1") if isinstance(x, str) else x
@@ -182,10 +182,11 @@ class EmailCache:
             for item in response_list:
                 if isinstance(item, tuple):
                     serialized_tuple = tuple(
-                        x.decode("latin-1") if isinstance(x, bytes) else x for x in item
+                        x.decode("latin-1") if isinstance(x, (bytes, bytearray)) else x
+                        for x in item
                     )
                     serializable_list.append(serialized_tuple)
-                elif isinstance(item, bytes):
+                elif isinstance(item, (bytes, bytearray)):
                     serializable_list.append(item.decode("latin-1"))
                 else:
                     serializable_list.append(item)

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -158,6 +158,33 @@ async def test_email_cache_fetch_variations(hass):
         res_other = await cache.fetch("9", "OTHER_PARTS")
         assert res_other[0] == "OK"
 
+    # 3b. Test IMAP fetch with bytearray response data
+    with patch(
+        "custom_components.mail_and_packages.utils.cache.email_fetch",
+        AsyncMock(
+            return_value=(
+                "OK",
+                [
+                    (b"header", bytearray(b"bytearray_body")),
+                    bytearray(b"raw_bytearray"),
+                ],
+            )
+        ),
+    ):
+        res_ba_fetch = await cache.fetch("12", "(RFC822)")
+        assert res_ba_fetch[0] == "OK"
+        assert "12:(RFC822)" in cache._persistent_store
+        # Verify store entry contains JSON-serializable strings instead of bytearray
+        stored_entry = cache._persistent_store["12:(RFC822)"]["data"]
+        assert stored_entry[1][0] == ("header", "bytearray_body")
+        assert stored_entry[1][1] == "raw_bytearray"
+
+        # Verify restoration on re-fetch returns bytes
+        res_ba_restore = await cache.fetch("12", "(RFC822)")
+        assert res_ba_restore[0] == "OK"
+        assert res_ba_restore[1][0] == (b"header", b"bytearray_body")
+        assert res_ba_restore[1][1] == b"raw_bytearray"
+
     # 4. Test fetch_batch with active account
     with patch(
         "custom_components.mail_and_packages.utils.cache.email_fetch_batch",


### PR DESCRIPTION
## Proposed change

Fix a Home Assistant JSON storage serialization error (`Bad data at $.data.entries...=bytearray(...)`) occurring when IMAP response payloads contain `bytearray` objects.

`EmailCache._store_persistent` previously checked items using `isinstance(x, bytes)`. Because `bytearray` is not a subclass of `bytes` in Python, `bytearray` items bypassed conversion to `latin-1` strings and were passed directly to Home Assistant's `Store` JSON serializer.

This PR updates `_store_persistent` to handle `isinstance(..., (bytes, bytearray))` and updates `fetch` deserialization checks for `isinstance(item, (list, tuple))`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1348
- This PR is related to issue:
