### PR TITLE
fix(imap): do not treat transient network errors as auth failure

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -860,7 +860,7 @@ async def _validate_login(
         errors[CONF_USERNAME] = errors[CONF_PASSWORD] = "invalid_auth"
     except ssl.SSLError:
         errors["base"] = "ssl_error"
-    except (TimeoutError, AioImapException, ConnectionRefusedError) as err:
+    except (TimeoutError, AioImapException, ConnectionRefusedError, OSError) as err:
         _LOGGER.error(
             "Unable to connect: %s (IMAP server %s:%s as %s, security: %s, oauth: False, class: %s)",
             err if str(err) else "Authentication failed or timed out",

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -199,11 +199,9 @@ async def login(
                     ) from err
             else:
                 await account.login(user, pwd)
-        except TimeoutError:
-            raise
         except (AioImapException, OSError) as err:
             _LOGGER.error("Error logging in to IMAP Server: %s", err)
-            raise InvalidAuth from err
+            raise
 
     if account.protocol.state not in {AUTH, SELECTED}:
         _LOGGER.error(

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -532,7 +532,7 @@ async def test_login_exception(caplog):
         mock_acc.protocol.state = NONAUTH
         mock_imap_ssl.return_value = mock_acc
 
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(OSError):
             await login(mock_hass, "host", 993, "user", "pass", "SSL")
         assert "Error logging in to IMAP Server" in caplog.text
 


### PR DESCRIPTION
## Proposed change

Prevent transient network and socket errors (`OSError`, socket drops, connection resets, network timeouts) during IMAP login from being wrapped in `InvalidAuth`.

Previously, wrapping generic `OSError` in `InvalidAuth` caused the coordinator to raise `ConfigEntryAuthFailed`, forcing Home Assistant to enter a re-authentication flow even though credentials were valid.

With this change:
1. `login()` re-raises `OSError` and `AioImapException` as network errors rather than wrapping them into `InvalidAuth`.
2. `_validate_login()` in `config_flow.py` handles `OSError` as a connection error (`cannot_connect`).
3. The coordinator catches transient connection errors, logs the issue, and returns cached data (`if self._data: return self._data`), preserving sensor states during temporary network outages without forcing re-auth.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: