### PR TITLE
fix(amazon): add plural Livrés to AMAZON_DELIVERED_SUBJECT

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -163,7 +163,7 @@ AMAZON_DELIVERED_SUBJECT = [
     "Dostarczono:",
     "Geliefert:",
     "Livré",
-    "Livraison",
+    "Livrés",
     "Entregado:",
     "Bezorgd:",
     "Zugestellt:",


### PR DESCRIPTION
## Proposed change

Fixes an issue where Amazon France (`amazon.fr`) delivered package emails with the plural subject `Livrés : « ... »` failed to match IMAP search queries on Outlook (`outlook.office365.com`) IMAP servers (referencing issue #1364).

### Root Cause & Fix:
- `AMAZON_DELIVERED_SUBJECT` contained `"Livré"` (singular) but was missing `"Livrés"` (plural).
- Outlook IMAP tokenization treats `"Livre"` and `"Livres"` as distinct search terms, so searching IMAP for `SUBJECT "Livre"` did not return emails with the subject starting with `"Livrés : "`.
- Added `"Livrés"` to `AMAZON_DELIVERED_SUBJECT` and removed `"Livraison"` (which is a shipment/delivering term) so `AMAZON_DELIVERED_SUBJECT` length stays $\le 10$.
- For `amazon.fr`, IMAP search now generates `OR OR SUBJECT "Livre" SUBJECT "Livres" SUBJECT "Livraison"`, matching `"Livrés : « ... »"` on Outlook IMAP.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1364
- This PR is related to issue: #1364