### PR TITLE
fix(usps): revert usps_packages SENSOR_DATA config

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -334,10 +334,7 @@ SENSOR_DATA = {
         "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Delivery Exception"],
     },
-    "usps_packages": {
-        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
-        "subject": ["Expected Delivery by"],
-    },
+    "usps_packages": {},
     "usps_pickup": {
         "email": ["auto-reply@usps.com"],
         "subject": ["USPS - Your Package Pickup Request"],


### PR DESCRIPTION
## Proposed change

Reverts the `usps_packages` entry in `SENSOR_DATA` back to an empty dictionary (`{}`) so that `usps_packages` is computed as the sum of delivering and delivered packages instead of performing an IMAP search for `"Expected Delivery by"`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR is related to issue: #1248