### PR TITLE
fix(amazon): support Amazon.fr delivery emails (#1364)

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -171,10 +171,12 @@ AMAZON_SHIPMENT_TRACKING = [
     "confirmation-commande",
     "verzending-volgen",
     "update-bestelling",
+    "pickup-point",
 ]
 AMAZON_DELIVERING_SUBJECT = [
     "Out for delivery:",
     "In Zustellung:",
+    "En cours de livraison:",
 ]
 AMAZON_SHIPMENT_SUBJECT = [
     "Shipped:",
@@ -182,9 +184,10 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Spedito:",
     "Versandt:",
     "Versendet:",
+    "Expédié:",
     *AMAZON_DELIVERING_SUBJECT,
 ]
-AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:"]
+AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:", "Commandé:"]
 AMAZON_EMAIL = [
     "order-update@",
     "update-bestelling@",

--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -134,10 +134,14 @@ class AmazonShipper(Shipper):
             return {AMAZON_ORDER: result}
 
         if sensor_type == AMAZON_HUB:
-            return await self._amazon_hub(account, fwds, cache, forwarding_header)
+            return await self._amazon_hub(
+                account, fwds, domain, cache, forwarding_header
+            )
 
         if sensor_type == AMAZON_OTP:
-            result = await self._amazon_otp(account, fwds, cache, forwarding_header)
+            result = await self._amazon_otp(
+                account, fwds, domain, cache, forwarding_header
+            )
             return {sensor_type: result}
 
         if sensor_type == AMAZON_EXCEPTION:
@@ -572,6 +576,7 @@ class AmazonShipper(Shipper):
         self,
         account: IMAP4_SSL,
         fwds: list[str] | None = None,
+        domain: str | None = None,
         cache: EmailCache | None = None,
         forwarding_header: str = "",
     ) -> dict[str, Any]:
@@ -581,7 +586,7 @@ class AmazonShipper(Shipper):
         code = []
         processed_ids = []
         today = get_today().strftime("%d-%b-%Y")
-        address_list = amazon_email_addresses(fwds, "amazon.com")
+        address_list = amazon_email_addresses(fwds, domain)
         for search_subject in AMAZON_HUB_SUBJECT:
             (server_response, data) = await email_search(
                 account,
@@ -620,13 +625,14 @@ class AmazonShipper(Shipper):
         self,
         account: IMAP4_SSL,
         fwds: list[str] | None = None,
+        domain: str | None = None,
         cache: EmailCache | None = None,
         forwarding_header: str = "",
     ) -> dict[str, Any]:
         """Find Amazon OTP code."""
         code = []
         today = get_today().strftime("%d-%b-%Y")
-        address_list = amazon_email_addresses(fwds, "amazon.com")
+        address_list = amazon_email_addresses(fwds, domain)
         (server_response, data) = await email_search(
             account,
             address_list,

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -64,7 +64,15 @@ DOMAIN_LANG_MAP = {
         "auto-bevestiging",
         "Bezorgd:",
     ],
-    "amazon.fr": ["confirmation-commande", "Livré", "Livraison : Votre", "Arrivée :"],
+    "amazon.fr": [
+        "Livré",
+        "Livraison : Votre",
+        "Arrivée :",
+        "Expédié:",
+        "Expédié",
+        "En cours de livraison:",
+        "Commandé:",
+    ],
     "amazon.ca": ["confirmation-commande", "Livré", "Livraison : Votre", "Arrivée :"],
     "amazon.es": [
         "confirmar-envio",

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1346,3 +1346,34 @@ async def test_amazon_delivering_no_order_id_no_arrival_date(hass):
         res = await shipper.process(mock_account, "today", "amazon_delivering")
         assert res["amazon_delivering"] == 1
         assert res["amazon_delivering_order"] == []
+
+
+@pytest.mark.asyncio
+async def test_amazon_hub_and_otp_domain(hass):
+    """Test AmazonShipper passes configured amazon_domain to _amazon_hub and _amazon_otp."""
+    shipper = AmazonShipper(hass, {"amazon_domain": "amazon.fr"})
+    mock_account = AsyncMock()
+
+    with patch(
+        "custom_components.mail_and_packages.shippers.amazon.email_search",
+        new_callable=AsyncMock,
+        return_value=("OK", [None]),
+    ) as mock_search:
+        await shipper.process(mock_account, "today", "amazon_hub")
+        assert mock_search.called
+        search_addresses = (
+            mock_search.call_args.kwargs.get("address") or mock_search.call_args.args[1]
+        )
+        assert "pickup-point@amazon.fr" in search_addresses
+
+    with patch(
+        "custom_components.mail_and_packages.shippers.amazon.email_search",
+        new_callable=AsyncMock,
+        return_value=("OK", [None]),
+    ) as mock_search:
+        await shipper.process(mock_account, "today", "amazon_otp")
+        assert mock_search.called
+        search_addresses = (
+            mock_search.call_args.kwargs.get("address") or mock_search.call_args.args[1]
+        )
+        assert "order-update@amazon.fr" in search_addresses

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -478,3 +478,29 @@ async def test_search_amazon_emails_single_and_multi_domain():
         )
         assert res_multi == [b"1", b"2"]
         assert mock_search.call_count == 2
+
+
+def test_amazon_email_addresses_fr():
+    """Test amazon_email_addresses for amazon.fr includes all required French senders."""
+    addresses = amazon_email_addresses(domain="amazon.fr")
+    assert "confirmation-commande@amazon.fr" in addresses
+    assert "order-update@amazon.fr" in addresses
+    assert "shipment-tracking@amazon.fr" in addresses
+    assert "pickup-point@amazon.fr" in addresses
+
+
+def test_filter_amazon_strings_fr():
+    """Test filter_amazon_strings for amazon.fr retains French subject strings."""
+    subjects = [
+        "Expédié:",
+        "En cours de livraison:",
+        "Livré",
+        "Commandé:",
+        "Shipped:",
+    ]
+    filtered = filter_amazon_strings(subjects, "amazon.fr")
+    assert "Expédié:" in filtered
+    assert "En cours de livraison:" in filtered
+    assert "Livré" in filtered
+    assert "Commandé:" in filtered
+    assert "Shipped:" not in filtered


### PR DESCRIPTION
## Proposed change

Adds support for Amazon France (`amazon.fr`) email notifications and ensures configured Amazon domains are passed to Hub and OTP searches.

Key updates:
- Added `"pickup-point"` to `AMAZON_SHIPMENT_TRACKING` so `pickup-point@amazon.fr` is included when searching sender addresses.
- Added French subject strings (`"Expédié:"` to `AMAZON_SHIPMENT_SUBJECT`, `"En cours de livraison:"` to `AMAZON_DELIVERING_SUBJECT`, `"Commandé:"` to `AMAZON_ORDERED_SUBJECT`).
- Updated `DOMAIN_LANG_MAP["amazon.fr"]` in `utils/amazon.py` to include French subject strings (`"Expédié:"`, `"Expédié"`, `"En cours de livraison:"`, `"Commandé:"`).
- Updated `_amazon_hub` and `_amazon_otp` in `shippers/amazon.py` to pass the configured `amazon_domain` rather than defaulting/hardcoding `"amazon.com"`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1364
- This PR is related to issue: