### PR TITLE
fix: IMAP connections hanging after the first successful scan

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -4,6 +4,7 @@ import asyncio
 import binascii
 import logging
 import re
+import ssl as ssl_lib
 import unicodedata
 from urllib.parse import quote, unquote
 
@@ -21,7 +22,6 @@ from aioimaplib import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import ssl
 
 from custom_components.mail_and_packages.const import DEFAULT_IMAP_TIMEOUT
 
@@ -143,6 +143,21 @@ def decode_folder_ref(folder: str) -> str:
     return unquote(folder)
 
 
+def _build_ssl_context(verify: bool) -> ssl_lib.SSLContext:
+    """Build a new SSLContext for a single IMAP connection.
+
+    The context must not be shared between connections. aioimaplib holds it for
+    the lifetime of the transport, and a context that has already served a
+    closed connection never completes the next handshake, so the server
+    greeting never arrives and the caller waits forever.
+    """
+    context = ssl_lib.create_default_context()
+    if not verify:
+        context.check_hostname = False
+        context.verify_mode = ssl_lib.CERT_NONE
+    return context
+
+
 class InvalidAuth(HomeAssistantError):
     """Raise exception for invalid credentials."""
 
@@ -164,11 +179,7 @@ async def login(
     If oauth_token is provided, uses XOAUTH2 SASL mechanism.
     Otherwise falls back to standard LOGIN command.
     """
-    ssl_context = (
-        ssl.client_context(ssl.SSLCipherList.PYTHON_DEFAULT)
-        if verify
-        else ssl.create_no_verify_ssl_context()
-    )
+    ssl_context = await hass.async_add_executor_job(_build_ssl_context, verify)
     if security == "SSL":
         account = IMAP4_SSL(
             host=host, port=port, ssl_context=ssl_context, timeout=timeout
@@ -176,7 +187,9 @@ async def login(
     else:
         account = IMAP4(host=host, port=port, timeout=timeout)
 
-    await account.wait_hello_from_server()
+    await asyncio.wait_for(
+        account.wait_hello_from_server(), timeout=min(timeout, 15.0)
+    )
 
     if account.protocol.state == NONAUTH:
         try:
@@ -810,5 +823,9 @@ async def logout(account: IMAP4_SSL | IMAP4) -> None:
     """Logout from IMAP server asynchronously."""
     try:
         await account.logout()
-    except (TimeoutError, AioImapException, OSError, asyncio.CancelledError) as err:
+    except asyncio.CancelledError:
+        # Runs from a finally during timeout teardown; suppressing cancellation
+        # here leaves the coordinator wedged until Home Assistant restarts.
+        raise
+    except (TimeoutError, AioImapException, OSError) as err:
         _LOGGER.debug("Error logging out of IMAP Server: %s", err)

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -187,9 +187,7 @@ async def login(
     else:
         account = IMAP4(host=host, port=port, timeout=timeout)
 
-    await asyncio.wait_for(
-        account.wait_hello_from_server(), timeout=min(timeout, 15.0)
-    )
+    await asyncio.wait_for(account.wait_hello_from_server(), timeout=min(timeout, 15.0))
 
     if account.protocol.state == NONAUTH:
         try:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1,6 +1,7 @@
 """Tests for IMAP and email utilities."""
 
 import asyncio
+import ssl
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -188,10 +189,17 @@ async def test_email_fetch_me_com():
     mock_imap.fetch.assert_called_with("1", "BODY[]")
 
 
+def _mock_hass() -> MagicMock:
+    """Return a hass mock whose executor jobs can be awaited."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func, *args: func(*args))
+    return hass
+
+
 @pytest.mark.asyncio
 async def test_login_success():
     """Test login success path."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -213,7 +221,7 @@ async def test_login_success():
 @pytest.mark.asyncio
 async def test_login_oauth_success():
     """Test login with OAuth2 success path."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -242,25 +250,45 @@ async def test_login_oauth_success():
 @pytest.mark.asyncio
 async def test_login_no_verify():
     """Test login without SSL verification."""
-    mock_hass = MagicMock()
-    with (
-        patch(
-            "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
-        ) as mock_imap_ssl,
-        patch("homeassistant.util.ssl.create_no_verify_ssl_context") as mock_ssl_ctx,
-    ):
+    mock_hass = _mock_hass()
+    with patch(
+        "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
+    ) as mock_imap_ssl:
         mock_acc = AsyncMock()
         mock_acc.protocol.state = AUTH
         mock_imap_ssl.return_value = mock_acc
 
         await login(mock_hass, "host", 993, "user", "pass", "SSL", verify=False)
-        assert mock_ssl_ctx.called
+
+        context = mock_imap_ssl.call_args.kwargs["ssl_context"]
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+
+
+@pytest.mark.asyncio
+async def test_login_builds_new_ssl_context_each_call():
+    """A context must not be reused: a shared one stalls the next handshake."""
+    mock_hass = _mock_hass()
+    with patch(
+        "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
+    ) as mock_imap_ssl:
+        mock_acc = AsyncMock()
+        mock_acc.protocol.state = AUTH
+        mock_imap_ssl.return_value = mock_acc
+
+        await login(mock_hass, "host", 993, "user", "pass", "SSL")
+        await login(mock_hass, "host", 993, "user", "pass", "SSL")
+
+    first, second = (
+        call.kwargs["ssl_context"] for call in mock_imap_ssl.call_args_list
+    )
+    assert first is not second
 
 
 @pytest.mark.asyncio
 async def test_login_non_ssl():
     """Test login with STARTTLS/Plain (non-SSL class)."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch("custom_components.mail_and_packages.utils.imap.IMAP4") as mock_imap:
         mock_acc = AsyncMock()
         mock_acc.protocol.state = AUTH
@@ -274,7 +302,7 @@ async def test_login_non_ssl():
 @pytest.mark.asyncio
 async def test_login_failure_no_auth(caplog):
     """Test login failure when state doesn't change to AUTH."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     caplog.set_level("ERROR")
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
@@ -291,7 +319,7 @@ async def test_login_failure_no_auth(caplog):
 @pytest.mark.asyncio
 async def test_login_protocol_auth_state():
     """Test login when protocol state is already AUTH."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -307,7 +335,7 @@ async def test_login_protocol_auth_state():
 @pytest.mark.asyncio
 async def test_login_protocol_state_error():
     """Test login when protocol state is unexpected."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -522,7 +550,7 @@ async def test_email_search_error_branch(caplog):
 @pytest.mark.asyncio
 async def test_login_exception(caplog):
     """Test login with exception (Line 51)."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     caplog.set_level("ERROR")
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
@@ -540,7 +568,7 @@ async def test_login_exception(caplog):
 @pytest.mark.asyncio
 async def test_login_state_fail(caplog):
     """Test login when state doesn't change (Line 55)."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     caplog.set_level("ERROR")
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
@@ -1749,7 +1777,7 @@ def test_parse_search_response():
 @pytest.mark.asyncio
 async def test_login_timeout_error():
     """Test login propagates TimeoutError."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -1978,7 +2006,7 @@ async def test_email_search_body_threshold():
 @pytest.mark.asyncio
 async def test_login_oauth_failed(caplog):
     """Test login with OAuth2 failure path."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:
@@ -2037,7 +2065,7 @@ async def test_email_search_yahoo_detection():
 @pytest.mark.asyncio
 async def test_login_oauth_timeout(caplog):
     """Test login with OAuth2 timeout path."""
-    mock_hass = MagicMock()
+    mock_hass = _mock_hass()
     with patch(
         "custom_components.mail_and_packages.utils.imap.IMAP4_SSL",
     ) as mock_imap_ssl:

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -752,14 +752,17 @@ async def test_logout_timeout(caplog):
 
 
 @pytest.mark.asyncio
-async def test_logout_cancelled(caplog):
-    """Test logout cancellation handling."""
+async def test_logout_cancelled():
+    """Cancellation must propagate out of logout.
+
+    logout() runs from a finally while the scan is being cancelled by its
+    timeout, so swallowing CancelledError here leaves the coordinator wedged.
+    """
     mock_acc = AsyncMock()
     mock_acc.logout.side_effect = asyncio.CancelledError()
-    caplog.set_level("DEBUG")
 
-    await logout(mock_acc)
-    assert "Error logging out of IMAP Server" in caplog.text
+    with pytest.raises(asyncio.CancelledError):
+        await logout(mock_acc)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1382.

IMAP connections succeed exactly once per Home Assistant process. The first scan after a restart works; every scan afterwards hangs at `wait_hello_from_server()` until the coordinator's budget expires, with no TCP connection to port 993 ever being opened. Only a restart clears it.

Full investigation, probe traces and before/after evidence are in #1382.

## The fix

`login()` built its context with `homeassistant.util.ssl.client_context()`, which delegates to a memoised `_client_context` and so returns **the same `SSLContext` instance every call**. aioimaplib keeps that context for the lifetime of the transport, and once it has served a connection that `logout()` later closed, the next handshake never completes.

This builds a fresh context per connection:

```python
def _build_ssl_context(verify: bool) -> ssl_lib.SSLContext:
    context = ssl_lib.create_default_context()
    if not verify:
        context.check_hostname = False
        context.verify_mode = ssl_lib.CERT_NONE
    return context
```

It runs via `hass.async_add_executor_job(...)` because constructing a context reads the CA bundle from disk and would otherwise block the event loop.

Verified on my instance, changing nothing else:

```
-- before --                     -- after --
13:15:49  greeting timed out     13:33:01  ctx id=...891168  post-login AUTH   OK
13:21:04  greeting timed out     13:38:14  ctx id=...977952  post-login AUTH   OK
13:26:19  greeting timed out
13:31:34  greeting timed out
```

Two consecutive successful scans with distinct context ids, and `sensor.mail_updated` advancing again after being frozen all day.

## Two hardening changes included

**Bound the greeting.** `wait_hello_from_server()` had no timeout of its own, so its only limit was the `timeout=` passed to `IMAP4_SSL(...)`, which the coordinator sets to the whole scan budget. A stalled greeting consumed all of it rather than failing fast. This applies the same `min(timeout, 15.0)` the OAuth branch already uses a few lines below.

**Stop `logout()` swallowing `asyncio.CancelledError`.** It runs from a `finally` in `process_emails()` while `asyncio.timeout` is cancelling the scan, so suppressing cancellation there prevents the coordinator unwinding cleanly. Other exception types are still logged at debug as before.

## Notes

- `from homeassistant.util import ssl` is removed because it had no remaining uses. stdlib `ssl` is imported as `ssl_lib` to avoid colliding with that former binding.
- Behaviour is unchanged for anyone whose connections already work; this only stops the context being reused.
- The `verify=False` path keeps its previous meaning (no hostname check, no cert verification).
- Tested against Fastmail with password auth on HA 2026.8.2. I do not have an OAuth account to exercise the XOAUTH2 branch, though it shares the same context construction and should benefit equally.
