### PR TITLE
feat(sensor): add Home Depot shipper support

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -36,6 +36,8 @@ from .const import (
     CONF_FORWARDED_EMAILS,
     CONF_GENERIC_CUSTOM_IMG,
     CONF_GENERIC_CUSTOM_IMG_FILE,
+    CONF_HOME_DEPOT_CUSTOM_IMG,
+    CONF_HOME_DEPOT_CUSTOM_IMG_FILE,
     CONF_IMAGE_SECURITY,
     CONF_IMAP_SECURITY,
     CONF_IMAP_TIMEOUT,
@@ -52,6 +54,7 @@ from .const import (
     DEFAULT_AMAZON_DAYS,
     DEFAULT_FEDEX_CUSTOM_IMG_FILE,
     DEFAULT_GENERIC_CUSTOM_IMG_FILE,
+    DEFAULT_HOME_DEPOT_CUSTOM_IMG_FILE,
     DEFAULT_UPS_CUSTOM_IMG_FILE,
     DEFAULT_WALMART_CUSTOM_IMG_FILE,
     DOMAIN,
@@ -440,3 +443,9 @@ def _apply_walmart_generic_fedex_defaults(updated_config):
         updated_config[CONF_FEDEX_CUSTOM_IMG] = False
     if CONF_FEDEX_CUSTOM_IMG_FILE not in updated_config:
         updated_config[CONF_FEDEX_CUSTOM_IMG_FILE] = DEFAULT_FEDEX_CUSTOM_IMG_FILE
+    if CONF_HOME_DEPOT_CUSTOM_IMG not in updated_config:
+        updated_config[CONF_HOME_DEPOT_CUSTOM_IMG] = False
+    if CONF_HOME_DEPOT_CUSTOM_IMG_FILE not in updated_config:
+        updated_config[CONF_HOME_DEPOT_CUSTOM_IMG_FILE] = (
+            DEFAULT_HOME_DEPOT_CUSTOM_IMG_FILE
+        )

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -47,6 +47,7 @@ ATTR_FEDEX_IMAGE = "fedex_image"
 ATTR_GENERIC_IMAGE = "generic_image"
 ATTR_USPS_IMAGE = "usps_image"
 ATTR_POST_DE_IMAGE = "post_de_image"
+ATTR_HOME_DEPOT_IMAGE = "home_depot_image"
 
 # Configuration Properties
 CONF_ALLOW_EXTERNAL = "allow_external"
@@ -65,6 +66,8 @@ CONF_GENERIC_CUSTOM_IMG = "generic_custom_img"
 CONF_GENERIC_CUSTOM_IMG_FILE = "generic_custom_img_file"
 CONF_POST_DE_CUSTOM_IMG = "post_de_custom_img"
 CONF_POST_DE_CUSTOM_IMG_FILE = "post_de_custom_img_file"
+CONF_HOME_DEPOT_CUSTOM_IMG = "home_depot_custom_img"
+CONF_HOME_DEPOT_CUSTOM_IMG_FILE = "home_depot_custom_img_file"
 CONF_STORAGE = "storage"
 CONF_FOLDER = "folder"
 CONF_PATH = "image_path"
@@ -124,6 +127,10 @@ DEFAULT_GENERIC_CUSTOM_IMG_FILE = (
 )
 DEFAULT_POST_DE_CUSTOM_IMG = False
 DEFAULT_POST_DE_CUSTOM_IMG_FILE = "custom_components/mail_and_packages/mail_none.gif"
+DEFAULT_HOME_DEPOT_CUSTOM_IMG = False
+DEFAULT_HOME_DEPOT_CUSTOM_IMG_FILE = (
+    "custom_components/mail_and_packages/no_deliveries_generic.jpg"
+)
 DEFAULT_AMAZON_DAYS = 3
 DEFAULT_AMAZON_DOMAIN = "amazon.com"
 DEFAULT_STORAGE = "custom_components/mail_and_packages/images/"
@@ -960,6 +967,36 @@ SENSOR_DATA = {
         "subject": ["delivery is delayed"],
     },
     "walmart_tracking": {"pattern": [r"\b#?[0-9]{7}-[0-9]{7,8}\b"]},
+    # Home Depot
+    "home_depot_delivering": {
+        "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
+        "subject": [
+            "out for delivery",
+            "arrives today",
+        ],
+    },
+    "home_depot_delivered": {
+        "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
+        "subject": [
+            "delivered",
+            "has arrived",
+        ],
+    },
+    "home_depot_packages": {
+        "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
+        "subject": [
+            "Shipped:",
+            "on its way",
+        ],
+    },
+    "home_depot_exception": {
+        "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
+        "subject": [
+            "delayed",
+            "delay",
+        ],
+    },
+    "home_depot_tracking": {"pattern": [r"\bWK\d{8}\b"]},
     # Shopify (standard order-notification templates). Sender varies per
     # store; these cover Shopify's shared sending infrastructure. Stores
     # sending from their own domain need their sender added here.
@@ -1803,6 +1840,31 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:archive-alert",
         key="walmart_exception",
     ),
+    # Home Depot
+    "home_depot_delivering": SensorEntityDescription(
+        name="Mail Home Depot Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="home_depot_delivering",
+    ),
+    "home_depot_delivered": SensorEntityDescription(
+        name="Mail Home Depot Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="home_depot_delivered",
+    ),
+    "home_depot_packages": SensorEntityDescription(
+        name="Mail Home Depot Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="home_depot_packages",
+    ),
+    "home_depot_exception": SensorEntityDescription(
+        name="Mail Home Depot Exception",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:archive-alert",
+        key="home_depot_exception",
+    ),
     # Shopify
     "shopify_delivered": SensorEntityDescription(
         name="Mail Shopify Delivered",
@@ -2132,6 +2194,7 @@ CAMERA_DATA = {
     "ups_camera": ["Mail UPS Camera"],
     "amazon_camera": ["Mail Amazon Delivery Camera"],
     "walmart_camera": ["Mail Walmart Delivery Camera"],
+    "home_depot_camera": ["Mail Home Depot Delivery Camera"],
     "fedex_camera": ["Mail FedEx Delivery Camera"],
     "generic_camera": ["Mail Generic Delivery Camera"],
     "post_de_camera": ["Mail Post DE Camera"],
@@ -2225,6 +2288,7 @@ SENSOR_ICON = 2
 MARKETPLACE_CARRIER_TRACKING = {
     "etsy": r"tracking number:?\s*#?([A-Za-z0-9]{8,34})",
     "shopify": r"tracking number:?\s*#?([A-Za-z0-9]{8,34})",
+    "home_depot": r"Tracking ID:?\s*#?([A-Za-z0-9]{8,34})",
 }
 
 # For sensors with delivering and delivered statuses
@@ -2237,6 +2301,7 @@ SHIPPERS = [
     "ups",
     "usps",
     "walmart",
+    "home_depot",
     "hermes",
     "royal",
     "auspost",

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -274,6 +274,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             "fedex_image": (False, False, False, True),
             "usps_image": (False, False, False, False),
             "post_de_image": (False, False, False, False),
+            "home_depot_image": (False, False, False, False),
         }
 
         for key, params in shipper_images.items():

--- a/tests/shippers/test_home_depot.py
+++ b/tests/shippers/test_home_depot.py
@@ -1,0 +1,176 @@
+"""Tests for the Home Depot shipper."""
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.mail_and_packages.const import ATTR_COUNT, ATTR_TRACKING
+from custom_components.mail_and_packages.shippers.generic import GenericShipper
+
+
+@pytest.mark.asyncio
+async def test_home_depot_delivering(hass):
+    """Test Home Depot out for delivery email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {})
+
+    msg = MIMEMultipart("alternative")
+    msg["From"] = "The Home Depot <homedepot@order.homedepot.com>"
+    msg["Subject"] = "Your Home Depot order is out for delivery today."
+    msg["Date"] = "Tue, 10 Mar 2026 11:16:00 -0400"
+
+    html_body = """
+    <html>
+      <body>
+        <h2>Order # WK00000000</h2>
+        <p>Get ready, Customer! Your delivery arrives today!</p>
+        <p>Your delivery is on track to arrive between 6:00am and 8:00pm with one of our carriers.</p>
+        <p>Deliver to Customer: 123 Main St, Anytown, CT 00000</p>
+      </body>
+    </html>
+    """
+    msg.attach(MIMEText(html_body, "html"))
+
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            return_value=("OK", [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.email.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.shipper.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch_headers",
+            return_value=(
+                "OK",
+                [b"Subject: Your Home Depot order is out for delivery today.\r\n"],
+            ),
+        ),
+    ):
+        result = await shipper.process(
+            account=mock_account,
+            date="10-Mar-2026",
+            sensor_type="home_depot_delivering",
+        )
+
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["WK00000000"]
+
+
+@pytest.mark.asyncio
+async def test_home_depot_shipped(hass):
+    """Test Home Depot package shipped email parsing via GenericShipper."""
+    shipper = GenericShipper(hass, {})
+
+    msg = MIMEMultipart("alternative")
+    msg["From"] = "The Home Depot <HomeDepot@order.homedepot.com>"
+    msg["Subject"] = "Order #WK00000000 Shipped: Your order is on its way, Customer!"
+    msg["Date"] = "Sun, 08 Mar 2026 18:07:00 -0400"
+
+    html_body = """
+    <html>
+      <body>
+        <b>Order #: </b><a href="#">WK00000000</a>
+        <b>Your package has shipped, Customer!</b>
+        <p>Tracking ID: 123456789012</p>
+        <p>ETA by FedEx: Tue, Mar 10</p>
+      </body>
+    </html>
+    """
+    msg.attach(MIMEText(html_body, "html"))
+
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_search",
+            return_value=("OK", [b"1"]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.email.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.shipper.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.email_fetch_headers",
+            return_value=(
+                "OK",
+                [
+                    b"Subject: Order #WK00000000 Shipped: Your order is on its way, Customer!\r\n"
+                ],
+            ),
+        ),
+    ):
+        result = await shipper.process(
+            account=mock_account,
+            date="08-Mar-2026",
+            sensor_type="home_depot_packages",
+        )
+
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["WK00000000"]
+    assert result["home_depot_carrier_tracking"] == {"WK00000000": "123456789012"}
+
+
+@pytest.mark.asyncio
+async def test_home_depot_marketplace_carrier_tracking(hass):
+    """Test extraction of embedded carrier tracking number for Home Depot deduplication."""
+    shipper = GenericShipper(hass, {})
+
+    msg = MIMEMultipart("alternative")
+    msg["From"] = "The Home Depot <HomeDepot@order.homedepot.com>"
+    msg["Subject"] = "Order #WK00000000 Shipped: Your order is on its way, Customer!"
+    msg["Date"] = "Sun, 08 Mar 2026 18:07:00 -0400"
+
+    html_body = """
+    <html>
+      <body>
+        <b>Order #: </b><a href="#">WK00000000</a>
+        <p>Tracking ID: 123456789012</p>
+      </body>
+    </html>
+    """
+    msg.attach(MIMEText(html_body, "html"))
+
+    mock_account = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.mail_and_packages.shippers.generic.get_tracking",
+            return_value=["WK00000000"],
+        ),
+        patch(
+            "custom_components.mail_and_packages.shippers.generic._find_carrier_number",
+            return_value="123456789012",
+        ),
+        patch(
+            "custom_components.mail_and_packages.utils.shipper.email_fetch",
+            return_value=("OK", [msg.as_bytes()]),
+        ),
+    ):
+        mapping = await shipper._collect_carrier_tracking(
+            "home_depot_packages",
+            [b"1"],
+            mock_account,
+        )
+
+    assert mapping == {"home_depot_carrier_tracking": {"WK00000000": "123456789012"}}


### PR DESCRIPTION
## Proposed change

Adds support for tracking Home Depot package deliveries (`home_depot_delivering`, `home_depot_delivered`, `home_depot_packages`, `home_depot_exception`, and `home_depot_camera`).

Includes:
- Sensor data and configuration definitions for Home Depot.
- `MARKETPLACE_CARRIER_TRACKING` rule for `home_depot` to extract embedded carrier tracking numbers from Home Depot shipping notifications for automatic deduplication against carrier sensors.
- Unit tests covering delivery and shipment email parsing as well as carrier tracking deduplication.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [x] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
