### PR TITLE
docs: update email deletion note in README and info.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ From your Home Assistant instance, the integration connects via IMAP to the emai
 
 See the [wiki](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki) for full details.
 
-> **Note:** Emails cannot be deleted until the next day, but you can filter them into a dedicated folder and point the integration at that folder. Delivery images revert to the no-mail placeholder after the first scan past midnight, local time.
+> **Note:** The integration does not delete or modify your emails. Do not delete delivery emails on the day they arrive, as the integration needs to find them during its scans. You can filter shipping notifications into a dedicated folder and point the integration at that folder. Delivery images revert to the no-mail placeholder after the first scan past midnight, local time.
 
 > **Privacy / Security:** All processing is done locally. No data is sent outside your Home Assistant instance. Files stored in the `www` folder are [publicly accessible](https://www.home-assistant.io/integrations/http/#hosting-files) by default — image filenames are randomised to reduce exposure. Two sensors are available for use in notifications:
 > - `sensor.mail_image_system_path`

--- a/info.md
+++ b/info.md
@@ -36,7 +36,7 @@ From your Home Assistant instance, the integration connects via IMAP to the emai
 
 See the [wiki](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages/wiki) for full details.
 
-> **Note:** Emails cannot be deleted until the next day, but you can filter them into a dedicated folder and point the integration at that folder. Delivery images revert to the no-mail placeholder after the first scan past midnight, local time.
+> **Note:** The integration does not delete or modify your emails. Do not delete delivery emails on the day they arrive, as the integration needs to find them during its scans. You can filter shipping notifications into a dedicated folder and point the integration at that folder. Delivery images revert to the no-mail placeholder after the first scan past midnight, local time.
 
 > **Privacy / Security:** All processing is done locally. No data is sent outside your Home Assistant instance. Files stored in the `www` folder are [publicly accessible](https://www.home-assistant.io/integrations/http/#hosting-files) by default — image filenames are randomised to reduce exposure. Two sensors are available for use in notifications:
 > - `sensor.mail_image_system_path`


### PR DESCRIPTION
## Proposed change

Clarifies the note regarding email deletion in `README.md` and `info.md`. The integration is read-only and does not delete or modify emails; the note is meant to advise users not to delete delivery emails on the day they arrive so the integration can find them during periodic IMAP scans.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: