### PR TITLE
fix(camera): stop shipper cleanup deleting the generic delivery GIF

### DIFF
--- a/custom_components/mail_and_packages/camera.py
+++ b/custom_components/mail_and_packages/camera.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_POST_DE_CUSTOM_IMG,
     CONF_POST_DE_CUSTOM_IMG_FILE,
     DOMAIN,
+    GENERIC_DELIVERIES_GIF,
     SENSOR_NAME,
     VERSION,
 )
@@ -333,7 +334,12 @@ class MailCam(CoordinatorEntity, Camera):
         if (
             self._last_delivery_images is not None
             and delivery_images == self._last_delivery_images
+            and await anyio.Path(self._file_path).exists()
         ):
+            # Only skip the rebuild while the GIF we last built is still on
+            # disk. Another shipper's cleanup can remove it from the shared
+            # image directory, and without this check the camera would keep
+            # pointing at a deleted file and serve the placeholder instead.
             _LOGGER.debug(
                 "Generic camera - delivery images unchanged, skipping GIF regeneration"
             )
@@ -352,7 +358,7 @@ class MailCam(CoordinatorEntity, Camera):
 
         image_path = self.coordinator.data.get(ATTR_IMAGE_PATH, "")
         full_storage_path = Path(self.hass.config.path(image_path))
-        gif_path = str(full_storage_path / "generic_deliveries.gif")
+        gif_path = str(full_storage_path / GENERIC_DELIVERIES_GIF)
 
         resized_images = await self.hass.async_add_executor_job(
             resize_images, delivery_images, 800, 600

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -19,6 +19,9 @@ PLATFORMS = ["binary_sensor", "camera", "sensor"]
 DATA = "data"
 COORDINATOR = "coordinator_mail"
 OVERLAY = ["overlay.png", "vignette.png", "white.png"]
+# The generic delivery camera assembles its animated GIF into the shared image
+# directory, so shipper code that sweeps that directory has to leave it alone.
+GENERIC_DELIVERIES_GIF = "generic_deliveries.gif"
 SERVICE_UPDATE_FILE_PATH = "update_file_path"
 CAMERA = "cameras"
 CONFIG_VER = 20

--- a/custom_components/mail_and_packages/utils/image.py
+++ b/custom_components/mail_and_packages/utils/image.py
@@ -31,6 +31,7 @@ from custom_components.mail_and_packages.const import (
     DEFAULT_FEDEX_CUSTOM_IMG_FILE,
     DEFAULT_UPS_CUSTOM_IMG_FILE,
     DEFAULT_WALMART_CUSTOM_IMG_FILE,
+    GENERIC_DELIVERIES_GIF,
     OVERLAY,
 )
 
@@ -116,6 +117,11 @@ def _cleanup_directory(path: str) -> None:
             files_before,
         )
         for file in files_before:
+            # The generic delivery camera owns this file and only rebuilds it
+            # when its source images change, so a shipper's directory-wide
+            # sweep of the shared image directory must not delete it.
+            if file == GENERIC_DELIVERIES_GIF:
+                continue
             if file.endswith((".gif", ".mp4", ".jpg", ".png")):
                 full_path = Path(path) / file
                 _delete_file(full_path, "cleanup_images")
@@ -419,7 +425,7 @@ def _get_image_name_from_directory(
             if not file_path.is_file():
                 continue
             filename = file_path.name
-            if filename == "generic_deliveries.gif":
+            if filename == GENERIC_DELIVERIES_GIF:
                 continue
             is_image_file = filename.endswith(".gif") or (
                 filename.endswith(".jpg") and ext == ".jpg"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -17,6 +17,7 @@ from custom_components.mail_and_packages.const import (
     ATTR_AMAZON_IMAGE,
     ATTR_IMAGE_PATH,
     DOMAIN,
+    GENERIC_DELIVERIES_GIF,
 )
 from tests.conftest import resolve_entity_id
 from tests.const import FAKE_CONFIG_DATA_CUSTOM_IMG
@@ -2365,6 +2366,68 @@ async def test_generic_camera_skip_conditions(hass, caplog):
         "Generic camera - filtered out amazon (no current deliveries, count=0)"
         in caplog.text
     )
+
+
+async def test_generic_camera_rebuilds_gif_when_missing(hass, caplog):
+    """Test the generic camera rebuilds its GIF if the file was removed.
+
+    The delivery images can stay identical all day (the same filename is reused
+    while a package is still reported as delivered), so the unchanged-images
+    short circuit would otherwise never rebuild. If something else removed the
+    GIF from the shared image directory in the meantime, the camera would keep
+    pointing at a deleted file and serve the no-deliveries placeholder.
+    """
+    config = MockConfigEntry(
+        domain=DOMAIN,
+        data={"resources": ["amazon_delivered"], "amazon_custom_img": False},
+    )
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = {
+        ATTR_IMAGE_PATH: "custom_components/mail_and_packages/images/",
+        ATTR_AMAZON_IMAGE: "package_arrived.jpg",
+        "amazon_delivered": 1,
+    }
+
+    camera = MailCam(hass, "generic_camera", config, coordinator)
+
+    gif_exists = True
+
+    def _exists(self) -> bool:
+        """Report the delivery image as present, the GIF per gif_exists."""
+        if GENERIC_DELIVERIES_GIF in str(self):
+            return gif_exists
+        return True
+
+    with (
+        patch("pathlib.Path.exists", _exists),
+        patch(
+            "custom_components.mail_and_packages.camera.resize_images",
+            return_value=[],
+        ),
+        patch(
+            "custom_components.mail_and_packages.camera.generate_delivery_gif",
+            return_value=True,
+        ) as mock_gif,
+        patch.object(camera, "check_file_path_access"),
+        patch.object(camera, "schedule_update_ha_state"),
+    ):
+        await camera.update_file_path()
+        assert mock_gif.call_count == 1
+        assert camera._file_path.endswith(GENERIC_DELIVERIES_GIF)
+
+        # Same delivery images and the GIF still on disk: skip the rebuild.
+        await camera.update_file_path()
+        assert mock_gif.call_count == 1
+        assert "delivery images unchanged, skipping GIF regeneration" in caplog.text
+
+        # Same delivery images but the GIF was swept away: rebuild it.
+        gif_exists = False
+        caplog.clear()
+        await camera.update_file_path()
+        assert mock_gif.call_count == 2
+        assert "delivery images unchanged, skipping GIF regeneration" not in caplog.text
+        assert camera._file_path.endswith(GENERIC_DELIVERIES_GIF)
 
 
 async def test_camera_fallback_to_recent_file(

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from custom_components.mail_and_packages.const import GENERIC_DELIVERIES_GIF
 from custom_components.mail_and_packages.utils.image import (
     _check_ffmpeg,
     _generate_mp4,
@@ -790,6 +791,48 @@ async def test_get_image_name_from_directory_skips_generic():
         )
         # Should skip generic_deliveries.gif and return valid_image.gif
         assert result == "valid_image.gif"
+
+
+def test_cleanup_images_preserves_generic_deliveries_gif(tmp_path):
+    """Test cleanup_images leaves the generic delivery camera's GIF in place.
+
+    The generic delivery camera assembles generic_deliveries.gif into the shared
+    image directory and only rebuilds it when its source images change. A
+    shipper sweeping that directory (USPS does on every scan) must not delete
+    it, or the camera keeps pointing at a file that no longer exists and serves
+    the no-deliveries placeholder for the rest of the day.
+    """
+    generic_gif = tmp_path / GENERIC_DELIVERIES_GIF
+    generic_gif.write_bytes(b"GIF89a")
+    swept = [
+        tmp_path / "mail.gif",
+        tmp_path / "informed_delivery.jpg",
+        tmp_path / "overlay.png",
+        tmp_path / "clip.mp4",
+    ]
+    for path in swept:
+        path.write_bytes(b"x")
+
+    cleanup_images(f"{tmp_path}/")
+
+    assert generic_gif.is_file()
+    assert generic_gif.read_bytes() == b"GIF89a"
+    for path in swept:
+        assert not path.exists()
+
+
+def test_cleanup_images_removes_generic_gif_when_named(tmp_path):
+    """Test the single-file form still deletes the GIF when asked by name.
+
+    The skip belongs to the directory-wide sweep only; an explicit request to
+    remove that file must still be honoured.
+    """
+    generic_gif = tmp_path / GENERIC_DELIVERIES_GIF
+    generic_gif.write_bytes(b"GIF89a")
+
+    cleanup_images(f"{tmp_path}/", GENERIC_DELIVERIES_GIF)
+
+    assert not generic_gif.exists()
 
 
 def test_generate_grid_img_ffmpeg_error(caplog):


### PR DESCRIPTION
## Proposed change

The generic delivery camera's photo is replaced by the `no deliveries` placeholder one scan after it first appears, while the delivered count stays correct — so the sensor looks right and only the picture is wrong.

Two behaviours combine to cause it:

1. **A shipper deletes the camera's file.** The camera assembles `generic_deliveries.gif` into the shared image directory, but `USPSShipper.process()` calls `_setup_image_directory()`, which runs `cleanup_images()` over that whole directory. That sweep deletes every `.gif/.jpg/.png` in it, including the camera's GIF, and it runs on every scan.

2. **The camera never rebuilds it.** `_update_generic_camera()` only regenerates the GIF when its *source image list* changes. A shipper's delivery image keeps the same filename for as long as the package is reported delivered — `_get_image_name_from_directory()` reuses any file created today — so the list stays identical and the rebuild is skipped. `_file_path` then points at a file that no longer exists, and `async_camera_image()` falls back to `no_deliveries_generic.jpg`.

Observed with an Amazon delivery photo on a 30-minute scan interval: GIF built at 16:51, deleted by the 17:21 USPS sweep, and at 17:51 the log shows

```
cleanup_images - Files in directory BEFORE cleanup: [..., 'generic_deliveries.gif']   # 17:21, then removed
Generic camera - delivery images unchanged, skipping GIF regeneration                 # 17:51, never rebuilt
Could not read camera Mail Generic Delivery Camera image from file: .../generic_deliveries.gif
```

`amazon_delivered` stayed `1` throughout, so the chip on the dashboard kept saying a package was delivered while the photo behind it was the placeholder. It did not recover until Home Assistant was restarted (which resets `_last_delivery_images` and forces a rebuild).

### Changes

- `_cleanup_directory()` skips `generic_deliveries.gif`. The file belongs to the camera, not to whichever shipper happens to sweep the directory. `_get_image_name_from_directory()` already skipped it for exactly this reason — this closes the other path. The filename is now a shared `GENERIC_DELIVERIES_GIF` constant rather than a literal repeated across two modules.
- `_update_generic_camera()` only takes the unchanged-images short circuit while the GIF it last built is still on disk, so the camera recovers on the next update if anything else removes the file.

Deleting the file by name via `cleanup_images(path, image)` is deliberately unchanged — only the directory-wide sweep skips it. There's a test covering that, so the skip can't quietly grow into "this file can never be removed".

### Tests

Three added, all run against `dev`:

- `test_cleanup_images_preserves_generic_deliveries_gif` — real `tmp_path`; the GIF survives a sweep that removes the surrounding `.gif/.jpg/.png/.mp4` files.
- `test_cleanup_images_removes_generic_gif_when_named` — the single-file form still deletes it when asked by name.
- `test_generic_camera_rebuilds_gif_when_missing` — with identical delivery images across three updates, the camera builds once, skips while the GIF is present, and rebuilds once it is gone.

Both regression tests were verified to **fail** with the source changes reverted and pass with them applied; the third passes either way, as a control. Full suite: 730 passed, coverage 99.86%. `ruff check`, `ruff format --check` and `codespell` are clean.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Found while debugging a live install (0.5.25) where an Amazon delivery photo disappeared from the dashboard within the hour. Worth noting for anyone triaging similar reports: this looks like an expiring image URL but isn't — the Amazon photo is a presigned S3 link valid for 3 days (`X-Amz-Expires: 259200`), and the integration re-downloads it successfully on every scan. The downloaded shipper image is fine the whole time; only the assembled GIF goes missing.
