### PR TITLE
fix(oauth): start reauth on revoked token, stop reconfigure skipping dead ones

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -1274,6 +1274,37 @@ class MailAndPackagesFlowHandler(
 
         return await self._show_reconfig_auth_form(user_input)
 
+    async def _async_valid_oauth_token(self, auth_type: str) -> dict | None:
+        """Return the entry's OAuth token if it is still usable, else None.
+
+        Refreshes the token when it has expired. A refresh failure means the
+        grant is gone (revoked, or expired because the provider's OAuth app is
+        still in a testing/unpublished state) and the user has to re-consent.
+        """
+        if not self._entry:
+            return None
+
+        try:
+            self.hass.data.setdefault(DOMAIN, {})
+            self.hass.data[DOMAIN]["oauth_provider"] = auth_type
+            implementation = (
+                await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                    self.hass,
+                    self._entry,
+                )
+            )
+            session = config_entry_oauth2_flow.OAuth2Session(
+                self.hass,
+                self._entry,
+                implementation,
+            )
+            await session.async_ensure_token_valid()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Stored OAuth token is no longer usable: %s", err)
+            return None
+
+        return session.token
+
     async def async_step_reconfig_imap(self, user_input=None):
         """Handle IMAP step for reconfigure."""
         self._errors = {}
