### PR TITLE
fix(binary_sensor): latch usps_mail_delivered for the rest of the day

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -89,6 +89,8 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         self._file_mtime_cache = {}
         self._hash_cache = {}
         self._in_transit_tracking: dict[str, dict[str, str]] = {}
+        self._mail_delivered_latch_date: str | None = None
+        self._mail_delivered_latched = False
         self.email_cache = EmailCache(hass=hass)
 
         _LOGGER.debug("Data will be update every %s", self.interval)
@@ -231,6 +233,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             data.update(shipper_data)
             self._dedupe_marketplace_duplicates(data, tracking_details)
             self._apply_tracking_state(data, tracking_details, today_iso)
+            self._latch_mail_delivered(data, today_iso)
 
             # Aggregate global transit and delivered sensors
             self._aggregate_package_counts(data)
@@ -523,6 +526,31 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 data[f"{prefix}_packages"] = len(in_transit) + (
                     delivered_count if isinstance(delivered_count, int) else 0
                 )
+
+    def _latch_mail_delivered(self, data: dict, today_iso: str) -> None:
+        """Latch usps_mail_delivered on for the rest of the day once seen.
+
+        The generic shipper recomputes this sensor from a live "delivered
+        today" IMAP search on every poll, so a transient search/verification
+        miss (or simply the message no longer matching by the time the next
+        poll runs) can flip it back to falsy even though the mail was
+        genuinely delivered earlier today. That makes off->on state-trigger
+        automations re-fire on every scan cycle instead of once per delivery.
+        Latch it: once truthy for today, keep it truthy until the date
+        changes, which is the same day boundary the underlying search
+        already resets on at midnight.
+        """
+        if "usps_mail_delivered" not in data:
+            return
+
+        if self._mail_delivered_latch_date != today_iso:
+            self._mail_delivered_latch_date = today_iso
+            self._mail_delivered_latched = False
+
+        self._mail_delivered_latched = self._mail_delivered_latched or bool(
+            data["usps_mail_delivered"]
+        )
+        data["usps_mail_delivered"] = int(self._mail_delivered_latched)
 
     def _update_tracking_for_prefix(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp import ClientResponseError
+from freezegun import freeze_time
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -15,7 +16,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.mail_and_packages.const import CONF_FOLDER, DOMAIN
 from custom_components.mail_and_packages.coordinator import MailDataUpdateCoordinator
 from custom_components.mail_and_packages.utils.imap import InvalidAuth
-from tests.const import FAKE_CONFIG_DATA
+from tests.const import FAKE_CONFIG_DATA, FAKE_CONFIG_DATA_USPS_DELIVERED
 
 
 @pytest.mark.asyncio
@@ -108,6 +109,103 @@ async def test_process_emails_invalid_return(hass):
 
     # Should just not crash, missing data ok
     assert "test_sensor" not in data
+
+
+@pytest.mark.asyncio
+async def test_mail_delivered_latches_on_across_polls(hass):
+    """usps_mail_delivered should stay on for the rest of the day once seen.
+
+    The underlying IMAP search is re-run and re-verified on every poll, so a
+    transient miss must not flip a real delivery back to off — that would
+    make an off->on state-trigger automation re-fire on every scan cycle.
+    """
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA_USPS_DELIVERED)
+
+    mock_shipper = AsyncMock()
+    mock_shipper.name = "usps"
+    mock_shipper.process_batch.side_effect = [
+        {"usps_mail_delivered": 1},
+        {"usps_mail_delivered": 0},
+        {"usps_mail_delivered": 0},
+    ]
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.get_shipper_for_sensor",
+            return_value=mock_shipper,
+        ),
+        freeze_time("2026-08-05 14:17:32"),
+    ):
+        first = await coordinator.process_emails(hass, FAKE_CONFIG_DATA_USPS_DELIVERED)
+        assert first["usps_mail_delivered"] == 1
+
+        # Two subsequent polls where the live search comes back empty (the
+        # flaky re-evaluation this bug is about) must not clear the flag.
+        second = await coordinator.process_emails(hass, FAKE_CONFIG_DATA_USPS_DELIVERED)
+        assert second["usps_mail_delivered"] == 1
+
+        third = await coordinator.process_emails(hass, FAKE_CONFIG_DATA_USPS_DELIVERED)
+        assert third["usps_mail_delivered"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mail_delivered_latch_resets_on_new_day(hass):
+    """usps_mail_delivered latch must reset once the day rolls over."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA_USPS_DELIVERED)
+
+    mock_shipper = AsyncMock()
+    mock_shipper.name = "usps"
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.coordinator.login",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.selectfolder",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.mail_and_packages.coordinator.get_shipper_for_sensor",
+            return_value=mock_shipper,
+        ),
+    ):
+        mock_shipper.process_batch.return_value = {"usps_mail_delivered": 1}
+        with freeze_time("2026-08-05 14:17:32"):
+            day_one = await coordinator.process_emails(
+                hass, FAKE_CONFIG_DATA_USPS_DELIVERED
+            )
+        assert day_one["usps_mail_delivered"] == 1
+
+        # New day, no mail delivered yet — the latch from yesterday must not
+        # leak through even though it's the same coordinator instance.
+        mock_shipper.process_batch.return_value = {"usps_mail_delivered": 0}
+        with freeze_time("2026-08-06 08:00:00"):
+            day_two = await coordinator.process_emails(
+                hass, FAKE_CONFIG_DATA_USPS_DELIVERED
+            )
+        assert day_two["usps_mail_delivered"] == 0
+
+
+def test_latch_mail_delivered_noop_when_sensor_not_present(hass):
+    """_latch_mail_delivered must not add the key when the sensor isn't in use."""
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    data = {"some_other_sensor": 1}
+    coordinator._latch_mail_delivered(data, "2026-08-05")
+
+    assert "usps_mail_delivered" not in data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`binary_sensor.mail_usps_mail_delivered` re-evaluates on every coordinator poll instead of latching for the day. Observed with a ~61 min poll interval:

```
14:17:32  off -> unavailable -> on   (14:17:52)
15:18:51  off -> unavailable -> on   (15:19:06)
16:19:53  off -> unavailable -> on   (16:20:29)
17:21:39  off -> unavailable -> on   (17:21:53)
...repeats every cycle for the rest of the day
```

Root cause: `usps_mail_delivered` is a generic `_delivered`-suffixed sensor, so its value comes from `GenericShipper`'s live "delivered today" IMAP search, re-run and re-verified on every poll (see `generic.py`'s dual-search logic — the `_delivered` count sensor intentionally re-searches "since today" each cycle so it resets at midnight). That's correct for the numeric `*_delivered` package-count sensors, but this key only backs a binary sensor. Any transient miss on a later poll (message no longer matching, subject re-verification flaking, etc.) flips the boolean back to falsy even though the mail genuinely arrived earlier that day.

