### PR TITLE
fix(imap): server-aware subject batching size and sequential execution

### DIFF
--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -27,8 +27,36 @@ from custom_components.mail_and_packages.const import DEFAULT_IMAP_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
-IMAP_SUBJECT_BATCH_SIZE = 1
+IMAP_SUBJECT_BATCH_SIZE_DEFAULT = 1
+IMAP_SUBJECT_BATCH_SIZE_EXTENDED = 10
 IMAP_ADDRESS_BATCH_SIZE = 5
+
+
+def _get_subject_batch_size(account: IMAP4_SSL) -> int:
+    """Return subject batch size based on server capability or host."""
+    # Servers with known limited or fragile compound OR query parsers (e.g. Outlook/Exchange, Yahoo/AOL)
+    if hasattr(account, "host") and isinstance(account.host, str):
+        host_lower = account.host.lower()
+        if any(h in host_lower for h in ("outlook", "office365", "yahoo", "aol")):
+            return IMAP_SUBJECT_BATCH_SIZE_DEFAULT
+        # Fast-track known capable servers like Gmail
+        if "gmail" in host_lower or "google" in host_lower:
+            return IMAP_SUBJECT_BATCH_SIZE_EXTENDED
+
+    # Capability check fallback (e.g. Gmail custom extension X-GM-EXT-1)
+    if hasattr(account, "has_capability") and callable(account.has_capability):
+        try:
+            res = account.has_capability("X-GM-EXT-1")
+            if asyncio.iscoroutine(res):
+                res.close()
+                return IMAP_SUBJECT_BATCH_SIZE_DEFAULT
+            if res:
+                return IMAP_SUBJECT_BATCH_SIZE_EXTENDED
+        except Exception:  # noqa: BLE001
+            pass
+
+    return IMAP_SUBJECT_BATCH_SIZE_DEFAULT
+
 
 # Register ESEARCH command if not already present in aioimaplib
 if "ESEARCH" not in aioimaplib.Commands:
@@ -531,62 +559,6 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
     return await _execute_sequential_search(account, folders, search_query)
 
 
