### PR TITLE
perf(imap): execute search batches concurrently

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -578,29 +578,44 @@ async def email_search(  # noqa: C901
                 return (res.result, [b" ".join(parsed)])
 
         # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
+        batch_queries = [
+            build_search(
+                addr_batch,
+                date,
+                subj_batch,
+                body_search,
+                header,
+                is_yahoo=is_yahoo,
+            )[1]
+            for addr_batch in address_batches
+            for subj_batch in subject_batches
+        ]
+
+        async def _run_search(query: str):
+            try:
+                res = await account.search(query, charset=None)
+                if res.result == "OK" and res.lines:
+                    return parse_search_response(res.lines)
+            except TimeoutError:
+                raise
+            except (AioImapException, OSError) as err:
+                _LOGGER.error("Error searching emails batch: %s", err)
+            return None
+
+        results = await asyncio.gather(
+            *[_run_search(q) for q in batch_queries], return_exceptions=True
+        )
+
         all_matched_ids: list[str] = []
         batch_success = False
-        for addr_batch in address_batches:
-            for subj_batch in subject_batches:
-                _unused, search = build_search(
-                    addr_batch,
-                    date,
-                    subj_batch,
-                    body_search,
-                    header,
-                    is_yahoo=is_yahoo,
-                )
-                try:
-                    res = await account.search(search, charset=None)
-                    if res.result == "OK":
-                        batch_success = True
-                        if res.lines:
-                            parsed = parse_search_response(res.lines)
-                            all_matched_ids.extend(parsed)
-                except TimeoutError:
-                    raise
-                except (AioImapException, OSError) as err:
-                    _LOGGER.error("Error searching emails batch: %s", err)
+        for r in results:
+            if isinstance(r, TimeoutError):
+                raise r
+            if isinstance(r, Exception):
+                _LOGGER.error("Error searching emails batch: %s", r)
+            elif r is not None:
+                batch_success = True
+                all_matched_ids.extend(r)
 
         if not batch_success and not all_matched_ids:
             return ("BAD", "All search batches failed")
@@ -624,26 +639,42 @@ async def email_search(  # noqa: C901
         return ("OK", [b" ".join(uids)])
 
     # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
+    batch_queries = [
+        build_search(
+            addr_batch,
+            date,
+            subj_batch,
+            body_search,
+            header,
+            is_yahoo=is_yahoo,
+        )[1]
+        for addr_batch in address_batches
+        for subj_batch in subject_batches
+    ]
+
+    async def _run_multi_search(query: str):
+        try:
+            return await _execute_single_search(account, query)
+        except TimeoutError:
+            raise
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error searching emails batch: %s", err)
+        return None
+
+    results = await asyncio.gather(
+        *[_run_multi_search(q) for q in batch_queries], return_exceptions=True
+    )
+
     all_matched_ids = []
     batch_success = False
-    for addr_batch in address_batches:
-        for subj_batch in subject_batches:
-            _unused, search = build_search(
-                addr_batch,
-                date,
-                subj_batch,
-                body_search,
-                header,
-                is_yahoo=is_yahoo,
-            )
-            try:
-                uids = await _execute_single_search(account, search)
-                batch_success = True
-                all_matched_ids.extend(uids)
-            except TimeoutError:
-                raise
-            except (AioImapException, OSError) as err:
-                _LOGGER.error("Error searching emails batch: %s", err)
+    for r in results:
+        if isinstance(r, TimeoutError):
+            raise r
+        if isinstance(r, Exception):
+            _LOGGER.error("Error searching emails batch: %s", r)
+        elif r is not None:
+            batch_success = True
+            all_matched_ids.extend(r)
 
     if not batch_success and not all_matched_ids:
         return ("BAD", "All search batches failed")

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -612,7 +612,7 @@ async def email_search(  # noqa: C901
             if isinstance(r, TimeoutError):
                 raise r
             if isinstance(r, Exception):
-                _LOGGER.error("Error searching emails batch: %s", r)
+                _LOGGER.error("Error searching emails batch: %r", r)
             elif r is not None:
                 batch_success = True
                 all_matched_ids.extend(r)
@@ -638,7 +638,8 @@ async def email_search(  # noqa: C901
             return ("BAD", str(err))
         return ("OK", [b" ".join(uids)])
 
-    # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
+    # Batch subjects and addresses sequentially across multi-folder searches
+    # to avoid race conditions when switching mailbox folders on a single connection.
     batch_queries = [
         build_search(
             addr_batch,
@@ -652,29 +653,17 @@ async def email_search(  # noqa: C901
         for subj_batch in subject_batches
     ]
 
-    async def _run_multi_search(query: str):
+    all_matched_ids = []
+    batch_success = False
+    for query in batch_queries:
         try:
-            return await _execute_single_search(account, query)
+            uids = await _execute_single_search(account, query)
+            batch_success = True
+            all_matched_ids.extend(uids)
         except TimeoutError:
             raise
         except (AioImapException, OSError) as err:
             _LOGGER.error("Error searching emails batch: %s", err)
-        return None
-
-    results = await asyncio.gather(
-        *[_run_multi_search(q) for q in batch_queries], return_exceptions=True
-    )
-
-    all_matched_ids = []
-    batch_success = False
-    for r in results:
-        if isinstance(r, TimeoutError):
-            raise r
-        if isinstance(r, Exception):
-            _LOGGER.error("Error searching emails batch: %s", r)
-        elif r is not None:
-            batch_success = True
-            all_matched_ids.extend(r)
 
     if not batch_success and not all_matched_ids:
         return ("BAD", "All search batches failed")

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -1626,6 +1626,42 @@ async def test_email_search_batch_and_exceptions():
         )
         assert res == ("BAD", "All search batches failed")
 
+    # Case 5: Multi-folder search batch encounters AioImapException
+    with patch(
+        "custom_components.mail_and_packages.utils.imap._execute_single_search",
+        side_effect=AioImapException("AioImap error"),
+    ):
+        res = await email_search(
+            mock_account, ["test@example.com"], "25-Mar-2026", subject=subjects
+        )
+        assert res == ("BAD", "All search batches failed")
+
+
+@pytest.mark.asyncio
+async def test_email_search_multifolders_batched_real_execution():
+    """Test multi-folder batched email_search without mocking _execute_single_search."""
+    mock_account = AsyncMock()
+    mock_account._folders = ["INBOX", "Archive"]
+    mock_account._current_folder = "INBOX"
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_account.has_capability = MagicMock(return_value=False)
+
+    # Return different UIDs across folders for sequential search
+    mock_account.uid_search.side_effect = [
+        MagicMock(result="OK", lines=[b"101"]),  # Batch 1, INBOX
+        MagicMock(result="OK", lines=[b"201"]),  # Batch 1, Archive
+        MagicMock(result="OK", lines=[b"102"]),  # Batch 2, INBOX
+        MagicMock(result="OK", lines=[]),  # Batch 2, Archive
+    ]
+
+    subjects = ["Sub1", "Sub2"]
+    res = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject=subjects
+    )
+    assert res[0] == "OK"
+    assert res[1] == [b"INBOX/101 Archive/201 INBOX/102"]
+
 
 @pytest.mark.asyncio
 async def test_email_fetch_failures():
@@ -1816,6 +1852,24 @@ async def test_email_search_batch_timeout_error():
         await email_search(
             mock_imap, ["test@example.com"], "25-Mar-2026", subject=subjects
         )
+
+
+@pytest.mark.asyncio
+async def test_email_search_single_folder_batch_exception():
+    """Test email_search single-folder batched subjects logs unexpected Exception and continues."""
+    mock_imap = AsyncMock()
+    mock_imap._folders = ["INBOX"]
+    # Return one normal result and one RuntimeError
+    mock_imap.search.side_effect = [
+        MagicMock(result="OK", lines=[b"101"]),
+        RuntimeError("Unexpected batch error"),
+    ]
+    subjects = [f"Subj {i}" for i in range(11)]
+    res = await email_search(
+        mock_imap, ["test@example.com"], "25-Mar-2026", subject=subjects
+    )
+    assert res[0] == "OK"
+    assert res[1] == [b"101"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

Parallelize IMAP search batch executions in `email_search` using `asyncio.gather(*tasks, return_exceptions=True)`.

When multiple subject variants (such as internationalized carrier phrases) or address batches are searched, running them concurrently avoids multiplying network round-trip latency across sequential requests, significantly reducing scan durations during Home Assistant startup and coordinator refreshes while preserving safe, compliant query structures for Outlook 365 / Exchange servers.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1385
- This PR is related to issue: #1379