The net effect: an off->on state-trigger automation meant to catch "mail just arrived" instead fires on every scan cycle, hours after the actual delivery, with nothing new having happened.

## Fix

Added a small per-day latch in `MailDataUpdateCoordinator` (`coordinator.py`): once `usps_mail_delivered` is computed truthy for a given day, it's held on for the rest of that day regardless of what later polls compute, until the date rolls over. This reuses the same day boundary the underlying search already resets on at midnight — no new reset condition was introduced, and the numeric `_delivered` sensors for other carriers (UPS, FedEx, etc.) are untouched since the latch only applies to `usps_mail_delivered`.

I checked the integration's other binary sensors (`usps_update`, `amazon_update`, `post_de_update`) — those intentionally represent "is the current delivery image non-empty right now" (a live comparison, not a "did X happen today" flag), so they don't have the same bug pattern and were left as-is.

## Test plan
- [x] Added `test_mail_delivered_latches_on_across_polls`: mocks the shipper batch result to flip on then intermittently return falsy on two subsequent polls; asserts the sensor stays on across all three.
- [x] Added `test_mail_delivered_latch_resets_on_new_day`: latches on for one frozen day, then freezes time to the next day with no delivery and asserts it resets to off.
- [x] Added `test_latch_mail_delivered_noop_when_sensor_not_present`: confirms the latch doesn't add the key when the sensor isn't a configured resource.
- [x] Full suite passes locally with coverage well above the required threshold.
- [x] `mypy`, `ruff check`, `ruff format`, and the project's pre-commit hooks all pass on the changed files.