### PR TITLE
fix(config): skip integration reload on oauth token refresh

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -115,6 +115,15 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
+OAUTH_TOKEN_KEYS = {
+    "token",
+    "access_token",
+    "refresh_token",
+    "expires_at",
+    "expires_in",
+    "auth_implementation",
+}
+
 
 async def async_setup(hass: HomeAssistant, config_entry: MailAndPackagesConfigEntry):  # pylint: disable=unused-argument
     """Disallow configuration via YAML."""
@@ -153,7 +162,15 @@ async def async_setup_entry(
     # Setup the data coordinator
     coordinator = MailDataUpdateCoordinator(hass, config, config_entry)
 
-    config_entry.runtime_data = MailAndPackagesData(coordinator=coordinator, cameras=[])
+    last_data = {
+        k: v for k, v in config_entry.data.items() if k not in OAUTH_TOKEN_KEYS
+    }
+    config_entry.runtime_data = MailAndPackagesData(
+        coordinator=coordinator,
+        cameras=[],
+        last_options=dict(config_entry.options),
+        last_data=last_data,
+    )
 
     # Fetch initial data in the background so setup doesn't block
     hass.async_create_task(coordinator.async_refresh())
@@ -169,6 +186,17 @@ async def update_listener(
     hass: HomeAssistant, config_entry: MailAndPackagesConfigEntry
 ) -> None:
     """Update listener."""
+    if config_entry.runtime_data:
+        current_non_oauth_data = {
+            k: v for k, v in config_entry.data.items() if k not in OAUTH_TOKEN_KEYS
+        }
+        if (
+            config_entry.options == config_entry.runtime_data.last_options
+            and current_non_oauth_data == config_entry.runtime_data.last_data
+        ):
+            _LOGGER.debug("Config entry update was token-only refresh; skipping reload")
+            return
+
     _LOGGER.debug("Attempting to reload sensors from the %s integration", DOMAIN)
     await hass.config_entries.async_reload(config_entry.entry_id)
 

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -60,6 +60,8 @@ class MailAndPackagesData:
 
     coordinator: "MailDataUpdateCoordinator"
     cameras: list
+    last_options: dict | None = None
+    last_data: dict | None = None
 
 
 type MailAndPackagesConfigEntry = ConfigEntry[MailAndPackagesData]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,7 @@ from custom_components.mail_and_packages import (
     async_migrate_entry,
     async_remove_config_entry_device,
     async_setup_entry,
+    update_listener,
 )
 from custom_components.mail_and_packages.const import (
     CONF_AMAZON_DOMAIN,
@@ -976,3 +977,56 @@ async def test_capost_mail_processing(hass, mock_imap_capost_mail, integration_c
     coordinator = entry.runtime_data.coordinator
     await coordinator.async_refresh()
     assert coordinator.data["capost_mail"] == 3
+
+
+@pytest.mark.asyncio
+async def test_update_listener_token_refresh_skips_reload():
+    """Test that update_listener skips async_reload on token-only updates."""
+    mock_hass = MagicMock()
+    mock_hass.config_entries.async_reload = AsyncMock()
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.options = {"scan_interval": 15}
+    mock_entry.data = {
+        "host": "imap.test.email",
+        "token": {"access_token": "token1"},
+    }
+
+    mock_runtime_data = MagicMock()
+    mock_runtime_data.last_options = {"scan_interval": 15}
+    mock_runtime_data.last_data = {"host": "imap.test.email"}
+    mock_entry.runtime_data = mock_runtime_data
+
+    # Simulate token refresh updating entry data
+    mock_entry.data = {
+        "host": "imap.test.email",
+        "token": {"access_token": "token2"},
+    }
+
+    await update_listener(mock_hass, mock_entry)
+
+    # async_reload should NOT have been called
+    mock_hass.config_entries.async_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_listener_options_change_triggers_reload():
+    """Test that update_listener triggers async_reload when options change."""
+    mock_hass = MagicMock()
+    mock_hass.config_entries.async_reload = AsyncMock()
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.options = {"scan_interval": 30}
+    mock_entry.data = {"host": "imap.test.email"}
+
+    mock_runtime_data = MagicMock()
+    mock_runtime_data.last_options = {"scan_interval": 15}
+    mock_runtime_data.last_data = {"host": "imap.test.email"}
+    mock_entry.runtime_data = mock_runtime_data
+
+    await update_listener(mock_hass, mock_entry)
+
+    # async_reload SHOULD be called
+    mock_hass.config_entries.async_reload.assert_called_once_with("test_entry")


### PR DESCRIPTION
## Proposed change

Gmail OAuth2 access tokens expire every 1 hour (3,600 seconds). During hourly coordinator updates, `session.async_ensure_token_valid()` refreshes the token and saves it to `config_entry.data["token"]` via `hass.config_entries.async_update_entry(...)`.

Currently, `update_listener` in `custom_components/mail_and_packages/__init__.py` listens for any update to `config_entry` and unconditionally calls `await hass.config_entries.async_reload(config_entry.entry_id)`.

When `async_reload` runs, Home Assistant unloads all integration entities (`camera` and `sensor`), temporarily marking them `unavailable`, and then re-adds them (`idle`), causing entities to cycle `idle` → `unavailable` → `idle` every 1 hour.

This PR updates `update_listener` and `MailAndPackagesData` to compare updated `config_entry.options` and non-token `config_entry.data` against the snapshot stored at setup time. When an entry update consists only of OAuth token refreshes, `update_listener` logs a debug message and skips calling `async_reload()`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1337
- This PR is related to issue:
