### PR TITLE
fix(shipper): decode multi-part RFC2047 MIME email subjects for tracking extraction

### DIFF
--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -509,7 +509,7 @@ class GenericShipper(Shipper):
                 else:
                     text_parts.append(str(part))
             return "".join(text_parts).strip()
-        except Exception:
+        except (LookupError, UnicodeError, TypeError):
             return str(header_val).strip()
 
     async def _verify_matched_subjects(

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -500,19 +500,17 @@ class GenericShipper(Shipper):
         if not header_val:
             return None
 
-        decoded = decode_header(header_val)[0]
-        subject_bytes, encoding = decoded
-        if encoding:
-            try:
-                if isinstance(subject_bytes, bytes):
-                    return subject_bytes.decode(encoding, "ignore").strip()
-                return str(subject_bytes).strip()
-            except (LookupError, UnicodeError):
-                pass
-
-        if isinstance(subject_bytes, bytes):
-            return subject_bytes.decode("utf-8", "ignore").strip()
-        return str(subject_bytes).strip()
+        try:
+            decoded_parts = decode_header(header_val)
+            text_parts = []
+            for part, encoding in decoded_parts:
+                if isinstance(part, bytes):
+                    text_parts.append(part.decode(encoding or "utf-8", errors="ignore"))
+                else:
+                    text_parts.append(str(part))
+            return "".join(text_parts).strip()
+        except Exception:
+            return str(header_val).strip()
 
     async def _verify_matched_subjects(
         self,

--- a/custom_components/mail_and_packages/utils/shipper.py
+++ b/custom_components/mail_and_packages/utils/shipper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import email
+import email.header
 import logging
 import re
 from pathlib import Path
@@ -16,6 +17,36 @@ from custom_components.mail_and_packages.utils.cache import EmailCache
 from .imap import email_fetch
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_decoded_subject(header_val: str | bytes | email.message.Message | None) -> str:
+    """Decode RFC2047 MIME encoded email subject."""
+    if header_val is None:
+        return ""
+    if hasattr(header_val, "get"):
+        header_val = header_val.get("subject", "")
+    if isinstance(header_val, (bytes, bytearray)):
+        try:
+            msg = email.message_from_bytes(header_val)
+            header_val = msg.get("subject", "")
+        except Exception:
+            header_val = str(header_val, "utf-8", errors="ignore")
+
+    header_str = str(header_val)
+    if not header_str:
+        return ""
+
+    try:
+        decoded_parts = email.header.decode_header(header_str)
+        text_parts = []
+        for part, encoding in decoded_parts:
+            if isinstance(part, bytes):
+                text_parts.append(part.decode(encoding or "utf-8", errors="ignore"))
+            else:
+                text_parts.append(str(part))
+        return "".join(text_parts).strip()
+    except Exception:
+        return header_str.strip()
 
 
 async def get_tracking(
@@ -68,9 +99,8 @@ def _find_tracking_in_subject(
     pattern: re.Pattern,
 ) -> str | None:
     """Find tracking number in email subject."""
-    email_subject = msg["subject"]
+    email_subject = get_decoded_subject(msg.get("subject"))
     if email_subject:
-        email_subject = str(email_subject)
         if (found := pattern.findall(email_subject)) and len(found) > 0:
             _LOGGER.debug("Found tracking number in email subject: %s", found[0])
             return found[0]

--- a/custom_components/mail_and_packages/utils/shipper.py
+++ b/custom_components/mail_and_packages/utils/shipper.py
@@ -29,7 +29,7 @@ def get_decoded_subject(header_val: str | bytes | email.message.Message | None) 
         try:
             msg = email.message_from_bytes(header_val)
             header_val = msg.get("subject", "")
-        except Exception:
+        except (TypeError, UnicodeError):
             header_val = str(header_val, "utf-8", errors="ignore")
 
     header_str = str(header_val)
@@ -45,7 +45,7 @@ def get_decoded_subject(header_val: str | bytes | email.message.Message | None) 
             else:
                 text_parts.append(str(part))
         return "".join(text_parts).strip()
-    except Exception:
+    except (LookupError, UnicodeError, TypeError):
         return header_str.strip()
 
 

--- a/tests/utils/test_shipper.py
+++ b/tests/utils/test_shipper.py
@@ -36,6 +36,28 @@ async def test_get_tracking_subject():
 
 
 @pytest.mark.asyncio
+async def test_get_tracking_subject_mime_encoded():
+    """Test get_tracking finds tracking number in multi-line RFC2047 MIME encoded subject."""
+    mock_acc = AsyncMock()
+    sdata = "1"
+    the_format = r"(93[0-9]{20})"
+
+    raw_email = (
+        b"Subject: =?UTF-8?q?USPS=C2=AE_Item_Delivered,_Front_Door/Porch_9305520845500011006?=\r\n"
+        b" =?UTF-8?q?969?=\r\n\r\n"
+        b"Body"
+    )
+
+    with patch(
+        "custom_components.mail_and_packages.utils.shipper.email_fetch",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        mock_fetch.return_value = ("OK", [raw_email])
+        result = await get_tracking(sdata, mock_acc, the_format)
+        assert result == ["9305520845500011006969"]
+
+
+@pytest.mark.asyncio
 async def test_get_tracking_body_ups():
     """Test get_tracking finds UPS number in body (simplified logic)."""
     mock_acc = AsyncMock()


### PR DESCRIPTION
## Description

When email subjects contain special characters or exceed standard line lengths (e.g. USPS delivery notification subjects with UTF-8 characters like `®`), email servers split and encode them across multiple lines using RFC-2047 MIME encoded-words:

```text
Subject: =?UTF-8?q?USPS=C2=AE_Item_Delivered,_Front_Door/Porch_9305520845500011006?=
 =?UTF-8?q?969?=
```

Previously:
1. `_find_tracking_in_subject()` in `utils/shipper.py` read `msg["subject"]` directly as a raw string without decoding RFC-2047 headers. The regex search would hit the `?=` boundary of the first MIME chunk and extract a truncated tracking number (e.g., 19 digits instead of 22 digits).
2. `_decode_subject()` in `shippers/generic.py` called `decode_header(header_val)[0]`, taking only the first decoded chunk and discarding subsequent parts of multi-line encoded subjects.

This caused tracking numbers extracted from `_delivering` vs `_delivered` subjects to mismatch, preventing `_deduplicate_batch_tracking()` from subtracting delivered packages from the delivering sensor.

## Proposed Changes
- Added `get_decoded_subject()` in `utils/shipper.py` to decode all parts of RFC-2047 MIME encoded subject headers and used it in `_find_tracking_in_subject()`.
- Updated `_decode_subject()` in `shippers/generic.py` to iterate over and concatenate all decoded parts from `decode_header()`.
- Added unit test in `tests/utils/test_shipper.py` covering multi-line RFC-2047 MIME encoded subject tracking number extraction.

## Testing
- Verified tracking number extraction on multi-line MIME subjects with unit tests.
- Tested live with USPS delivery notification emails in Home Assistant.