@@ -1283,6 +1314,7 @@ class MailAndPackagesFlowHandler(
             auth_type = self._data.get(CONF_AUTH_TYPE, AUTH_TYPE_PASSWORD)
 
             if auth_type != AUTH_TYPE_PASSWORD:
+                token = None
                 if (
                     self._entry
                     and self._entry.data.get(CONF_AUTH_TYPE) == auth_type
@@ -1291,6 +1323,18 @@ class MailAndPackagesFlowHandler(
                     == self._data.get(CONF_USERNAME)
                     and "token" in self._data
                 ):
+                    # Nothing OAuth-relevant changed, so a consent round-trip can
+                    # be skipped -- but only if the stored token actually still
+                    # works. Skipping on mere presence of a token means a user
+                    # reconfiguring to recover from a revoked/expired grant is
+                    # told "reconfigure_successful" while the dead token is
+                    # written straight back and the integration stays broken.
+                    token = await self._async_valid_oauth_token(auth_type)
+
+                if token is not None:
+                    # Carry the (possibly refreshed) token forward so saving
+                    # self._data cannot clobber it with the pre-refresh copy.
+                    self._data["token"] = token
                     self.hass.config_entries.async_update_entry(
                         self._entry,
                         data=self._data,

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -6,10 +6,12 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import timedelta
+from http import HTTPStatus
 from pathlib import Path
 from time import monotonic
 
 import anyio
+from aiohttp import ClientResponseError
 from aioimaplib import IMAP4_SSL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -112,6 +114,51 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             return file_hash
 
+    async def _async_oauth_access_token(self, auth_type: str) -> str:
+        """Return a valid OAuth2 access token, refreshing it when required.
+
+        Raises ConfigEntryAuthFailed when the grant itself is gone, so Home
+        Assistant starts a reauth flow instead of retrying forever.
+        """
+        try:
+            self.hass.data.setdefault(DOMAIN, {})
+            self.hass.data[DOMAIN]["oauth_provider"] = auth_type
+
+            implementation = (
+                await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                    self.hass,
+                    self.config_entry,
+                )
+            )
+            session = config_entry_oauth2_flow.OAuth2Session(
+                self.hass,
+                self.config_entry,
+                implementation,
+            )
+            await session.async_ensure_token_valid()
+        except ClientResponseError as err:
+            # The token endpoint rejecting the grant (typically "invalid_grant")
+            # means the refresh token has been revoked or has expired. Retrying
+            # can never recover from that, so surface it as an auth failure and
+            # let Home Assistant start a reauth flow.
+            if err.status in (HTTPStatus.BAD_REQUEST, HTTPStatus.UNAUTHORIZED):
+                _LOGGER.error(
+                    "OAuth token refresh was rejected (HTTP %s): %s. "
+                    "Reauthentication is required",
+                    err.status,
+                    err.message,
+                )
+                raise ConfigEntryAuthFailed(
+                    "OAuth token refresh failed, reauthentication required"
+                ) from err
+            _LOGGER.error("Error refreshing OAuth token: %s", err)
+            raise UpdateFailed("OAuth token refresh failed") from err
+        except Exception as err:
+            _LOGGER.error("Error refreshing OAuth token: %s", err)
+            raise UpdateFailed("OAuth token refresh failed") from err
+
+        return session.token["access_token"]
+
     async def _async_update_data(self):
         """Fetch data."""
         start = monotonic()
@@ -123,25 +170,9 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                     # Refresh OAuth2 token if using OAuth authentication
                     auth_type = config.get(CONF_AUTH_TYPE, AUTH_TYPE_PASSWORD)
                     if auth_type != AUTH_TYPE_PASSWORD and self.config_entry:
-                        try:
-                            self.hass.data.setdefault(DOMAIN, {})
-                            self.hass.data[DOMAIN]["oauth_provider"] = auth_type
-
-                            implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
-                                self.hass,
-                                self.config_entry,
-                            )
-                            session = config_entry_oauth2_flow.OAuth2Session(
-                                self.hass,
-                                self.config_entry,
-                                implementation,
-                            )
-                            await session.async_ensure_token_valid()
-                            config["oauth_token"] = session.token["access_token"]
-                        except Exception as err:
-                            _LOGGER.error("Error refreshing OAuth token")
-                            _LOGGER.debug("OAuth token refresh error details: %s", err)
-                            raise UpdateFailed("OAuth token refresh failed") from err
+                        config["oauth_token"] = await self._async_oauth_access_token(
+                            auth_type
+                        )
 
                     data = await self.process_emails(self.hass, config)
                 except ConfigEntryAuthFailed:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7474,7 +7474,7 @@ async def test_oauth_reconfig_flow_selection(hass, mock_imap_no_email, integrati
 
 @pytest.mark.asyncio
 async def test_oauth_reconfig_flow_skip_oauth(hass, mock_imap_no_email, integration):
-    """Test that reconfigure flow skips OAuth step when details are unchanged."""
+    """Test reconfigure skips OAuth when details are unchanged and the token works."""
     entry = integration
     # Update the entry with OAuth token and type to mock an existing OAuth setup
     hass.config_entries.async_update_entry(
@@ -7508,9 +7508,16 @@ async def test_oauth_reconfig_flow_skip_oauth(hass, mock_imap_no_email, integrat
     assert result["step_id"] == "reconfig_imap"
 
     # Configure IMAP with the exact same host/username (unchanged)
-    with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.AbstractOAuth2FlowHandler.async_step_pick_implementation"
-    ) as mock_pick:
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.AbstractOAuth2FlowHandler.async_step_pick_implementation"
+        ) as mock_pick,
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "_async_valid_oauth_token",
+            AsyncMock(return_value={"access_token": "fake_token"}),
+        ),
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -7524,6 +7531,75 @@ async def test_oauth_reconfig_flow_skip_oauth(hass, mock_imap_no_email, integrat
         assert mock_pick.call_count == 0
         assert result["type"] == "abort"
         assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.asyncio
+async def test_oauth_reconfig_flow_no_skip_when_token_dead(
+    hass, mock_imap_no_email, integration
+):
+    """Reconfigure must fall through to OAuth when the stored token is dead.
+
+    Same unchanged host/username as the skip test above -- only the token's
+    usability differs, which is what decides whether consent is needed.
+    """
+    entry = integration
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            "auth_type": "oauth2_google",
+            "token": {"access_token": "revoked_token"},
+            "host": "imap.test.email",
+            "username": "test@test.email",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"auth_type": "oauth2_google"},
+    )
+    assert result["step_id"] == "reconfig_imap"
+
+    pick_calls = []
+
+    async def _fake_pick_implementation(self, *args, **kwargs):
+        """Stand in for the external consent round-trip."""
+        pick_calls.append(True)
+        return self.async_abort(reason="oauth_started")
+
+    with (
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "async_step_pick_implementation",
+            _fake_pick_implementation,
+        ),
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "_async_valid_oauth_token",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "imap.test.email",
+                "port": 993,
+                "username": "test@test.email",
+                "imap_security": "SSL",
+            },
+        )
+
+    # A dead token must force a fresh consent round-trip, not a bogus
+    # "reconfigure_successful" that writes the dead token straight back.
+    assert pick_calls == [True]
+    assert result["reason"] == "oauth_started"
 
 
 @pytest.mark.asyncio
