### PR TITLE
fix(aliexpress): add out for delivery subject and body patterns

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -1096,6 +1096,7 @@ SENSOR_DATA = {
             "in your country/region",
             "in local transit",
             "with local carrier",
+            "out for delivery",
         ],
         "body": [
             "on the way",
@@ -1106,6 +1107,7 @@ SENSOR_DATA = {
             "customs",
             "transit",
             "departure",
+            "out for delivery",
         ],
     },
     "aliexpress_packages": {},

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1399,6 +1399,7 @@ async def test_shopify_delivered_class(hass, mock_imap_shopify_delivered):
         ("Package JY26CAA0D000551012: in your country/region", "aliexpress_delivering"),
         ("Package HM0000010001198611: in local transit", "aliexpress_delivering"),
         ("Package JY26CAA0D000551012: with local carrier", "aliexpress_delivering"),
+        ("Package JY26CAA0D000551012 is out for delivery", "aliexpress_delivering"),
         ("Package JY26CAA0D000551012 has been delivered", "aliexpress_delivered"),
         # Non-shipping notifications from the same sender must not match
         ("Order 8211968327931234: order confirmed", None),


### PR DESCRIPTION
## Proposed change

Adds `"out for delivery"` to `aliexpress_delivering` subject and body matchers in `const.py` to match AliExpress delivery notification emails with subjects such as `Package <ID> is out for delivery` (e.g. `Package JY26CAA0D000551012 is out for delivery`).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1352
- This PR is related to issue:
