### PR TITLE
feat(shippers): add support for Danish carriers (#1324)

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -709,12 +709,14 @@ SENSOR_DATA = {
             "no-reply@gls-pakete.de",
             "noreply@gls-group.nl",
             "noreply@gls.nl",
+            "pakke-shop@pakkeshop.dk",
         ],
         "subject": [
             "informacja o dostawie",
             "wurde durch GLS",
             "bezorgd",
             "afgeleverd",
+            "Du kan nu hente pakke",
         ],
         "body": [
             "została dzisiaj dostarczona",
@@ -731,6 +733,7 @@ SENSOR_DATA = {
             "no-reply@gls-pakete.de",
             "noreply@gls-group.nl",
             "noreply@gls.nl",
+            "noreply@gls-denmark.com",
         ],
         "subject": [
             "paczka w drodze",
@@ -738,6 +741,7 @@ SENSOR_DATA = {
             "kommt heute",
             "pakket onderweg",
             "bezorging vandaag",
+            "GLS pakke",
         ],
         "body": [
             "Zespół GLS",
@@ -1188,7 +1192,7 @@ SENSOR_DATA = {
     },
     "bolcom_packages": {},
     "bolcom_tracking": {"pattern": ["3S[A-Z0-9]{10,18}", "JJD\\d{14,25}", "\\d{14}"]},
-    # PostNord (Sweden)
+    # PostNord (Sweden/Denmark)
     "postnord_delivered": {
         "email": [
             "no-reply@postnord.com",
@@ -1199,6 +1203,7 @@ SENSOR_DATA = {
             "finns att hamta",
             "har levererats",
             "Levererad",
+            "klar til afhentning",
         ],
     },
     "postnord_delivering": {
@@ -1213,26 +1218,32 @@ SENSOR_DATA = {
             "ar pa vag",
             "på väg till dig",
             "pa vag till dig",
+            "Der er nyt om din PostNord-pakke",
         ],
     },
     "postnord_packages": {},
-    "postnord_tracking": {"pattern": ["[0-9]{13,18}SE", "SE[0-9]{9}SE"]},
-    # Bring (Sweden/Norway)
+    "postnord_tracking": {
+        "pattern": ["[0-9]{13,18}SE", "SE[0-9]{9}SE", "[0-9]{13,18}DK"]
+    },
+    # Bring (Sweden/Norway/Denmark)
     "bring_delivered": {
         "email": [
             "no-reply@bring.com",
             "notification@bring.com",
+            "noreply@bring.com",
         ],
         "subject": [
             "paket att hämta",
             "paket att hamta",
             "har levererats",
+            "Nu kan du hente din pakke fra",
         ],
     },
     "bring_delivering": {
         "email": [
             "no-reply@bring.com",
             "notification@bring.com",
+            "noreply@bring.com",
         ],
         "subject": [
             "sändning är på väg",
@@ -1241,10 +1252,51 @@ SENSOR_DATA = {
             "sandning har skickats",
             "Paket på väg",
             "Paket pa vag",
+            "er på vej",
         ],
     },
     "bring_packages": {},
     "bring_tracking": {"pattern": ["PARCEL[0-9A-Z]{10,20}", "CT[0-9]{9}NO"]},
+    # DAO (Denmark)
+    "dao_delivered": {
+        "email": ["no-reply@dao.as"],
+        "subject": ["Nu kan du hente din pakke fra"],
+    },
+    "dao_delivering": {
+        "body": ["Forsendelsen sendes med: DAO-DK-DIREKTE"],
+    },
+    "dao_packages": {},
+    "dao_tracking": {},
+    # Budbee
+    "budbee_delivering": {
+        "email": ["no-reply@budbee.com"],
+        "subject": ["er nu registreret hos Budbee"],
+    },
+    "budbee_delivered": {},
+    "budbee_packages": {},
+    "budbee_tracking": {},
+    # Airmee
+    "airmee_delivered": {
+        "email": ["no-reply@airmee.com"],
+        "subject": ["Airmee har leveret din pakke"],
+    },
+    "airmee_delivering": {
+        "email": ["no-reply@airmee.com"],
+        "subject": ["Levering booket av Amazon med Airmee"],
+    },
+    "airmee_packages": {},
+    "airmee_tracking": {},
+    # Burd Delivery
+    "burd_delivered": {
+        "email": ["support@burd.dk"],
+        "subject": ["Din pakke er leveret"],
+    },
+    "burd_delivering": {
+        "email": ["support@burd.dk"],
+        "subject": ["Din pakke fra"],
+    },
+    "burd_packages": {},
+    "burd_tracking": {},
     # DB Schenker (Sweden)
     "db_schenker_delivered": {
         "email": [
@@ -1904,6 +1956,82 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         native_unit_of_measurement="package(s)",
         icon="mdi:package-variant-closed",
         key="etsy_packages",
+    ),
+    # DAO
+    "dao_delivering": SensorEntityDescription(
+        name="Mail DAO Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="dao_delivering",
+    ),
+    "dao_delivered": SensorEntityDescription(
+        name="Mail DAO Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="dao_delivered",
+    ),
+    "dao_packages": SensorEntityDescription(
+        name="Mail DAO Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="dao_packages",
+    ),
+    # Budbee
+    "budbee_delivering": SensorEntityDescription(
+        name="Mail Budbee Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="budbee_delivering",
+    ),
+    "budbee_delivered": SensorEntityDescription(
+        name="Mail Budbee Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="budbee_delivered",
+    ),
+    "budbee_packages": SensorEntityDescription(
+        name="Mail Budbee Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="budbee_packages",
+    ),
+    # Airmee
+    "airmee_delivering": SensorEntityDescription(
+        name="Mail Airmee Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="airmee_delivering",
+    ),
+    "airmee_delivered": SensorEntityDescription(
+        name="Mail Airmee Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="airmee_delivered",
+    ),
+    "airmee_packages": SensorEntityDescription(
+        name="Mail Airmee Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="airmee_packages",
+    ),
+    # Burd Delivery
+    "burd_delivering": SensorEntityDescription(
+        name="Mail Burd Delivery Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="burd_delivering",
+    ),
+    "burd_delivered": SensorEntityDescription(
+        name="Mail Burd Delivery Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant",
+        key="burd_delivered",
+    ),
+    "burd_packages": SensorEntityDescription(
+        name="Mail Burd Delivery Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="burd_packages",
     ),
     ###
     # !!! Insert new sensors above these summary sensors !!!

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1871,3 +1871,79 @@ async def test_shopify_no_carrier_tracking_is_noop(hass, mock_imap):
     result = await shipper.process(mock_imap, "today", "shopify_packages")
     assert result[ATTR_COUNT] == 1
     assert "shopify_carrier_tracking" not in result
+
+
+def test_danish_carrier_patterns():
+    """Test matching Danish carrier subjects, emails, and bodies against SENSOR_DATA."""
+    # DAO
+    dao_del_subj = "Nu kan du hente din pakke fra TestShop"
+    dao_del_email = "no-reply@dao.as"
+    dao_deliv_body = "Forsendelsen sendes med: DAO-DK-DIREKTE\nTrackingnummer: 12345"
+
+    assert any(s in dao_del_subj for s in SENSOR_DATA["dao_delivered"]["subject"])
+    assert dao_del_email in SENSOR_DATA["dao_delivered"]["email"]
+    assert any(b in dao_deliv_body for b in SENSOR_DATA["dao_delivering"]["body"])
+
+    # Bring DK
+    bring_deliv_email = "noreply@bring.com"
+    bring_deliv_subj = "En pakke fra Sender is er på vej"
+    bring_del_subj = "Nu kan du hente din pakke fra Sender"
+
+    assert bring_deliv_email in SENSOR_DATA["bring_delivering"]["email"]
+    assert any(
+        s in bring_deliv_subj for s in SENSOR_DATA["bring_delivering"]["subject"]
+    )
+    assert bring_deliv_email in SENSOR_DATA["bring_delivered"]["email"]
+    assert any(s in bring_del_subj for s in SENSOR_DATA["bring_delivered"]["subject"])
+
+    # PostNord DK
+    pn_deliv_email = "no-reply@postnord.com"
+    pn_deliv_subj = "Der er nyt om din PostNord-pakke"
+    pn_del_subj = "Din PostNord-pakke er klar til afhentning"
+
+    assert pn_deliv_email in SENSOR_DATA["postnord_delivering"]["email"]
+    assert any(
+        s in pn_deliv_subj for s in SENSOR_DATA["postnord_delivering"]["subject"]
+    )
+    assert pn_deliv_email in SENSOR_DATA["postnord_delivered"]["email"]
+    assert any(s in pn_del_subj for s in SENSOR_DATA["postnord_delivered"]["subject"])
+
+    # Budbee
+    budbee_email = "no-reply@budbee.com"
+    budbee_subj = "Din ordre fra SENDER er nu registreret hos Budbee"
+
+    assert budbee_email in SENSOR_DATA["budbee_delivering"]["email"]
+    assert any(s in budbee_subj for s in SENSOR_DATA["budbee_delivering"]["subject"])
+
+    # Airmee
+    airmee_email = "no-reply@airmee.com"
+    airmee_deliv_subj = "Levering booket av Amazon med Airmee"
+    airmee_del_subj = "Airmee har leveret din pakke"
+
+    assert airmee_email in SENSOR_DATA["airmee_delivering"]["email"]
+    assert any(
+        s in airmee_deliv_subj for s in SENSOR_DATA["airmee_delivering"]["subject"]
+    )
+    assert airmee_email in SENSOR_DATA["airmee_delivered"]["email"]
+    assert any(s in airmee_del_subj for s in SENSOR_DATA["airmee_delivered"]["subject"])
+
+    # Burd Delivery
+    burd_email = "support@burd.dk"
+    burd_deliv_subj = "Din pakke fra SENDER"
+    burd_del_subj = "Din pakke er leveret"
+
+    assert burd_email in SENSOR_DATA["burd_delivering"]["email"]
+    assert any(s in burd_deliv_subj for s in SENSOR_DATA["burd_delivering"]["subject"])
+    assert burd_email in SENSOR_DATA["burd_delivered"]["email"]
+    assert any(s in burd_del_subj for s in SENSOR_DATA["burd_delivered"]["subject"])
+
+    # GLS Denmark
+    gls_deliv_email = "noreply@gls-denmark.com"
+    gls_deliv_subj = "GLS pakke"
+    gls_del_email = "pakke-shop@pakkeshop.dk"
+    gls_del_subj = "Du kan nu hente pakke 12345678"
+
+    assert gls_deliv_email in SENSOR_DATA["gls_delivering"]["email"]
+    assert any(s in gls_deliv_subj for s in SENSOR_DATA["gls_delivering"]["subject"])
+    assert gls_del_email in SENSOR_DATA["gls_delivered"]["email"]
+    assert any(s in gls_del_subj for s in SENSOR_DATA["gls_delivered"]["subject"])


### PR DESCRIPTION
## Proposed change

Adds support for parsing email notifications for Danish shipping carriers:
- **DAO**
- **Bring (DK)**
- **PostNord (DK)**
- **Budbee**
- **Airmee**
- **Burd Delivery**
- **GLS Denmark**

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [x] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1324
- This PR is related to issue:
