### PR TITLE
fix(imap): handle transient OAuth timeout without triggering reauth (#1365)

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -172,9 +172,9 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                     # Refresh OAuth2 token if using OAuth authentication
                     auth_type = config.get(CONF_AUTH_TYPE, AUTH_TYPE_PASSWORD)
                     if auth_type != AUTH_TYPE_PASSWORD and self.config_entry:
-                        config["oauth_token"] = await self._async_oauth_access_token(
-                            auth_type
-                        )
+                        oauth_token = await self._async_oauth_access_token(auth_type)
+                        config["oauth_token"] = oauth_token
+                        self.config["oauth_token"] = oauth_token
 
                     data = await self.process_emails(self.hass, config)
                 except ConfigEntryAuthFailed:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -189,14 +189,9 @@ async def login(
                             getattr(res, "result", None),
                             getattr(res, "lines", None),
                         )
-                except TimeoutError as err:
-                    _LOGGER.error(
-                        "OAuth authentication timed out for %s. This typically indicates invalid OAuth credentials, missing 'https://mail.google.com/' scope, or a mismatched email address.",
-                        user,
-                    )
-                    raise InvalidAuth(
-                        "OAuth authentication timed out or failed"
-                    ) from err
+                except TimeoutError:
+                    _LOGGER.warning("OAuth authentication timed out for %s", user)
+                    raise
             else:
                 await account.login(user, pwd)
         except (AioImapException, OSError) as err:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1994,7 +1994,7 @@ async def test_login_oauth_timeout(caplog):
         mock_acc.xoauth2.side_effect = TimeoutError("Timeout during xoauth2")
         mock_imap_ssl.return_value = mock_acc
 
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(TimeoutError):
             await login(
                 mock_hass,
                 "host",


### PR DESCRIPTION
## Proposed change

Resolve recurring OAuth authentication timeouts and forced re-authentication loops during token refresh cycles for Gmail/IMAP OAuth integrations.

- `utils/imap.py`: Re-raise `TimeoutError` during `account.xoauth2(...)` so transient network delays or server stalls are raised as recoverable `UpdateFailed` errors rather than being wrapped in `InvalidAuth` (which triggered Home Assistant Repair issues and `ConfigEntryAuthFailed`).
- `coordinator.py`: Synchronize refreshed OAuth access tokens into `self.config["oauth_token"]` across coordinator updates.
- `tests/utils/test_imap_email.py`: Updated `test_login_oauth_timeout` assertion to verify `TimeoutError` propagation.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1365
- This PR is related to issue: