### PR TITLE
refactor: reduce cyclomatic complexity and resolve noqa comments

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -669,32 +669,56 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
 
         return transit
 
-    async def _binary_sensor_update(self):  # noqa: C901
+    async def _check_camera_update(self, base_name: str) -> None:
+        """Check image hash changes for a specific delivery camera."""
+        image_attr_name = f"ATTR_{base_name.upper()}_IMAGE"
+        image_attr = getattr(const, image_attr_name, None)
+        if not image_attr:
+            return
+
+        image = self._data.get(image_attr)
+        _LOGGER.debug("%s image from data: %s", base_name.title(), image)
+        if not image:
+            return
+
+        image_path = default_image_path(self.hass, self.config).rstrip("/") + "/"
+        path = f"{image_path}{base_name}/"
+        delivery_image = self.hass.config.path(f"{path}{image}")
+        _LOGGER.debug("Full %s image path: %s", base_name.title(), delivery_image)
+
+        custom_img_key = getattr(const, f"CONF_{base_name.upper()}_CUSTOM_IMG", None)
+        custom_img_file_key = getattr(
+            const, f"CONF_{base_name.upper()}_CUSTOM_IMG_FILE", None
+        )
+        if custom_img_key and self.config.get(custom_img_key):
+            none_image = self.config.get(custom_img_file_key)
+        elif base_name == "post_de":
+            none_image = f"{Path(__file__).parent}/mail_none.gif"
+        else:
+            none_image = f"{Path(__file__).parent}/no_deliveries_{base_name}.jpg"
+
+        if await anyio.Path(delivery_image).exists():
+            image_hash = await self._get_file_hash_if_changed(delivery_image)
+            none_hash = await self._get_file_hash_if_changed(none_image)
+            _LOGGER.debug("%s Image hash: %s", base_name.title(), image_hash)
+            _LOGGER.debug("%s None hash: %s", base_name.title(), none_hash)
+            self._data[f"{base_name}_update"] = image_hash != none_hash
+
+    async def _binary_sensor_update(self):
         """Update binary sensor states."""
-        # USPS uses ATTR_USPS_IMAGE instead of the old ATTR_IMAGE_NAME
         _LOGGER.debug("Data: %s", self._data)
         image = self._data.get(ATTR_USPS_IMAGE)
         if image:
             path = default_image_path(self.hass, self.config)
             usps_image = f"{path}/{image}"
             usps_none = f"{Path(__file__).parent}/mail_none.gif"
-            usps_check = await anyio.Path(usps_image).exists()
-            _LOGGER.debug("USPS Check: %s", usps_check)
-            if usps_check:
-                # Optimized: Use _get_file_hash_if_changed
+            if await anyio.Path(usps_image).exists():
                 image_hash = await self._get_file_hash_if_changed(usps_image)
                 none_hash = await self._get_file_hash_if_changed(usps_none)
-
                 _LOGGER.debug("USPS Image hash: %s", image_hash)
                 _LOGGER.debug("USPS None hash: %s", none_hash)
+                self._data["usps_update"] = image_hash != none_hash
 
-                if image_hash != none_hash:
-                    self._data["usps_update"] = True
-                else:
-                    self._data["usps_update"] = False
-
-        # Handle generic delivery cameras (Amazon, UPS, Walmart, FedEx, Generic) with unified logic
-        # Derive camera list dynamically from CAMERA_DATA, excluding usps_camera and generic_camera
         delivery_cameras = [
             camera_type.replace("_camera", "")
             for camera_type in const.CAMERA_DATA
@@ -702,61 +726,4 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
         ]
 
         for base_name in delivery_cameras:
-            # Derive attribute and config keys dynamically
-            image_attr_name = f"ATTR_{base_name.upper()}_IMAGE"
-            image_attr = getattr(const, image_attr_name, None)
-            if not image_attr:
-                continue
-
-            custom_img_key = getattr(
-                const,
-                f"CONF_{base_name.upper()}_CUSTOM_IMG",
-                None,
-            )
-            custom_img_file_key = getattr(
-                const,
-                f"CONF_{base_name.upper()}_CUSTOM_IMG_FILE",
-                None,
-            )
-            update_key = f"{base_name}_update"
-
-            image = self._data.get(image_attr)
-            _LOGGER.debug("%s image from data: %s", base_name.title(), image)
-            if image:
-                # Normalize path to avoid double slashes
-                image_path = (
-                    default_image_path(self.hass, self.config).rstrip("/") + "/"
-                )
-                path = f"{image_path}{base_name}/"
-                # Use absolute path for file existence check
-                delivery_image_relative = f"{path}{image}"
-                delivery_image = self.hass.config.path(delivery_image_relative)
-                _LOGGER.debug(
-                    "Full %s image path: %s",
-                    base_name.title(),
-                    delivery_image,
-                )
-
-                if custom_img_key and self.config.get(custom_img_key):
-                    none_image = self.config.get(custom_img_file_key)
-                elif base_name == "post_de":
-                    none_image = f"{Path(__file__).parent}/mail_none.gif"
-                else:
-                    none_image = (
-                        f"{Path(__file__).parent}/no_deliveries_{base_name}.jpg"
-                    )
-
-                image_check = await anyio.Path(delivery_image).exists()
-                _LOGGER.debug("%s Check: %s", base_name.title(), image_check)
-                if image_check:
-                    # Optimized: Use _get_file_hash_if_changed
-                    image_hash = await self._get_file_hash_if_changed(delivery_image)
-                    none_hash = await self._get_file_hash_if_changed(none_image)
-
-                    _LOGGER.debug("%s Image hash: %s", base_name.title(), image_hash)
-                    _LOGGER.debug("%s None hash: %s", base_name.title(), none_hash)
-
-                    if image_hash != none_hash:
-                        self._data[update_key] = True
-                    else:
-                        self._data[update_key] = False
+            await self._check_camera_update(base_name)

--- a/custom_components/mail_and_packages/shippers/post_de.py
+++ b/custom_components/mail_and_packages/shippers/post_de.py
@@ -275,7 +275,66 @@ class PostDEShipper(Shipper):
         await self.hass.async_add_executor_job(cleanup_images, path + "/")
         return True
 
-    async def _process_post_de_email(  # noqa: C901
+    def _check_and_save_image(
+        self,
+        img_bytes: bytes,
+        out_path: str,
+        content_type: str,
+    ) -> str | None:
+        """Validate and save scanned image if dimensions match envelope scans."""
+        try:
+            img = Image.open(io.BytesIO(img_bytes))
+            if img.format is None:
+                _LOGGER.debug("Post DE image format is unidentified (None)")
+                return None
+
+            if content_type == "image/png" and img.format != "PNG":
+                _LOGGER.debug(
+                    "Post DE image format mismatch: expected PNG, got %s",
+                    img.format,
+                )
+                return None
+            if content_type == "image/jpeg" and img.format != "JPEG":
+                _LOGGER.debug(
+                    "Post DE image format mismatch: expected JPEG, got %s",
+                    img.format,
+                )
+                return None
+
+            width, height = img.size
+            if width > 150 and height > 100:
+                ext = ".png" if content_type == "image/png" else ".jpg"
+                filename = random_filename(ext=ext)
+                target = Path(out_path) / filename
+                with target.open("wb") as f:
+                    f.write(img_bytes)
+                return str(target)
+        except UnidentifiedImageError as err:
+            _LOGGER.warning("Unidentified image found in Post DE email: %s", err)
+        except (OSError, ValueError, TypeError) as err:
+            _LOGGER.debug("Error checking/saving Post DE image: %s", err)
+        return None
+
+    async def _extract_post_de_scan(
+        self,
+        part: email.message.Message,
+        image_output_path: str,
+    ) -> str | None:
+        """Extract and save single image part if valid."""
+        if part.get_content_type() not in ("image/png", "image/jpeg"):
+            return None
+        payload = part.get_payload(decode=True)
+        if not payload:
+            return None
+
+        return await self.hass.async_add_executor_job(
+            self._check_and_save_image,
+            payload,
+            image_output_path,
+            part.get_content_type(),
+        )
+
+    async def _process_post_de_email(
         self,
         account: IMAP4_SSL,
         num: str,
@@ -295,78 +354,14 @@ class PostDEShipper(Shipper):
             msg_parts = (await email_fetch(account, num, "(RFC822)"))[1]
         _LOGGER.debug("Processing Post DE email number: %s", num)
         for response_part in msg_parts:
-            if isinstance(response_part, (bytes, bytearray)):
-                msg = email.message_from_bytes(response_part)
-                for part in msg.walk():
-                    if part.get_content_type() in ("image/png", "image/jpeg"):
-                        payload = part.get_payload(decode=True)
-                        if not payload:
-                            continue
-
-                        # Check image dimensions to skip logos/icons
-                        def _check_and_save(
-                            img_bytes: bytes,
-                            out_path: str,
-                            content_type: str,
-                        ) -> str | None:
-                            try:
-                                img = Image.open(io.BytesIO(img_bytes))
-                                if img.format is None:
-                                    _LOGGER.debug(
-                                        "Post DE image format is unidentified (None)"
-                                    )
-                                    return None
-
-                                # Validate format against expected content type
-                                if content_type == "image/png" and img.format != "PNG":
-                                    _LOGGER.debug(
-                                        "Post DE image format mismatch: expected PNG, got %s",
-                                        img.format,
-                                    )
-                                    return None
-                                if (
-                                    content_type == "image/jpeg"
-                                    and img.format != "JPEG"
-                                ):
-                                    _LOGGER.debug(
-                                        "Post DE image format mismatch: expected JPEG, got %s",
-                                        img.format,
-                                    )
-                                    return None
-
-                                width, height = img.size
-                                if width > 150 and height > 100:
-                                    ext = (
-                                        ".png"
-                                        if content_type == "image/png"
-                                        else ".jpg"
-                                    )
-                                    filename = random_filename(ext=ext)
-                                    target = Path(out_path) / filename
-                                    with target.open("wb") as f:
-                                        f.write(img_bytes)
-                                    return str(target)
-                            except UnidentifiedImageError as err:
-                                _LOGGER.warning(
-                                    "Unidentified image found in Post DE email: %s", err
-                                )
-                            except (OSError, ValueError, TypeError) as err:
-                                _LOGGER.debug(
-                                    "Error checking/saving Post DE image: %s", err
-                                )
-                            return None
-
-                        saved_path = await self.hass.async_add_executor_job(
-                            _check_and_save,
-                            payload,
-                            image_output_path,
-                            part.get_content_type(),
-                        )
-                        if saved_path:
-                            images.append(saved_path)
-                            image_count += 1
-                            _LOGGER.debug(
-                                "Extracted Post DE mail image: %s", saved_path
-                            )
+            if not isinstance(response_part, (bytes, bytearray)):
+                continue
+            msg = email.message_from_bytes(response_part)
+            for part in msg.walk():
+                saved_path = await self._extract_post_de_scan(part, image_output_path)
+                if saved_path:
+                    images.append(saved_path)
+                    image_count += 1
+                    _LOGGER.debug("Extracted Post DE mail image: %s", saved_path)
 
         return image_count, images

--- a/custom_components/mail_and_packages/utils/cache.py
+++ b/custom_components/mail_and_packages/utils/cache.py
@@ -97,7 +97,63 @@ class EmailCache:
         if expired_keys and self._store:
             await self.async_save()
 
-    async def fetch(  # noqa: C901
+    def _get_persistent_cache(self, cache_key: str) -> tuple | None:
+        """Retrieve and decode data from persistent cache if present."""
+        if cache_key not in self._persistent_store:
+            return None
+        entry = self._persistent_store[cache_key]
+        cached_data = entry.get("data")
+        if not (
+            cached_data and isinstance(cached_data, list) and len(cached_data) == 2
+        ):
+            return None
+
+        status, response_list = cached_data
+        if not isinstance(response_list, list):
+            return (status, response_list)
+
+        restored_list = []
+        for item in response_list:
+            if isinstance(item, (list, tuple)):
+                restored_list.append(
+                    tuple(
+                        x.encode("latin-1") if isinstance(x, str) else x for x in item
+                    )
+                )
+            elif isinstance(item, str):
+                restored_list.append(item.encode("latin-1"))
+            else:
+                restored_list.append(item)
+        return (status, restored_list)
+
+    async def _fetch_from_imap(self, eid_str: str, parts: str) -> tuple:
+        """Fetch email parts from IMAP server."""
+        if "HEADER" in parts:
+            return await email_fetch_headers(self.account, eid_str)
+        if "TEXT" in parts or parts == "(BODY[1])":
+            return await email_fetch_text(self.account, eid_str, parts)
+        return await email_fetch(self.account, eid_str, parts)
+
+    def _get_memory_cache(self, eid_str: str, parts: str) -> tuple | None:
+        """Check in-memory tier caches."""
+        if parts in ("(RFC822)", "BODY[]"):
+            return self._cache_rfc822.get(eid_str)
+        if "HEADER" in parts:
+            return self._cache_headers.get(eid_str) or self._cache_rfc822.get(eid_str)
+        if "TEXT" in parts or parts == "(BODY[1])":
+            return self._cache_text.get(eid_str) or self._cache_rfc822.get(eid_str)
+        return None
+
+    def _store_memory_cache(self, eid_str: str, parts: str, res: tuple) -> None:
+        """Store successful result in memory tier caches."""
+        if parts in ("(RFC822)", "BODY[]"):
+            self._cache_rfc822[eid_str] = res
+        elif "HEADER" in parts:
+            self._cache_headers[eid_str] = res
+        elif "TEXT" in parts or parts == "(BODY[1])":
+            self._cache_text[eid_str] = res
+
+    async def fetch(
         self,
         email_id: str | bytes,
         parts: str = "(RFC822)",
@@ -105,73 +161,24 @@ class EmailCache:
     ) -> tuple:
         """Fetch email content or return from cache."""
         eid_str = email_id.decode() if isinstance(email_id, bytes) else str(email_id)
-
         cache_key = f"{eid_str}:{parts}"
 
-        # Check persistent cache first if available
-        if cache_key in self._persistent_store:
-            entry = self._persistent_store[cache_key]
-            cached_data = entry.get("data")
-            if cached_data and isinstance(cached_data, list) and len(cached_data) == 2:
-                status, response_list = cached_data
-                restored_list = []
-                if isinstance(response_list, list):
-                    for item in response_list:
-                        if isinstance(item, (list, tuple)):
-                            restored_list.append(
-                                tuple(
-                                    x.encode("latin-1") if isinstance(x, str) else x
-                                    for x in item
-                                )
-                            )
-                        elif isinstance(item, str):
-                            restored_list.append(item.encode("latin-1"))
-                        else:
-                            restored_list.append(item)
-                else:
-                    restored_list = response_list
-                return (status, restored_list)
+        persistent = self._get_persistent_cache(cache_key)
+        if persistent is not None:
+            return persistent
 
-        if parts in ("(RFC822)", "BODY[]"):
-            if eid_str in self._cache_rfc822:
-                return self._cache_rfc822[eid_str]
-            if self.account is None:
-                return ("NO", ["No active IMAP connection"])
-            res = await email_fetch(self.account, eid_str, parts)
-            if res[0] == "OK":
-                self._cache_rfc822[eid_str] = res
-                self._store_persistent(cache_key, res, shipper)
-            return res
-
-        if "HEADER" in parts:
-            if eid_str in self._cache_headers:
-                return self._cache_headers[eid_str]
-            if eid_str in self._cache_rfc822:
-                return self._cache_rfc822[eid_str]
-            if self.account is None:
-                return ("NO", ["No active IMAP connection"])
-            res = await email_fetch_headers(self.account, eid_str)
-            if res[0] == "OK":
-                self._cache_headers[eid_str] = res
-                self._store_persistent(cache_key, res, shipper)
-            return res
-
-        if "TEXT" in parts or parts == "(BODY[1])":
-            if eid_str in self._cache_text:
-                return self._cache_text[eid_str]
-            if eid_str in self._cache_rfc822:
-                return self._cache_rfc822[eid_str]
-            if self.account is None:
-                return ("NO", ["No active IMAP connection"])
-            res = await email_fetch_text(self.account, eid_str, parts)
-            if res[0] == "OK":
-                self._cache_text[eid_str] = res
-                self._store_persistent(cache_key, res, shipper)
-            return res
+        mem_hit = self._get_memory_cache(eid_str, parts)
+        if mem_hit is not None:
+            return mem_hit
 
         if self.account is None:
             return ("NO", ["No active IMAP connection"])
-        return await email_fetch(self.account, eid_str, parts)
+
+        res = await self._fetch_from_imap(eid_str, parts)
+        if res[0] == "OK":
+            self._store_memory_cache(eid_str, parts, res)
+            self._store_persistent(cache_key, res, shipper)
+        return res
 
     def _store_persistent(self, eid_str: str, data: tuple, shipper: str) -> None:
         """Store fetched email data in persistent structure."""

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -243,7 +243,74 @@ def clean_search_string(val: str) -> str:
     return cleaned.replace('"', "").replace(":", "").strip()
 
 
-def build_search(  # noqa: C901
+def _build_address_clause(
+    address: list, header: str = "", is_yahoo: bool = False
+) -> str:
+    """Build FROM / HEADER address search clause."""
+    if header:
+        parts = [f'OR HEADER "{header}" "{a}" FROM "{a}"' for a in address]
+        if len(parts) == 1:
+            return f"({parts[0]})" if is_yahoo else parts[0]
+        or_prefix = " ".join(["OR"] * (len(parts) - 1))
+        return (
+            f"({or_prefix} {' '.join(parts)})"
+            if is_yahoo
+            else f"{or_prefix} {' '.join(parts)}"
+        )
+
+    if len(address) == 1:
+        return f'FROM "{address[0]}"'
+
+    joined = '" FROM "'.join(address)
+    or_prefix = " ".join(["OR"] * (len(address) - 1))
+    return (
+        f'({or_prefix} FROM "{joined}")' if is_yahoo else f'{or_prefix} FROM "{joined}"'
+    )
+
+
+def _build_subject_clause(subject: str | list[str] = "", is_yahoo: bool = False) -> str:
+    """Build SUBJECT search clause."""
+    if not subject:
+        return ""
+    subjects = [subject] if isinstance(subject, str) else subject
+    safe_subjects = [clean_search_string(s) for s in subjects]
+    safe_subjects = list(dict.fromkeys(s for s in safe_subjects if s))
+
+    if len(safe_subjects) == 1:
+        return f'SUBJECT "{safe_subjects[0]}"'
+    if len(safe_subjects) > 1:
+        subject_prefix = " ".join(["OR"] * (len(safe_subjects) - 1))
+        subject_joined = '" SUBJECT "'.join(safe_subjects)
+        return (
+            f'({subject_prefix} SUBJECT "{subject_joined}")'
+            if is_yahoo
+            else f'{subject_prefix} SUBJECT "{subject_joined}"'
+        )
+    return ""
+
+
+def _build_body_clause(body: str | list[str] = "", is_yahoo: bool = False) -> str:
+    """Build BODY search clause."""
+    if not body:
+        return ""
+    bodies = [body] if isinstance(body, str) else body
+    safe_bodies = [clean_search_string(b) for b in bodies]
+    safe_bodies = [b for b in safe_bodies if b]
+
+    if len(safe_bodies) == 1:
+        return f'BODY "{safe_bodies[0]}"'
+    if len(safe_bodies) > 1:
+        body_prefix = " ".join(["OR"] * (len(safe_bodies) - 1))
+        body_joined = '" BODY "'.join(safe_bodies)
+        return (
+            f'({body_prefix} BODY "{body_joined}")'
+            if is_yahoo
+            else f'{body_prefix} BODY "{body_joined}"'
+        )
+    return ""
+
+
+def build_search(
     address: list,
     date: str,
     subject: str | list[str] = "",
@@ -271,80 +338,22 @@ def build_search(  # noqa: C901
     if not address:
         raise ValueError("address list must not be empty")
 
-    # Build the address/header clause
-    if header:
-        # Each address matches via header (forwarded) OR FROM (direct), so
-        # users with mixed setups (some carriers forwarded, others direct)
-        # don't need separate configurations.
-        parts = [f'OR HEADER "{header}" "{a}" FROM "{a}"' for a in address]
-        if len(parts) == 1:
-            addr_clause = f"({parts[0]})" if is_yahoo else parts[0]
-        else:
-            or_prefix = " ".join(["OR"] * (len(parts) - 1))
-            addr_clause = (
-                f"({or_prefix} {' '.join(parts)})"
-                if is_yahoo
-                else f"{or_prefix} {' '.join(parts)}"
-            )
-    elif len(address) == 1:
-        addr_clause = f'FROM "{address[0]}"'
-    else:
-        joined = '" FROM "'.join(address)
-        or_prefix = " ".join(["OR"] * (len(address) - 1))
-        addr_clause = (
-            f'({or_prefix} FROM "{joined}")'
+    addr_clause = _build_address_clause(address, header, is_yahoo)
+    subject_part = _build_subject_clause(subject, is_yahoo)
+    body_part = _build_body_clause(body, is_yahoo)
+
+    criteria_parts = [p for p in (subject_part, body_part) if p]
+    if criteria_parts:
+        search_criteria = " ".join(criteria_parts)
+        imap_search = (
+            f"({addr_clause} {search_criteria} {the_date})"
             if is_yahoo
-            else f'{or_prefix} FROM "{joined}"'
+            else f"{addr_clause} {search_criteria} {the_date}"
         )
-
-    # Handle multiple subjects
-    subject_part = ""
-    if subject:
-        subjects = [subject] if isinstance(subject, str) else subject
-        safe_subjects = [clean_search_string(s) for s in subjects]
-        # Deduplicate while deterministically preserving insertion order
-        safe_subjects = list(dict.fromkeys(s for s in safe_subjects if s))
-
-        if len(safe_subjects) == 1:
-            subject_part = f'SUBJECT "{safe_subjects[0]}"'
-        elif len(safe_subjects) > 1:
-            subject_prefix = " ".join(["OR"] * (len(safe_subjects) - 1))
-            subject_joined = '" SUBJECT "'.join(safe_subjects)
-            subject_part = (
-                f'({subject_prefix} SUBJECT "{subject_joined}")'
-                if is_yahoo
-                else f'{subject_prefix} SUBJECT "{subject_joined}"'
-            )
-
-    # Handle multiple bodies
-    body_part = ""
-    if body:
-        bodies = [body] if isinstance(body, str) else body
-        safe_bodies = [clean_search_string(b) for b in bodies]
-        safe_bodies = [b for b in safe_bodies if b]
-
-        if len(safe_bodies) == 1:
-            body_part = f'BODY "{safe_bodies[0]}"'
-        elif len(safe_bodies) > 1:
-            body_prefix = " ".join(["OR"] * (len(safe_bodies) - 1))
-            body_joined = '" BODY "'.join(safe_bodies)
-            body_part = (
-                f'({body_prefix} BODY "{body_joined}")'
-                if is_yahoo
-                else f'{body_prefix} BODY "{body_joined}"'
-            )
-
-    if is_yahoo:
-        if subject_part or body_part:
-            search_criteria = f"{subject_part} {body_part}".strip()
-            imap_search = f"({addr_clause} {search_criteria} {the_date})"
-        else:
-            imap_search = f"({addr_clause} {the_date})"
-    elif subject_part or body_part:
-        search_criteria = f"{subject_part} {body_part}".strip()
-        imap_search = f"{addr_clause} {search_criteria} {the_date}"
     else:
-        imap_search = f"{addr_clause} {the_date}"
+        imap_search = (
+            f"({addr_clause} {the_date})" if is_yahoo else f"{addr_clause} {the_date}"
+        )
 
     _LOGGER.debug("DEBUG imap_search: %s", imap_search)
 
@@ -427,7 +436,76 @@ def _parse_esearch_line(line_bytes: bytes) -> list[bytes]:
     return [f"{encode_folder_ref(mailbox)}/{uid}".encode() for uid in uids]
 
 
-async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[bytes]:  # noqa: C901
+def _supports_multisearch(account: IMAP4_SSL) -> bool:
+    """Check if account supports MULTISEARCH capability safely."""
+    if not hasattr(account, "has_capability"):
+        return False
+    try:
+        res = account.has_capability("MULTISEARCH")
+        if asyncio.iscoroutine(res):
+            res.close()
+            return False
+        return bool(res)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def _execute_multisearch(
+    account: IMAP4_SSL, folders: list[str], search_query: str
+) -> list[bytes]:
+    """Execute ESEARCH across multiple folders."""
+    all_uids = []
+    folder_list = " ".join([quote_folder(encode_imap_utf7(f)) for f in folders])
+    args = ("IN", f"({folder_list})", search_query)
+    try:
+        timeout = getattr(account, "timeout", None)
+        if not isinstance(timeout, (int, float)):
+            timeout = None
+        res = await account.protocol.execute(
+            Command(
+                "ESEARCH",
+                account.protocol.new_tag(),
+                *args,
+                loop=account.protocol.loop,
+                timeout=timeout,
+            )
+        )
+        if res.result == "OK":
+            for line in res.lines:
+                if line:
+                    all_uids.extend(_parse_esearch_line(line))
+    except TimeoutError:
+        raise
+    except (AioImapException, OSError) as err:
+        _LOGGER.error("Error executing ESEARCH: %s", err)
+    return all_uids
+
+
+async def _execute_sequential_search(
+    account: IMAP4_SSL, folders: list[str], search_query: str
+) -> list[bytes]:
+    """Execute search across folders sequentially."""
+    all_uids = []
+    for folder in folders:
+        select_ok = await selectfolder(account, folder)
+        if not select_ok:
+            continue
+        try:
+            res = await account.uid_search(search_query, charset=None)
+            if res.result == "OK" and res.lines:
+                parsed = parse_search_response(res.lines)
+                all_uids.extend(
+                    f"{encode_folder_ref(folder)}/{uid.decode()}".encode()
+                    for uid in parsed
+                )
+        except TimeoutError:
+            raise
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error searching folder %s: %s", folder, err)
+    return all_uids
+
+
+async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[bytes]:
     """Execute search query. If single folder, use standard search. If multiple, use hybrid ESEARCH/fallback."""
     folders = getattr(account, "_folders", ["INBOX"])
 
@@ -437,69 +515,136 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
             return parse_search_response(res.lines)
         return []
 
-    all_uids = []
+    if _supports_multisearch(account):
+        return await _execute_multisearch(account, folders, search_query)
+    return await _execute_sequential_search(account, folders, search_query)
 
-    # Check for MULTISEARCH capability safely (handling mock/AsyncMock in tests)
-    is_multisearch = False
-    if hasattr(account, "has_capability"):
-        try:
-            res = account.has_capability("MULTISEARCH")
-            if asyncio.iscoroutine(res):
-                res.close()
-                is_multisearch = False
-            else:
-                is_multisearch = bool(res)
-        except Exception:  # noqa: BLE001
-            pass
 
-    if is_multisearch:
-        # ESEARCH IN ("folder1" "folder2") query - encode and quote folders
-        folder_list = " ".join([quote_folder(encode_imap_utf7(f)) for f in folders])
-        args = ("IN", f"({folder_list})", search_query)
-        try:
-            timeout = getattr(account, "timeout", None)
-            if not isinstance(timeout, (int, float)):
-                timeout = None
-            res = await account.protocol.execute(
-                Command(
-                    "ESEARCH",
-                    account.protocol.new_tag(),
-                    *args,
-                    loop=account.protocol.loop,
-                    timeout=timeout,
-                )
+async def _search_all_batches(
+    account: IMAP4_SSL,
+    address_batches: list[list[str]],
+    subject_batches: list[list[str] | str],
+    date: str,
+    body_search: str | list[str],
+    header: str,
+    is_yahoo: bool,
+    use_multi_folder: bool,
+) -> tuple:
+    """Execute batch searches over address/subject batches."""
+    all_matched_ids: list[bytes] = []
+    batch_success = False
+    for addr_batch in address_batches:
+        for subj_batch in subject_batches:
+            _unused, search = build_search(
+                addr_batch,
+                date,
+                subj_batch,
+                body_search,
+                header,
+                is_yahoo=is_yahoo,
             )
-            if res.result == "OK":
-                for line in res.lines:
-                    if line:
-                        all_uids.extend(_parse_esearch_line(line))
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error executing ESEARCH: %s", err)
-    else:
-        # Sequential select and search fallback - no limits on configured folders
-        for folder in folders:
-            select_ok = await selectfolder(account, folder)
-            if not select_ok:
-                continue
             try:
-                res = await account.uid_search(search_query, charset=None)
-                if res.result == "OK" and res.lines:
-                    parsed = parse_search_response(res.lines)
-                    all_uids.extend(
-                        f"{encode_folder_ref(folder)}/{uid.decode()}".encode()
-                        for uid in parsed
-                    )
+                if use_multi_folder:
+                    uids = await _execute_single_search(account, search)
+                    batch_success = True
+                    all_matched_ids.extend(uids)
+                else:
+                    res = await account.search(search, charset=None)
+                    if res.result == "OK":
+                        batch_success = True
+                        if res.lines:
+                            parsed = parse_search_response(res.lines)
+                            all_matched_ids.extend(parsed)
             except TimeoutError:
                 raise
             except (AioImapException, OSError) as err:
-                _LOGGER.error("Error searching folder %s: %s", folder, err)
+                _LOGGER.error("Error searching emails batch: %s", err)
 
-    return all_uids
+    if not batch_success and not all_matched_ids:
+        return ("BAD", "All search batches failed")
+
+    unique_ids = list(dict.fromkeys(all_matched_ids))
+    return ("OK", [b" ".join(unique_ids)])
 
 
-async def email_search(  # noqa: C901
+async def _email_search_single_folder(
+    account: IMAP4_SSL,
+    address_batches: list[list[str]],
+    subject_batches: list[list[str] | str],
+    date: str,
+    body_search: str | list[str],
+    header: str,
+    is_yahoo: bool,
+    is_batched: bool,
+    address: list,
+    subject_search: list | str,
+) -> tuple:
+    """Execute search on a single folder mailbox."""
+    if not is_batched:
+        _unused, search = build_search(
+            address, date, subject_search, body_search, header, is_yahoo=is_yahoo
+        )
+        try:
+            res = await account.search(search, charset=None)
+        except TimeoutError:
+            raise
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error searching emails: %s", err)
+            return ("BAD", str(err))
+        parsed = parse_search_response(res.lines)
+        return (res.result, [b" ".join(parsed)])
+
+    return await _search_all_batches(
+        account,
+        address_batches,
+        subject_batches,
+        date,
+        body_search,
+        header,
+        is_yahoo,
+        use_multi_folder=False,
+    )
+
+
+async def _email_search_multi_folder(
+    account: IMAP4_SSL,
+    address_batches: list[list[str]],
+    subject_batches: list[list[str] | str],
+    date: str,
+    body_search: str | list[str],
+    header: str,
+    is_yahoo: bool,
+    is_batched: bool,
+    address: list,
+    subject_search: list | str,
+) -> tuple:
+    """Execute search across multiple folders."""
+    if not is_batched:
+        _unused, search = build_search(
+            address, date, subject_search, body_search, header, is_yahoo=is_yahoo
+        )
+        try:
+            uids = await _execute_single_search(account, search)
+        except TimeoutError:
+            raise
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error searching emails: %s", err)
+            return ("BAD", str(err))
+        return ("OK", [b" ".join(uids)])
+
+    return await _search_all_batches(
+        account,
+        address_batches,
+        subject_batches,
+        date,
+        body_search,
+        header,
+        is_yahoo,
+        use_multi_folder=True,
+    )
+
+
+async def email_search(
     account: IMAP4_SSL,
     address: list,
     date: str,
@@ -525,9 +670,6 @@ async def email_search(  # noqa: C901
         host_lower = account.host.lower()
         is_yahoo = "yahoo" in host_lower or "aol" in host_lower
 
-    # If there are more than 2 body patterns or if patterns contain regex metacharacters,
-    # do not search them server-side to prevent IMAP search failures and query timeouts.
-    # Instead, we let the shipper's client-side text filtering handle it.
     body_search = body
     if body:
         bodies = [body] if isinstance(body, str) else body
@@ -537,7 +679,6 @@ async def email_search(  # noqa: C901
     subject_search = subject
     if isinstance(subject, list):
         cleaned_subjects = [clean_search_string(s) for s in subject]
-        # Deduplicate while deterministically preserving insertion order
         subject_search = list(dict.fromkeys(s for s in cleaned_subjects if s))
 
     address_batches = (
@@ -562,95 +703,31 @@ async def email_search(  # noqa: C901
     is_batched = len(address_batches) > 1 or len(subject_batches) > 1
 
     if len(folders) <= 1:
-        if not is_batched:
-            _unused, search = build_search(
-                address, date, subject_search, body_search, header, is_yahoo=is_yahoo
-            )
-            try:
-                res = await account.search(search, charset=None)
-            except TimeoutError:
-                raise
-            except (AioImapException, OSError) as err:
-                _LOGGER.error("Error searching emails: %s", err)
-                return ("BAD", str(err))
-            else:
-                parsed = parse_search_response(res.lines)
-                return (res.result, [b" ".join(parsed)])
-
-        # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
-        all_matched_ids: list[str] = []
-        batch_success = False
-        for addr_batch in address_batches:
-            for subj_batch in subject_batches:
-                _unused, search = build_search(
-                    addr_batch,
-                    date,
-                    subj_batch,
-                    body_search,
-                    header,
-                    is_yahoo=is_yahoo,
-                )
-                try:
-                    res = await account.search(search, charset=None)
-                    if res.result == "OK":
-                        batch_success = True
-                        if res.lines:
-                            parsed = parse_search_response(res.lines)
-                            all_matched_ids.extend(parsed)
-                except TimeoutError:
-                    raise
-                except (AioImapException, OSError) as err:
-                    _LOGGER.error("Error searching emails batch: %s", err)
-
-        if not batch_success and not all_matched_ids:
-            return ("BAD", "All search batches failed")
-
-        # Deduplicate and return in same format as individual search
-        unique_ids = list(dict.fromkeys(all_matched_ids))
-        return ("OK", [b" ".join(unique_ids)])
-
-    # Multi-folder search logic
-    if not is_batched:
-        _unused, search = build_search(
-            address, date, subject_search, body_search, header, is_yahoo=is_yahoo
+        return await _email_search_single_folder(
+            account,
+            address_batches,
+            subject_batches,
+            date,
+            body_search,
+            header,
+            is_yahoo,
+            is_batched,
+            address,
+            subject_search,
         )
-        try:
-            uids = await _execute_single_search(account, search)
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error searching emails: %s", err)
-            return ("BAD", str(err))
-        return ("OK", [b" ".join(uids)])
 
-    # Batch subjects and addresses in small groups to prevent query complexity timeouts (e.g. on Outlook O365)
-    all_matched_ids = []
-    batch_success = False
-    for addr_batch in address_batches:
-        for subj_batch in subject_batches:
-            _unused, search = build_search(
-                addr_batch,
-                date,
-                subj_batch,
-                body_search,
-                header,
-                is_yahoo=is_yahoo,
-            )
-            try:
-                uids = await _execute_single_search(account, search)
-                batch_success = True
-                all_matched_ids.extend(uids)
-            except TimeoutError:
-                raise
-            except (AioImapException, OSError) as err:
-                _LOGGER.error("Error searching emails batch: %s", err)
-
-    if not batch_success and not all_matched_ids:
-        return ("BAD", "All search batches failed")
-
-    # Deduplicate and return in same format as individual search
-    unique_ids = list(dict.fromkeys(all_matched_ids))
-    return ("OK", [b" ".join(unique_ids)])
+    return await _email_search_multi_folder(
+        account,
+        address_batches,
+        subject_batches,
+        date,
+        body_search,
+        header,
+        is_yahoo,
+        is_batched,
+        address,
+        subject_search,
+    )
 
 
 async def email_fetch(account: IMAP4_SSL, num, parts: str = "(RFC822)") -> tuple:
@@ -740,41 +817,26 @@ async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") ->
         return (res.result, res.lines)
 
 
-async def email_fetch_batch(  # noqa: C901
-    account: IMAP4_SSL, nums: list[str | bytes], parts: str = "(RFC822)"
+async def _fetch_batch_single_folder(
+    account: IMAP4_SSL, nums: list[str | bytes], parts: str
 ) -> tuple:
-    """Download specified emails for parsing asynchronously in a batch."""
-    if not nums:
-        return ("OK", [])
+    """Fetch a batch of emails from the currently active folder."""
+    num_strs = [num.decode() if isinstance(num, bytes) else str(num) for num in nums]
+    num_list_str = ",".join(num_strs)
+    try:
+        res = await account.fetch(num_list_str, parts)
+    except TimeoutError:
+        raise
+    except (AioImapException, OSError) as err:
+        _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
+        return ("BAD", str(err))
+    else:
+        return (res.result, res.lines)
 
-    if account.host == "imap.mail.me.com":
-        parts = "BODY[]"
 
-    # Check if any ID contains a folder prefix
-    has_folder_prefix = False
-    for num in nums:
-        num_str = num.decode() if isinstance(num, bytes) else str(num)
-        if "/" in num_str:
-            has_folder_prefix = True
-            break
-
-    if not has_folder_prefix:
-        num_strs = [
-            num.decode() if isinstance(num, bytes) else str(num) for num in nums
-        ]
-        num_list_str = ",".join(num_strs)
-        try:
-            res = await account.fetch(num_list_str, parts)
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
-            return ("BAD", str(err))
-        else:
-            return (res.result, res.lines)
-
-    # Group nums by their folder prefix
-    folder_to_nums = {}
+def _group_nums_by_folder(nums: list[str | bytes]) -> dict[str | None, list[str]]:
+    """Group composite and standard email UIDs by their folder reference."""
+    folder_to_nums: dict[str | None, list[str]] = {}
     for num in nums:
         num_str = num.decode() if isinstance(num, bytes) else str(num)
         if "/" in num_str:
@@ -783,7 +845,14 @@ async def email_fetch_batch(  # noqa: C901
         else:
             folder, actual_num = None, num_str
         folder_to_nums.setdefault(folder, []).append(actual_num)
+    return folder_to_nums
 
+
+async def _fetch_batch_multi_folder(
+    account: IMAP4_SSL, nums: list[str | bytes], parts: str
+) -> tuple:
+    """Fetch emails grouped across multiple folders."""
+    folder_to_nums = _group_nums_by_folder(nums)
     all_results = []
     overall_result = "OK"
 
@@ -804,6 +873,26 @@ async def email_fetch_batch(  # noqa: C901
             return ("BAD", str(err))
 
     return (overall_result, all_results)
+
+
+async def email_fetch_batch(
+    account: IMAP4_SSL, nums: list[str | bytes], parts: str = "(RFC822)"
+) -> tuple:
+    """Download specified emails for parsing asynchronously in a batch."""
+    if not nums:
+        return ("OK", [])
+
+    if account.host == "imap.mail.me.com":
+        parts = "BODY[]"
+
+    has_folder_prefix = any(
+        "/" in (n.decode() if isinstance(n, bytes) else str(n)) for n in nums
+    )
+
+    if not has_folder_prefix:
+        return await _fetch_batch_single_folder(account, nums, parts)
+
+    return await _fetch_batch_multi_folder(account, nums, parts)
 
 
 async def logout(account: IMAP4_SSL | IMAP4) -> None:

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -1079,14 +1079,14 @@ async def test_process_delivering_uses_since_date(hass):
 
 
 @pytest.mark.asyncio
-async def test_process_delivered_uses_since_date(hass):
+async def test_process_delivered_uses_since_date(hass, tmp_path):
     """_delivered sensors search twice: since_date for tracking dedup, date for count.
 
     The first call uses since_date so delivered tracking numbers can cancel out
     old in-transit emails. The second call uses today's date so the sensor count
     resets at midnight.
     """
-    shipper = GenericShipper(hass, {"image_path": "/tmp/test/"})  # noqa: S108
+    shipper = GenericShipper(hass, {"image_path": str(tmp_path)})
     mock_account = AsyncMock()
 
     with (

--- a/tests/shippers/test_post_de.py
+++ b/tests/shippers/test_post_de.py
@@ -719,3 +719,23 @@ async def test_post_de_copy_nomail_image_relative_path(hass):
 
         await shipper._copy_nomail_image("test_dir", "test.gif", relative_path)
         mock_copy.assert_called_once_with(expected_resolved_path, "test_dir/test.gif")
+
+
+@pytest.mark.asyncio
+async def test_process_post_de_email_non_bytes(hass):
+    """Test _process_post_de_email ignores non-bytes parts."""
+    shipper = PostDEShipper(hass, {})
+    mock_account = AsyncMock()
+    mock_account.fetch.return_value = MagicMock(
+        result="OK", lines=[None, "not-bytes", 123]
+    )
+
+    image_count, images = await shipper._process_post_de_email(
+        account=mock_account,
+        num="1",
+        image_output_path="/test",
+        image_count=0,
+        images=[],
+    )
+    assert image_count == 0
+    assert images == []

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -221,3 +221,17 @@ async def test_email_cache_fetch_variations(hass):
     cache._cache_text["test"] = ("OK", [])
     cache.clear()
     assert len(cache._cache_text) == 0
+
+
+@pytest.mark.asyncio
+async def test_persistent_cache_corrupted_structure(hass):
+    """Test _get_persistent_cache returns None for corrupted data format."""
+    cache = EmailCache(hass=hass)
+    cache._persistent_store = {
+        "bad_len": {"data": ["OK"]},
+        "not_list": {"data": "invalid"},
+        "no_data": {},
+    }
+    assert cache._get_persistent_cache("bad_len") is None
+    assert cache._get_persistent_cache("not_list") is None
+    assert cache._get_persistent_cache("no_data") is None

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -14,8 +14,10 @@ from custom_components.mail_and_packages.utils.email import (
 )
 from custom_components.mail_and_packages.utils.imap import (
     InvalidAuth,
+    _build_body_clause,
     _execute_single_search,
     _parse_esearch_line,
+    _supports_multisearch,
     build_search,
     clean_search_string,
     decode_folder_ref,
@@ -2057,3 +2059,15 @@ async def test_login_oauth_timeout(caplog):
                 oauth_token="token",
             )
         assert "OAuth authentication timed out for user" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_build_body_clause_empty_and_multisearch_no_capability():
+    """Test _build_body_clause with empty/whitespace-only bodies and _supports_multisearch without capability method."""
+    # Empty list or list of whitespace/quotes only
+    assert _build_body_clause(["", '""']) == ""
+    assert _build_body_clause([]) == ""
+
+    # Account without has_capability attribute
+    plain_mock = MagicMock(spec=[])
+    assert _supports_multisearch(plain_mock) is False


### PR DESCRIPTION
## Proposed change

This PR refactors functions across the integration that previously required `# noqa: C901` complexity overrides or `# noqa: S108` temporary file path lint suppressions, reducing cyclomatic complexity to strictly adhere to the project's linter configuration without suppression comments.

Key refactorings:
- **`tests/shippers/test_generic.py`**: Replaced hardcoded `/tmp/test/` with pytest's standard `tmp_path` fixture (`str(tmp_path)`), eliminating `# noqa: S108`.
- **`custom_components/mail_and_packages/coordinator.py`**: Extracted `_check_camera_update` helper method from `_binary_sensor_update`.
- **`custom_components/mail_and_packages/shippers/post_de.py`**: Extracted `_check_and_save_image` and `_extract_post_de_scan` helpers from `_process_post_de_email`.
- **`custom_components/mail_and_packages/utils/cache.py`**: Extracted `_get_persistent_cache`, `_fetch_from_imap`, `_get_memory_cache`, and `_store_memory_cache` from `fetch`.
- **`custom_components/mail_and_packages/utils/imap.py`**:
  - `build_search`: Extracted `_build_address_clause`, `_build_subject_clause`, and `_build_body_clause`.
  - `_execute_single_search`: Extracted `_supports_multisearch`, `_execute_multisearch`, and `_execute_sequential_search`.
  - `email_search`: Extracted `_search_all_batches`, `_email_search_single_folder`, and `_email_search_multi_folder`.
  - `email_fetch_batch`: Extracted `_fetch_batch_single_folder`, `_group_nums_by_folder`, and `_fetch_batch_multi_folder`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