-async def _search_all_batches_concurrent(
-    account: IMAP4_SSL,
-    address_batches: list[list[str]],
-    subject_batches: list[list[str] | str],
-    date: str,
-    body_search: str | list[str],
-    header: str,
-    is_yahoo: bool,
-) -> tuple:
-    """Execute single-folder batch searches concurrently using asyncio.gather."""
-    batch_queries = [
-        build_search(
-            addr_batch,
-            date,
-            subj_batch,
-            body_search,
-            header,
-            is_yahoo=is_yahoo,
-        )[1]
-        for addr_batch in address_batches
-        for subj_batch in subject_batches
-    ]
-
-    async def _run_search(query: str):
-        try:
-            res = await account.search(query, charset=None)
-            if res.result == "OK" and res.lines:
-                return parse_search_response(res.lines)
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error searching emails batch: %s", err)
-        return None
-
-    results = await asyncio.gather(
-        *[_run_search(q) for q in batch_queries], return_exceptions=True
-    )
-
-    all_matched_ids: list[bytes] = []
-    batch_success = False
-    for r in results:
-        if isinstance(r, TimeoutError):
-            raise r
-        if isinstance(r, Exception):
-            _LOGGER.error("Error searching emails batch: %r", r)
-        elif r is not None:
-            batch_success = True
-            all_matched_ids.extend(r)
-
-    if not batch_success and not all_matched_ids:
-        return ("BAD", "All search batches failed")
-
-    unique_ids = list(dict.fromkeys(all_matched_ids))
-    return ("OK", [b" ".join(unique_ids)])
-
-
 async def _search_all_batches_sequential(
     account: IMAP4_SSL,
     address_batches: list[list[str]],
@@ -595,8 +567,9 @@ async def _search_all_batches_sequential(
     body_search: str | list[str],
     header: str,
     is_yahoo: bool,
+    use_multi_folder: bool = False,
 ) -> tuple:
-    """Execute multi-folder batch searches sequentially to avoid folder selection race conditions."""
+    """Execute batch searches sequentially to maintain a single in-flight command on the IMAP connection."""
     batch_queries = [
         build_search(
             addr_batch,
@@ -614,9 +587,17 @@ async def _search_all_batches_sequential(
     batch_success = False
     for query in batch_queries:
         try:
-            uids = await _execute_single_search(account, query)
-            batch_success = True
-            all_matched_ids.extend(uids)
+            if use_multi_folder:
+                uids = await _execute_single_search(account, query)
+                batch_success = True
+                all_matched_ids.extend(uids)
+            else:
+                res = await account.search(query, charset=None)
+                if res.result == "OK":
+                    batch_success = True
+                    if res.lines:
+                        parsed = parse_search_response(res.lines)
+                        all_matched_ids.extend(parsed)
         except TimeoutError:
             raise
         except (AioImapException, OSError) as err:
@@ -656,7 +637,7 @@ async def _email_search_single_folder(
         parsed = parse_search_response(res.lines)
         return (res.result, [b" ".join(parsed)])
 
-    return await _search_all_batches_concurrent(
+    return await _search_all_batches_sequential(
         account,
         address_batches,
         subject_batches,
@@ -664,6 +645,7 @@ async def _email_search_single_folder(
         body_search,
         header,
         is_yahoo,
+        use_multi_folder=False,
     )
 
 
@@ -701,6 +683,7 @@ async def _email_search_multi_folder(
         body_search,
         header,
         is_yahoo,
+        use_multi_folder=True,
     )
 
 
@@ -750,13 +733,13 @@ async def email_search(
         else [address]
     )
 
+    subject_batch_size = _get_subject_batch_size(account)
     subject_batches = (
         [
-            subject_search[i : i + IMAP_SUBJECT_BATCH_SIZE]
-            for i in range(0, len(subject_search), IMAP_SUBJECT_BATCH_SIZE)
+            subject_search[i : i + subject_batch_size]
+            for i in range(0, len(subject_search), subject_batch_size)
         ]
-        if isinstance(subject_search, list)
-        and len(subject_search) > IMAP_SUBJECT_BATCH_SIZE
+        if isinstance(subject_search, list) and len(subject_search) > subject_batch_size
         else [subject_search]
     )
 

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -17,6 +17,7 @@ from custom_components.mail_and_packages.utils.imap import (
     InvalidAuth,
     _build_body_clause,
     _execute_single_search,
+    _get_subject_batch_size,
     _parse_esearch_line,
     _supports_multisearch,
     build_search,
@@ -1889,15 +1890,15 @@ async def test_email_search_batch_timeout_error():
 
 @pytest.mark.asyncio
 async def test_email_search_single_folder_batch_exception():
-    """Test email_search single-folder batched subjects logs unexpected Exception and continues."""
+    """Test email_search single-folder batched subjects logs AioImapException/OSError and continues."""
     mock_imap = AsyncMock()
     mock_imap._folders = ["INBOX"]
-    # Return one normal result and one RuntimeError
+    # Return one normal result and one OSError
     mock_imap.search.side_effect = [
         MagicMock(result="OK", lines=[b"101"]),
-        RuntimeError("Unexpected batch error"),
+        OSError("Batch error"),
     ]
-    subjects = [f"Subj {i}" for i in range(11)]
+    subjects = [f"Subj {i}" for i in range(2)]
     res = await email_search(
         mock_imap, ["test@example.com"], "25-Mar-2026", subject=subjects
     )
@@ -2156,3 +2157,64 @@ async def test_build_body_clause_empty_and_multisearch_no_capability():
     # Account without has_capability attribute
     plain_mock = MagicMock(spec=[])
     assert _supports_multisearch(plain_mock) is False
+
+
+def test_get_subject_batch_size():
+    """Test _get_subject_batch_size for various IMAP server hosts and capabilities."""
+    # Outlook / Office365
+    mock_outlook = MagicMock()
+    mock_outlook.host = "outlook.office365.com"
+    assert _get_subject_batch_size(mock_outlook) == 1
+
+    # Yahoo / AOL
+    mock_yahoo = MagicMock()
+    mock_yahoo.host = "imap.mail.yahoo.com"
+    assert _get_subject_batch_size(mock_yahoo) == 1
+
+    # Gmail via host
+    mock_gmail = MagicMock()
+    mock_gmail.host = "imap.gmail.com"
+    assert _get_subject_batch_size(mock_gmail) == 10
+
+    # Gmail via capability X-GM-EXT-1
+    mock_custom_cap = MagicMock(spec=["has_capability"])
+    mock_custom_cap.has_capability = MagicMock(
+        side_effect=lambda cap: cap == "X-GM-EXT-1"
+    )
+    assert _get_subject_batch_size(mock_custom_cap) == 10
+
+    # Capability check exception
+    mock_err_cap = MagicMock(spec=["has_capability"])
+    mock_err_cap.has_capability = MagicMock(side_effect=Exception("Capability error"))
+    assert _get_subject_batch_size(mock_err_cap) == 1
+
+    # Generic server without special host or capabilities
+    mock_generic = MagicMock(spec=[])
+    assert _get_subject_batch_size(mock_generic) == 1
+
+
+@pytest.mark.asyncio
+async def test_email_search_gmail_extended_batching():
+    """Test email_search batches up to 10 subjects on Gmail."""
+    mock_gmail = AsyncMock()
+    mock_gmail.host = "imap.gmail.com"
+    mock_gmail._folders = ["INBOX"]
+
+    res = MagicMock()
+    res.result = "OK"
+    res.lines = [b"101 102"]
+    mock_gmail.search.return_value = res
+
+    # 10 subjects should fit in 1 single batch on Gmail
+    subjects = [f"Subj {i}" for i in range(10)]
+    result = await email_search(
+        mock_gmail, ["test@example.com"], "25-Mar-2026", subject=subjects
+    )
+    assert result[0] == "OK"
+    assert result[1] == [b"101 102"]
+    assert mock_gmail.search.call_count == 1
+    # Check that the query contains all 10 subjects OR'ed
+    query = mock_gmail.search.call_args.args[0]
+    assert 'SUBJECT "Subj 0"' in query
+    assert 'SUBJECT "Subj 9"' in query
+    assert query.count("SUBJECT") == 10


### PR DESCRIPTION
## Proposed change

Addresses the connection abort error (`aioimaplib.Abort('unexpected tagged response')`) reported when using `asyncio.gather` on a single `aioimaplib` connection in #1385, while maintaining fast search times on servers that support compound `OR` queries (such as Gmail):

1. **Sequential IMAP Batch Execution**:
   - `aioimaplib` maintains a single `self.current_command` reference across the socket protocol, making concurrent `search()` calls on a single connection unsafe.
   - All search batches are executed sequentially across the connection to preserve protocol state integrity.

2. **Server-Aware Subject Batching Size**:
   - Added `_get_subject_batch_size(account)`:
     - Servers with known fragile `OR` query parsers or nested query limitations (Outlook / Office 365, Yahoo / AOL) use `IMAP_SUBJECT_BATCH_SIZE_DEFAULT = 1` (single subject per query) to avoid search timeouts and syntax errors.
     - Known capable servers (Gmail / Google or servers with the `X-GM-EXT-1` capability) use `IMAP_SUBJECT_BATCH_SIZE_EXTENDED = 10`, allowing subjects to be batched and searched in a single round-trip.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1385
- This PR is related to issue: #1386