@@ -8221,3 +8297,140 @@ async def test_async_oauth_create_entry_reauth_successful(hass):
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.asyncio
+async def test_reconfig_imap_reruns_oauth_when_token_dead(hass):
+    """Reconfigure must re-run OAuth when the stored token no longer refreshes.
+
+    Regression test: the skip branch used to check only that a token was
+    present, so a user reconfiguring to recover from a revoked or expired grant
+    was told "reconfigure_successful" while the dead token was written straight
+    back and the integration stayed broken.
+    """
+    data = {
+        CONF_HOST: "imap.test.email",
+        CONF_USERNAME: "test@test.email",
+        CONF_AUTH_TYPE: "oauth2_google",
+        "token": {"access_token": "dead", "refresh_token": "revoked"},
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+
+    flow = MailAndPackagesFlowHandler()
+    flow.hass = hass
+    flow._entry = entry
+    flow._data = dict(data)
+    flow._errors = {}
+
+    with (
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "_async_valid_oauth_token",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "async_step_pick_implementation",
+            AsyncMock(return_value={"type": FlowResultType.EXTERNAL_STEP}),
+        ) as pick_implementation,
+    ):
+        result = await flow.async_step_reconfig_imap(
+            {
+                CONF_HOST: "imap.test.email",
+                CONF_USERNAME: "test@test.email",
+                CONF_AUTH_TYPE: "oauth2_google",
+            }
+        )
+
+    assert pick_implementation.called
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+
+@pytest.mark.asyncio
+async def test_reconfig_imap_skips_oauth_when_token_valid(hass):
+    """A working token still skips consent, and the refreshed token is kept."""
+    data = {
+        CONF_HOST: "imap.test.email",
+        CONF_USERNAME: "test@test.email",
+        CONF_AUTH_TYPE: "oauth2_google",
+        "token": {"access_token": "stale", "refresh_token": "good"},
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+
+    refreshed = {"access_token": "refreshed", "refresh_token": "good"}
+
+    flow = MailAndPackagesFlowHandler()
+    flow.hass = hass
+    flow._entry = entry
+    flow._data = dict(data)
+    flow._errors = {}
+
+    with (
+        patch.object(
+            MailAndPackagesFlowHandler,
+            "_async_valid_oauth_token",
+            AsyncMock(return_value=refreshed),
+        ),
+        patch.object(hass.config_entries, "async_reload", AsyncMock()),
+    ):
+        result = await flow.async_step_reconfig_imap(
+            {
+                CONF_HOST: "imap.test.email",
+                CONF_USERNAME: "test@test.email",
+                CONF_AUTH_TYPE: "oauth2_google",
+            }
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    # The refreshed token must survive: saving the pre-refresh copy of _data
+    # would silently roll the entry back to the stale access token.
+    assert entry.data["token"] == refreshed
+
+
+@pytest.mark.asyncio
+async def test_valid_oauth_token_helper(hass):
+    """_async_valid_oauth_token returns the token only when it still refreshes."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"token": {"access_token": "x"}})
+    entry.add_to_hass(hass)
+
+    flow = MailAndPackagesFlowHandler()
+    flow.hass = hass
+    flow._entry = entry
+
+    # No entry -> nothing to validate.
+    flow._entry = None
+    assert await flow._async_valid_oauth_token("oauth2_google") is None
+    flow._entry = entry
+
+    good_session = AsyncMock()
+    good_session.token = {"access_token": "refreshed"}
+    with (
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.OAuth2Session",
+            return_value=good_session,
+        ),
+    ):
+        assert await flow._async_valid_oauth_token("oauth2_google") == {
+            "access_token": "refreshed"
+        }
+
+    bad_session = AsyncMock()
+    bad_session.async_ensure_token_valid.side_effect = Exception("invalid_grant")
+    with (
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.config_flow.config_entry_oauth2_flow.OAuth2Session",
+            return_value=bad_session,
+        ),
+    ):
+        assert await flow._async_valid_oauth_token("oauth2_google") is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,13 +2,17 @@
 
 import asyncio
 import datetime
+from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiohttp import ClientResponseError
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mail_and_packages.const import CONF_FOLDER
+from custom_components.mail_and_packages.const import CONF_FOLDER, DOMAIN
 from custom_components.mail_and_packages.coordinator import MailDataUpdateCoordinator
 from custom_components.mail_and_packages.utils.imap import InvalidAuth
 from tests.const import FAKE_CONFIG_DATA
@@ -820,6 +824,319 @@ async def test_process_emails_delivered_tracking_reversed_order(hass):
     # In-transit tracking should still correctly exclude the delivered ones
     assert set(data["ups_tracking"]) == {"UPS_IN_TRANSIT"}
     assert set(data["ups_delivered_tracking"]) == {"UPS_DELIVERED_TODAY"}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_file_hash_if_changed(hass):
+    """Test _get_file_hash_if_changed caching and error paths."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    with (
+        patch("os.path.getmtime", return_value=12345),
+        patch(
+            "custom_components.mail_and_packages.coordinator.hash_file",
+            return_value="hash_abc",
+        ),
+    ):
+        hash1 = await coordinator._get_file_hash_if_changed("test_file.gif")
+        assert hash1 == "hash_abc"
+
+        # Repeated call returns cached hash directly without re-hashing
+        hash2 = await coordinator._get_file_hash_if_changed("test_file.gif")
+        assert hash2 == "hash_abc"
+
+    # OSError returns None
+    with patch("os.path.getmtime", side_effect=OSError("File missing")):
+        assert (await coordinator._get_file_hash_if_changed("missing.gif")) is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_oauth_token_refresh(hass):
+    """Test _async_update_data OAuth2 token refresh success and failure paths."""
+    config = {**FAKE_CONFIG_DATA, "auth_type": "oauth2_google"}
+    entry = MockConfigEntry(domain="mail_and_packages", data=config)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+        coordinator.config_entry = entry
+
+    mock_session = AsyncMock()
+    mock_session.token = {"access_token": "refreshed_oauth_token"}
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+        patch.object(
+            coordinator, "process_emails", AsyncMock(return_value={"test": 1})
+        ),
+        patch.object(coordinator, "_binary_sensor_update", AsyncMock()),
+    ):
+        res = await coordinator._async_update_data()
+        assert res == {"test": 1}
+
+    # Error during OAuth refresh raises UpdateFailed when no cached _data exists
+    coordinator._data = {}
+    mock_session_fail = AsyncMock()
+    mock_session_fail.async_ensure_token_valid.side_effect = Exception(
+        "OAuth refresh error"
+    )
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session_fail,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+def _oauth_error(status: int) -> ClientResponseError:
+    """Build a token endpoint error response."""
+    return ClientResponseError(
+        request_info=None,
+        history=(),
+        status=status,
+        message="invalid_grant",
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_oauth_token_revoked_triggers_reauth(hass, caplog):
+    """A rejected refresh token must raise ConfigEntryAuthFailed, not UpdateFailed.
+
+    Google answers a revoked or expired refresh token with 400 invalid_grant.
+    Retrying can never recover from that, so the integration has to ask the user
+    to re-consent instead of logging the same failure forever.
+    """
+    config = {**FAKE_CONFIG_DATA, "auth_type": "oauth2_google"}
+    entry = MockConfigEntry(domain="mail_and_packages", data=config)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+        coordinator.config_entry = entry
+
+    mock_session = AsyncMock()
+    mock_session.async_ensure_token_valid.side_effect = _oauth_error(
+        HTTPStatus.BAD_REQUEST
+    )
+
+    # Cached data must not mask the auth failure.
+    coordinator._data = {"cached": True}
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+    # The underlying reason must be visible without enabling debug logging.
+    assert "invalid_grant" in caplog.text
+    assert "Reauthentication is required" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_coordinator_oauth_token_server_error_is_retryable(hass):
+    """A 5xx from the token endpoint is transient and must stay UpdateFailed."""
+    config = {**FAKE_CONFIG_DATA, "auth_type": "oauth2_google"}
+    entry = MockConfigEntry(domain="mail_and_packages", data=config)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+        coordinator.config_entry = entry
+
+    mock_session = AsyncMock()
+    mock_session.async_ensure_token_valid.side_effect = _oauth_error(
+        HTTPStatus.INTERNAL_SERVER_ERROR
+    )
+
+    coordinator._data = {}
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_process_emails_copy_external_images_error(hass, caplog):
+    """Test process_emails handles copy_images OSError/ValueError gracefully."""
+    config = {**FAKE_CONFIG_DATA, "allow_external": True}
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.copy_images",
+            side_effect=OSError("Copy error"),
+        ),
+    ):
+        await coordinator.process_emails(hass, config)
+
+    assert "Problem creating: Copy error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_imap_connection_folder_failures(hass):
+    """Test _get_imap_connection folder selection exception and invalid folder return."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # 1. Folder selection exception
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            side_effect=Exception("IMAP select error"),
+        ),
+        pytest.raises(UpdateFailed, match="Folder selection failed: IMAP select error"),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+    # 2. Folder selection returns False
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=False,
+        ),
+        pytest.raises(UpdateFailed, match="Folder selection failed: INBOX"),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_get_imap_connection_deletes_auth_failed_issue(hass):
+    """Test _get_imap_connection deletes auth_failed issue if present."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # Pre-register issue in registry
+    issue_registry = ir.async_get(hass)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "auth_failed",
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="auth_failed",
+    )
+    assert (DOMAIN, "auth_failed") in issue_registry.issues
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+    ):
+        await coordinator._get_imap_connection(
+            {**FAKE_CONFIG_DATA, CONF_FOLDER: "INBOX"}
+        )
+
+    assert (DOMAIN, "auth_failed") not in issue_registry.issues
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_data_error_with_cached_data_and_auth_failed(
+    hass,
+):
+    """Test _async_update_data re-raises ConfigEntryAuthFailed and returns cached data on generic error."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # 1. ConfigEntryAuthFailed is re-raised
+    with (
+        patch.object(
+            coordinator,
+            "process_emails",
+            AsyncMock(side_effect=ConfigEntryAuthFailed("Auth failed")),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+    # 2. Generic Exception with pre-existing cached _data returns cached _data
+    coordinator._data = {"cached": "value"}
+    with patch.object(
+        coordinator,
+        "process_emails",
+        AsyncMock(side_effect=Exception("Generic update error")),
+    ):
+        res = await coordinator._async_update_data()
+        assert res == {"cached": "value"}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_different_hash_and_post_de(hass):
+    """Test _binary_sensor_update when image hash differs from none hash for USPS and post_de."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    coordinator._data = {
+        "usps_image": "mail_123.jpg",
+        "post_de_image": "post_de_123.jpg",
+    }
+
+    # Mock hash_file to return non-none hash
+    with patch(
+        "custom_components.mail_and_packages.coordinator.hash_file",
+        return_value="new_hash",
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator.hass.states.get("binary_sensor.mail_usps_mail").state == "on"
+    assert coordinator.hass.states.get("binary_sensor.mail_post_de_mail").state == "on"
 
 
 def test_dedupe_marketplace_duplicates_etsy():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -906,7 +906,7 @@ async def test_coordinator_oauth_token_refresh(hass):
 def _oauth_error(status: int) -> ClientResponseError:
     """Build a token endpoint error response."""
     return ClientResponseError(
-        request_info=None,
+        request_info=AsyncMock(),
         history=(),
         status=status,
         message="invalid_grant",
@@ -1128,15 +1128,109 @@ async def test_coordinator_binary_sensor_update_different_hash_and_post_de(hass)
         "post_de_image": "post_de_123.jpg",
     }
 
-    # Mock hash_file to return non-none hash
-    with patch(
-        "custom_components.mail_and_packages.coordinator.hash_file",
-        return_value="new_hash",
+    # Mock image exists check and hash_file
+    with (
+        patch("anyio.Path.exists", return_value=True),
+        patch(
+            "custom_components.mail_and_packages.coordinator.hash_file",
+            side_effect=["hash_a", "hash_b", "hash_c", "hash_d"],
+        ),
     ):
         await coordinator._binary_sensor_update()
 
-    assert coordinator.hass.states.get("binary_sensor.mail_usps_mail").state == "on"
-    assert coordinator.hass.states.get("binary_sensor.mail_post_de_mail").state == "on"
+    assert coordinator._data.get("usps_update") is True
+    assert coordinator._data.get("post_de_update") is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_same_hash_and_custom_img(hass):
+    """Test _binary_sensor_update false branches for image hashes equal and custom image settings."""
+    config = {
+        **FAKE_CONFIG_DATA,
+        "amazon_custom_img": True,
+        "amazon_custom_img_file": "custom_amazon.jpg",
+    }
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+
+    coordinator._data = {
+        "usps_image": "mail_123.jpg",
+        "amazon_image": "amazon_123.jpg",
+    }
+
+    with (
+        patch("anyio.Path.exists", return_value=True),
+        patch.object(
+            coordinator,
+            "_get_file_hash_if_changed",
+            AsyncMock(return_value="same_hash"),
+        ),
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator._data.get("usps_update") is False
+    assert coordinator._data.get("amazon_update") is False
+
+
+@pytest.mark.asyncio
+async def test_coordinator_oauth_token_refresh_client_response_error_non_400_401(
+    hass,
+):
+    """Test client response error with non-400/401 status raises UpdateFailed (line 155)."""
+    config = {**FAKE_CONFIG_DATA, "auth_type": "oauth2_google"}
+    entry = MockConfigEntry(domain="mail_and_packages", data=config)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, config)
+        coordinator.config_entry = entry
+
+    mock_session = AsyncMock()
+    mock_session.async_ensure_token_valid.side_effect = _oauth_error(
+        HTTPStatus.BAD_GATEWAY
+    )
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.config_entry_oauth2_flow.OAuth2Session",
+            return_value=mock_session,
+        ),
+        pytest.raises(UpdateFailed, match="OAuth token refresh failed"),
+    ):
+        await coordinator._async_oauth_access_token("oauth2_google")
+
+
+@pytest.mark.asyncio
+async def test_coordinator_binary_sensor_update_missing_image_attr_and_default_none_image(
+    hass,
+):
+    """Test _binary_sensor_update when image attribute isn't in const (line 668) and standard default none image (line 704)."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    coordinator._data = {
+        "ups_image": "ups_123.jpg",
+    }
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.const.CAMERA_DATA",
+            {"fake_camera": {}, "ups_camera": {}},
+        ),
+        patch("anyio.Path.exists", return_value=True),
+        patch.object(
+            coordinator,
+            "_get_file_hash_if_changed",
+            AsyncMock(side_effect=["hash_ups", "hash_none"]),
+        ),
+    ):
+        await coordinator._binary_sensor_update()
+
+    assert coordinator._data.get("ups_update") is True
 
 
 def test_dedupe_marketplace_duplicates_etsy():


### PR DESCRIPTION
## Problem

An OAuth (Gmail) mailbox whose refresh token has been revoked or has expired ends up permanently broken with **no way to recover from the UI**. Two separate issues combine:

**1. A dead grant is reported as a transient failure, so reauth never starts.**

`MailDataUpdateCoordinator._async_update_data` turned every OAuth refresh failure into `UpdateFailed` and logged the underlying error at `debug`:

```python
except Exception as err:
    _LOGGER.error("Error refreshing OAuth token")
    _LOGGER.debug("OAuth token refresh error details: %s", err)
    raise UpdateFailed("OAuth token refresh failed") from err
```

Google answers a revoked/expired refresh token with `400 invalid_grant`, which retrying can never fix. But `ConfigEntryAuthFailed` is only raised on the *IMAP login* path, which is never reached because the refresh aborts first — so Home Assistant never offers reauth, and the log shows only:

```
Error refreshing OAuth token
Problem updating sensors: OAuth token refresh failed
Error fetching Mail and Packages (imap.gmail.com) data: OAuth token refresh failed
```

repeating every scan interval, with the actual reason invisible unless debug logging is enabled.

**2. Reconfigure reports success without re-running OAuth.**

`async_step_reconfig_imap` skips the consent round-trip when auth type, host and username are unchanged and a `token` key exists:

```python
and "token" in self._data
```

That checks only that a token is **present**, never that it **works**. A user reconfiguring specifically to recover from a revoked grant is shown `reconfigure_successful` while the dead token is written straight back and the integration stays broken. Before #1326 this branch went to `async_step_pick_implementation()` unconditionally, so reconfigure used to be a working recovery path.

With both in play there is no route back to a working integration short of deleting and re-adding the entry (losing all options).

## Changes

- **`coordinator.py`** — a `ClientResponseError` with status 400/401 from the token endpoint now raises `ConfigEntryAuthFailed`, so HA starts a reauth flow. Other failures (network blips, 5xx) remain `UpdateFailed` and keep retrying. The provider's error is logged at `error` level instead of `debug`.
- **`coordinator.py`** — the refresh is extracted into `_async_oauth_access_token()`, keeping `_async_update_data` within the C901 complexity limit.
- **`config_flow.py`** — the reconfigure skip additionally requires the stored token to still refresh (`_async_valid_oauth_token`). It also assigns the refreshed token into `self._data` before saving, so writing the pre-refresh copy of `_data` cannot roll the entry back to a stale access token.

The existing reauth flow already performs a real consent round-trip, so once `ConfigEntryAuthFailed` is raised the recovery path works without further changes.

## Tests

- `test_coordinator_oauth_token_revoked_triggers_reauth` — 400 raises `ConfigEntryAuthFailed` even when cached data exists, and the reason is visible at error level.
- `test_coordinator_oauth_token_server_error_is_retryable` — 5xx stays `UpdateFailed`.
- `test_oauth_reconfig_flow_no_skip_when_token_dead` — a dead token forces consent; the paired existing skip test is unchanged in intent and now mocks a working token.
- `test_reconfig_imap_reruns_oauth_when_token_dead` / `test_reconfig_imap_skips_oauth_when_token_valid` — the second also asserts the refreshed token is not clobbered.
- `test_valid_oauth_token_helper` — both branches of the new helper.

`612 passed`, coverage 99.88%. `ruff check` and `ruff format` clean.

## Notes

Encountered in the wild: the Google Cloud OAuth consent screen was in **Testing** publishing status, where Google expires refresh tokens after 7 days. That is a user-side configuration issue, but it makes this failure mode recur on a weekly cycle, which is how both bugs surfaced. Publishing the app to production stops the expiry; these changes make the failure recoverable when it does happen.
