### PR TITLE
feat(usps): add scheduled pickup sensor (usps_pickup)

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -329,6 +329,12 @@ SENSOR_DATA = {
         "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Expected Delivery by"],
     },
+    "usps_pickup": {
+        "email": ["auto-reply@usps.com"],
+        "subject": ["USPS - Your Package Pickup Request"],
+        "body": ["Total Packages: (\\d+)"],
+        "body_count": True,
+    },
     "usps_tracking": {"pattern": ["9[2345]\\d{15,26}"]},
     "usps_mail": {
         "email": [
@@ -1381,6 +1387,12 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         native_unit_of_measurement="package(s)",
         icon="mdi:package-variant-closed",
         key="usps_packages",
+    ),
+    "usps_pickup": SensorEntityDescription(
+        name="Mail USPS Scheduled Pickup",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-up",
+        key="usps_pickup",
     ),
     # UPS
     "ups_delivered": SensorEntityDescription(

--- a/tests/shippers/test_usps_pickup.py
+++ b/tests/shippers/test_usps_pickup.py
@@ -1,0 +1,59 @@
+"""Tests for USPS pickup sensor processing via generic shipper."""
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.mail_and_packages.shippers.generic import GenericShipper
+
+
+@pytest.mark.asyncio
+async def test_usps_pickup_email_generic_shipper(hass):
+    """Test parsing of USPS Scheduled Pickup email via GenericShipper."""
+    shipper = GenericShipper(hass, {})
+
+    msg = MIMEMultipart("alternative")
+    msg["From"] = "auto-reply@usps.com"
+    msg["Subject"] = "USPS - Your Package Pickup Request"
+    msg["Date"] = "Wed, 12 Aug 2026 12:46:26 -0400"
+    html_body = """
+    <html>
+      <body>
+        <p>Thank you for using USPS.com. We have successfully completed your Package Pickup.</p>
+        <p>Confirmation #: WEC000000000</p>
+        <p>Total Packages: 50</p>
+        <p>Scheduled Pickup Date: 08/12/2026</p>
+      </body>
+    </html>
+    """
+    msg.attach(MIMEText(html_body, "html"))
+
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            return_value=("OK", [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.email.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch_headers",
+            return_value=("OK", [b"Subject: USPS - Your Package Pickup Request\r\n"]),
+        ),
+    ):
+        result = await shipper.process(
+            account=mock_account,
+            date="12-Aug-2026",
+            sensor_type="usps_pickup",
+        )
+
+    assert result["count"] == 50


### PR DESCRIPTION
## Proposed change

Adds a new `usps_pickup` sensor (`Mail USPS Scheduled Pickup`) to track completed USPS Package Pickup notifications based on emails from `auto-reply@usps.com`.

### Changes
- Registered `usps_pickup` in `SENSOR_DATA` to match subject `USPS - Your Package Pickup Request` from `auto-reply@usps.com`.
- Configured `body_count: True` with regex pattern `Total Packages: (\d+)` to extract the total count of packages picked up.
- Added `usps_pickup` (`Mail USPS Scheduled Pickup`) entry to `SENSOR_TYPES` with unit `package(s)` and icon `mdi:package-up`.
- Added unit test coverage in `tests/shippers/test_usps_pickup.py`.

## Type of change

- [x] New feature (which adds functionality)
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: