### PR TITLE
fix(imap): batch subject search terms individually to avoid compound OR issues

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -27,7 +27,7 @@ from custom_components.mail_and_packages.const import DEFAULT_IMAP_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
-IMAP_SUBJECT_BATCH_SIZE = 5
+IMAP_SUBJECT_BATCH_SIZE = 1
 IMAP_ADDRESS_BATCH_SIZE = 5
 
 # Register ESEARCH command if not already present in aioimaplib
@@ -579,6 +579,7 @@ async def email_search(  # noqa: C901
 
         # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
         all_matched_ids: list[str] = []
+        batch_success = False
         for addr_batch in address_batches:
             for subj_batch in subject_batches:
                 _unused, search = build_search(
@@ -591,13 +592,18 @@ async def email_search(  # noqa: C901
                 )
                 try:
                     res = await account.search(search, charset=None)
-                    if res.result == "OK" and res.lines:
-                        parsed = parse_search_response(res.lines)
-                        all_matched_ids.extend(parsed)
+                    if res.result == "OK":
+                        batch_success = True
+                        if res.lines:
+                            parsed = parse_search_response(res.lines)
+                            all_matched_ids.extend(parsed)
                 except TimeoutError:
                     raise
                 except (AioImapException, OSError) as err:
                     _LOGGER.error("Error searching emails batch: %s", err)
+
+        if not batch_success and not all_matched_ids:
+            return ("BAD", "All search batches failed")
 
         # Deduplicate and return in same format as individual search
         unique_ids = list(dict.fromkeys(all_matched_ids))
@@ -619,6 +625,7 @@ async def email_search(  # noqa: C901
 
     # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
     all_matched_ids = []
+    batch_success = False
     for addr_batch in address_batches:
         for subj_batch in subject_batches:
             _unused, search = build_search(
@@ -631,11 +638,15 @@ async def email_search(  # noqa: C901
             )
             try:
                 uids = await _execute_single_search(account, search)
+                batch_success = True
                 all_matched_ids.extend(uids)
             except TimeoutError:
                 raise
             except (AioImapException, OSError) as err:
                 _LOGGER.error("Error searching emails batch: %s", err)
+
+    if not batch_success and not all_matched_ids:
+        return ("BAD", "All search batches failed")
 
     # Deduplicate and return in same format as individual search
     unique_ids = list(dict.fromkeys(all_matched_ids))

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -983,6 +983,20 @@ async def test_email_search_batching_error(caplog):
 
 
 @pytest.mark.asyncio
+async def test_email_search_batching_all_error():
+    """Test email_search batching when all batches fail."""
+    mock_acc = AsyncMock()
+    mock_acc.search.side_effect = OSError("Batch failure")
+
+    subjects = [f"Sub{i}" for i in range(2)]
+    result = await email_search(
+        mock_acc, ["test@example.com"], "25-Mar-2026", subject=subjects
+    )
+
+    assert result == ("BAD", "All search batches failed")
+
+
+@pytest.mark.asyncio
 async def test_email_search_address_batching():
     """Test email_search batching logic for > 5 sender addresses."""
     mock_acc = AsyncMock()
@@ -1601,6 +1615,16 @@ async def test_email_search_batch_and_exceptions():
         assert res[0] == "OK"
         # The failed batch is ignored, returns only first batch result
         assert res[1] == [b"INBOX/1001"]
+
+    # Case 4: All multi-folder search batches fail
+    with patch(
+        "custom_components.mail_and_packages.utils.imap._execute_single_search",
+        side_effect=OSError("All batches failed"),
+    ):
+        res = await email_search(
+            mock_account, ["test@example.com"], "25-Mar-2026", subject=subjects
+        )
+        assert res == ("BAD", "All search batches failed")
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -911,7 +911,7 @@ def test_clean_search_string_empty():
 
 @pytest.mark.asyncio
 async def test_email_search_batching():
-    """Test email_search batching logic for > 5 subjects."""
+    """Test email_search batching logic for multiple subjects."""
     mock_acc = AsyncMock()
 
     # Mocking two batches: first with IDs 1 2, second with ID 3
@@ -925,8 +925,8 @@ async def test_email_search_batching():
 
     mock_acc.search.side_effect = [res1, res2]
 
-    # 6 subjects will trigger 2 batches (5 + 1)
-    subjects = [f"Sub{i}" for i in range(6)]
+    # 2 subjects will trigger 2 batches (1 + 1) with IMAP_SUBJECT_BATCH_SIZE = 1
+    subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
         mock_acc, ["test@example.com"], "25-Mar-2026", subject=subjects
     )
@@ -951,7 +951,7 @@ async def test_email_search_batching_partially_no_results():
 
     mock_acc.search.side_effect = [res1, res2]
 
-    subjects = [f"Sub{i}" for i in range(6)]
+    subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
         mock_acc, ["test@example.com"], "25-Mar-2026", subject=subjects
     )
@@ -972,7 +972,7 @@ async def test_email_search_batching_error(caplog):
 
     mock_acc.search.side_effect = [res1, OSError("Batch failure")]
 
-    subjects = [f"Sub{i}" for i in range(6)]
+    subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
         mock_acc, ["test@example.com"], "25-Mar-2026", subject=subjects
     )
@@ -1576,8 +1576,8 @@ async def test_email_search_batch_and_exceptions():
         )
         assert res == ("BAD", "Search error")
 
-    # Case 2: Batching subjects (more than 5 subjects)
-    subjects = [f"Sub{i}" for i in range(6)]
+    # Case 2: Batching subjects (multiple subjects)
+    subjects = [f"Sub{i}" for i in range(2)]
     # Mock successful returns for both batches
     with patch(
         "custom_components.mail_and_packages.utils.imap._execute_single_search",


### PR DESCRIPTION
## Proposed change

Set `IMAP_SUBJECT_BATCH_SIZE` to 1. 

When searching mailboxes on Microsoft Exchange / Outlook.com (`outlook.office365.com`), compound `OR` search clauses combining multiple `FROM` criteria with multiple `SUBJECT` criteria in a single query frequently result in dropped results or parsing anomalies on Exchange servers. Batching each subject search individually ensures that each query consists only of a simple `FROM` list and a single `SUBJECT`, preventing compound boolean expression issues.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1364
- This PR is related to issue: #1364
