### PR TITLE
fix(amazon): handle French typography colons, date regex, and search deduplication

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -163,9 +163,9 @@ AMAZON_DELIVERED_SUBJECT = [
     "Dostarczono:",
     "Geliefert:",
     "Livré",
+    "Livraison",
     "Entregado:",
     "Bezorgd:",
-    "Livraison : Votre",
     "Zugestellt:",
 ]
 AMAZON_SHIPMENT_TRACKING = [
@@ -183,7 +183,7 @@ AMAZON_SHIPMENT_TRACKING = [
 AMAZON_DELIVERING_SUBJECT = [
     "Out for delivery:",
     "In Zustellung:",
-    "En cours de livraison:",
+    "En cours de livraison",
 ]
 AMAZON_SHIPMENT_SUBJECT = [
     "Shipped:",
@@ -191,10 +191,14 @@ AMAZON_SHIPMENT_SUBJECT = [
     "Spedito:",
     "Versandt:",
     "Versendet:",
-    "Expédié:",
+    "Expédié",
     *AMAZON_DELIVERING_SUBJECT,
 ]
-AMAZON_ORDERED_SUBJECT = ["Ordered:", "Pedido efetuado:", "Commandé:"]
+AMAZON_ORDERED_SUBJECT = [
+    "Ordered:",
+    "Pedido efetuado:",
+    "Commandé",
+]
 AMAZON_EMAIL = [
     "order-update@",
     "update-bestelling@",
@@ -236,6 +240,8 @@ AMAZON_TIME_PATTERN = [
     "Entrega:",
     "A chegar:",
     "Arrivée :",
+    "Livraison :",
+    "Arrive aujourd'hui",
     "Chega ",
     "Verwachte bezorgdatum:",
     "Votre date de livraison prévue est :",
@@ -275,9 +281,18 @@ AMAZON_TIME_PATTERN_REGEX = [
     "Arriverà (\\w+ \\d+) - (\\w+ \\d+)",
     "Arriverà (\\w+ \\d+)",
     "Arriverà (\\w+ \\d*)",
-    "Arrivée (\\w+ \\d+) - (\\w+ \\d+)",
-    "Arrivée (\\w+ \\d+)",
-    "Arrivée (\\w+ \\d*)",
+    "Arrivée\\s*:?\\s*(heute|aujourd'hui)",
+    "Arrivée\\s*:?\\s*(?:le )?(\\d+ \\w+)",
+    "Arrivée\\s*:?\\s*(?:le )?(\\w+ \\d+) - (\\w+ \\d+)",
+    "Arrivée\\s*:?\\s*(?:le )?(\\w+ \\d+)",
+    "Arrivée\\s*:?\\s*(?:le )?(\\w+ \\d*)",
+    "Arrivée\\s*:?\\s*(?:le )?(\\w+)",
+    "Livraison\\s*:?\\s*(heute|aujourd'hui)",
+    "Livraison\\s*:?\\s*(?:le )?(\\d+ \\w+)",
+    "Livraison\\s*:?\\s*(?:le )?(\\w+ \\d+) - (\\w+ \\d+)",
+    "Livraison\\s*:?\\s*(?:le )?(\\w+ \\d+)",
+    "Livraison\\s*:?\\s*(?:le )?(\\w+ \\d*)",
+    "Livraison\\s*:?\\s*(?:le )?(\\w+)",
     "Chega ((\\w+(-\\w+)?))",
     "Wordt bezorgd op (\\w+ \\d+ \\w+)",
     "Wordt bezorgd op (\\w+ \\d+)",
@@ -292,23 +307,6 @@ AMAZON_EXCEPTION_BODY = "running late"
 AMAZON_EXCEPTION = "amazon_exception"
 AMAZON_EXCEPTION_ORDER = "amazon_exception_order"
 AMAZON_PATTERN = "[0-9]{3}-[0-9]{7}-[0-9]{7}"
-AMAZON_LANGS = [
-    "it_IT",
-    "it_IT.UTF-8",
-    "pl_PL",
-    "pl_PL.UTF-8",
-    "de_DE",
-    "de_DE.UTF-8",
-    "es_ES",
-    "es_ES.UTF-8",
-    "pt_PT",
-    "pt_PT.UTF-8",
-    "pt_BR",
-    "pt_BR.UTF-8",
-    "fr_CA",
-    "fr_CA.UTF-8",
-    "",
-]
 AMAZON_OTP = "amazon_otp"
 AMAZON_OTP_CODE = "amazon_otp_code"
 AMAZON_OTP_REGEX = "(\n)(\\d{6})(\n)"

--- a/custom_components/mail_and_packages/utils/amazon.py
+++ b/custom_components/mail_and_packages/utils/amazon.py
@@ -66,12 +66,12 @@ DOMAIN_LANG_MAP = {
     ],
     "amazon.fr": [
         "Livré",
-        "Livraison : Votre",
-        "Arrivée :",
-        "Expédié:",
+        "Livrés",
+        "Livraison",
+        "Arrivée",
         "Expédié",
-        "En cours de livraison:",
-        "Commandé:",
+        "En cours de livraison",
+        "Commandé",
     ],
     "amazon.ca": ["confirmation-commande", "Livré", "Livraison : Votre", "Arrivée :"],
     "amazon.es": [

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -299,6 +299,7 @@ def build_search(  # noqa: C901
     if subject:
         subjects = [subject] if isinstance(subject, str) else subject
         safe_subjects = [clean_search_string(s) for s in subjects]
+        # Deduplicate while deterministically preserving insertion order
         safe_subjects = list(dict.fromkeys(s for s in safe_subjects if s))
 
         if len(safe_subjects) == 1:
@@ -533,6 +534,7 @@ async def email_search(  # noqa: C901
     subject_search = subject
     if isinstance(subject, list):
         cleaned_subjects = [clean_search_string(s) for s in subject]
+        # Deduplicate while deterministically preserving insertion order
         subject_search = list(dict.fromkeys(s for s in cleaned_subjects if s))
 
     if len(folders) <= 1:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -231,13 +231,13 @@ def clean_search_string(val: str) -> str:
 
     Normalizes Unicode characters to NFKD decomposed form, strips non-ASCII
     characters to ensure compatibility with US-ASCII only IMAP servers,
-    and removes any double quotes to prevent syntax corruption.
+    and removes any double quotes and colons to prevent syntax corruption.
     """
     if not val:
         return ""
     normalized = unicodedata.normalize("NFKD", val)
     cleaned = normalized.encode("ascii", "ignore").decode("ascii")
-    return cleaned.replace('"', "")
+    return cleaned.replace('"', "").replace(":", "").strip()
 
 
 def build_search(  # noqa: C901
@@ -299,7 +299,7 @@ def build_search(  # noqa: C901
     if subject:
         subjects = [subject] if isinstance(subject, str) else subject
         safe_subjects = [clean_search_string(s) for s in subjects]
-        safe_subjects = [s for s in safe_subjects if s]
+        safe_subjects = list(dict.fromkeys(s for s in safe_subjects if s))
 
         if len(safe_subjects) == 1:
             subject_part = f'SUBJECT "{safe_subjects[0]}"'
@@ -530,10 +530,15 @@ async def email_search(  # noqa: C901
         if len(bodies) > 2 or any(re.search(r"[()|\[\]?*+^$\\]", b) for b in bodies):
             body_search = ""
 
+    subject_search = subject
+    if isinstance(subject, list):
+        cleaned_subjects = [clean_search_string(s) for s in subject]
+        subject_search = list(dict.fromkeys(s for s in cleaned_subjects if s))
+
     if len(folders) <= 1:
-        if not isinstance(subject, list) or len(subject) <= 10:
+        if not isinstance(subject_search, list) or len(subject_search) <= 10:
             _unused, search = build_search(
-                address, date, subject, body_search, header, is_yahoo=is_yahoo
+                address, date, subject_search, body_search, header, is_yahoo=is_yahoo
             )
             try:
                 res = await account.search(search, charset=None)
@@ -548,8 +553,8 @@ async def email_search(  # noqa: C901
 
         # Batch subjects in groups of 10
         all_matched_ids = []
-        for i in range(0, len(subject), 10):
-            batch = subject[i : i + 10]
+        for i in range(0, len(subject_search), 10):
+            batch = subject_search[i : i + 10]
             _unused, search = build_search(
                 address, date, batch, body_search, header, is_yahoo=is_yahoo
             )
@@ -568,9 +573,9 @@ async def email_search(  # noqa: C901
         return ("OK", [b" ".join(unique_ids)])
 
     # Multi-folder search logic
-    if not isinstance(subject, list) or len(subject) <= 10:
+    if not isinstance(subject_search, list) or len(subject_search) <= 10:
         _unused, search = build_search(
-            address, date, subject, body_search, header, is_yahoo=is_yahoo
+            address, date, subject_search, body_search, header, is_yahoo=is_yahoo
         )
         try:
             uids = await _execute_single_search(account, search)
@@ -583,8 +588,8 @@ async def email_search(  # noqa: C901
 
     # Batch subjects in groups of 10
     all_matched_ids = []
-    for i in range(0, len(subject), 10):
-        batch = subject[i : i + 10]
+    for i in range(0, len(subject_search), 10):
+        batch = subject_search[i : i + 10]
         _unused, search = build_search(
             address, date, batch, body_search, header, is_yahoo=is_yahoo
         )

--- a/tests/utils/test_amazon.py
+++ b/tests/utils/test_amazon.py
@@ -492,15 +492,27 @@ def test_amazon_email_addresses_fr():
 def test_filter_amazon_strings_fr():
     """Test filter_amazon_strings for amazon.fr retains French subject strings."""
     subjects = [
-        "Expédié:",
-        "En cours de livraison:",
+        "Expédié",
+        "En cours de livraison",
         "Livré",
-        "Commandé:",
+        "Livrés",
+        "Livraison",
+        "Commandé",
         "Shipped:",
     ]
     filtered = filter_amazon_strings(subjects, "amazon.fr")
-    assert "Expédié:" in filtered
-    assert "En cours de livraison:" in filtered
+    assert "Expédié" in filtered
+    assert "En cours de livraison" in filtered
     assert "Livré" in filtered
-    assert "Commandé:" in filtered
+    assert "Livrés" in filtered
+    assert "Livraison" in filtered
+    assert "Commandé" in filtered
     assert "Shipped:" not in filtered
+
+
+def test_amazon_date_regex_fr():
+    """Test amazon_date_regex for French date formats."""
+    assert amazon_date_regex("Arrivée : aujourd'hui") == "aujourd'hui"
+    assert amazon_date_regex("Arrivée : 14 août") == "14 août"
+    assert amazon_date_regex("Livraison : aujourd'hui") == "aujourd'hui"
+    assert amazon_date_regex("Livraison : 15 août") == "15 août"

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -780,6 +780,13 @@ def test_build_search_multi_subject():
     )
 
 
+def test_build_search_deduplicate_subjects():
+    """Test build_search deduplicates safe subjects after ASCII normalization."""
+    subjects = ["Commandé:", "Commandé :", "Commandé"]
+    utf8, search = build_search(["test@example.com"], "25-Mar-2026", subject=subjects)
+    assert search == 'FROM "test@example.com" SUBJECT "Commande" SINCE 25-Mar-2026'
+
+
 def test_build_search_single_addr_with_subject():
     """Test build_search with single address and subject."""
     utf8, search = build_search(["test@example.com"], "25-Mar-2026", subject="Test")
@@ -865,7 +872,7 @@ def test_build_search_with_body_and_non_ascii():
     utf8, search = build_search(
         ["test@example.com"], "25-Mar-2026", body="Tracking émojis 🎉"
     )
-    assert 'BODY "Tracking emojis "' in search
+    assert 'BODY "Tracking emojis"' in search
 
 
 def test_build_search_unicode_normalization():


### PR DESCRIPTION
## Proposed change

Fixes an issue where Amazon France (`amazon.fr`) email notifications failed to match or timed out during update cycles (referencing issue #1364).

### Root Causes & Fixes:
1. **French Typography & Colon Spacing**:
   - French Amazon subjects contain spaces before colons (e.g. `Commandé : « ... »`, `Expédié : ...`, `En cours de livraison : « ... »`, `Livrés : ...`).
   - Collapsed French subject entries in `const.py` and `utils/amazon.py` to base subject terms (`Commandé`, `Expédié`, `En cours de livraison`, `Livré`, `Livrés`, `Livraison`). Substring matching in Python automatically covers all colon/quote variations while keeping IMAP queries concise.

2. **French Date Regex Parsing (`14 août`, `aujourd'hui`)**:
   - Updated `AMAZON_TIME_PATTERN_REGEX` to support optional spaces/colons (`Arrivée\s*:?\s*`, `Livraison\s*:?\s*`) and French date ordering (`(?:\d+ \w+)`, e.g. `14 août`).

3. **IMAP Search Deduplication**:
   - Updated `clean_search_string()` and `email_search()` in `utils/imap.py` to strip colons and deduplicate search terms using `dict.fromkeys()`. This prevents query bloat when normalizing subjects.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1364
- This PR is related to issue: #1364