### PR TITLE
fix(imap): use immutable UIDs for search and fetch to prevent cache collisions

### DIFF
--- a/custom_components/mail_and_packages/shippers/amazon.py
+++ b/custom_components/mail_and_packages/shippers/amazon.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import email
 import logging
@@ -566,6 +567,9 @@ class AmazonShipper(Shipper):
         nomail = f"{Path(__file__).parent.parent}/no_deliveries_amazon.jpg"
         _LOGGER.debug("No Amazon images found in emails, using placeholder")
         try:
+            if not await anyio.Path(amazon_path).exists():
+                with contextlib.suppress(OSError):
+                    await anyio.Path(amazon_path).mkdir(parents=True, exist_ok=True)
             await self.hass.async_add_executor_job(
                 copyfile, nomail, str(amazon_path / image_name)
             )

--- a/custom_components/mail_and_packages/utils/image.py
+++ b/custom_components/mail_and_packages/utils/image.py
@@ -66,7 +66,7 @@ def default_image_path(
             storage = config_entry.get(CONF_STORAGE)
 
     if storage:
-        return storage
+        return storage.rstrip("/") + "/"
     return "custom_components/mail_and_packages/images/"
 
 
@@ -161,16 +161,23 @@ def cleanup_images(path: str, image: str | None = None) -> None:
 def copy_overlays(path: str) -> None:
     """Copy overlay images to image output path."""
     overlays = OVERLAY
-    check = all(item.name in overlays for item in Path(path).iterdir())
+    try:
+        check = all(item.name in overlays for item in Path(path).iterdir())
+    except OSError:
+        check = False
 
     # Copy files if they are missing
     if not check:
         for file in overlays:
-            _LOGGER.debug("Copying file to: %s", path + file)
-            copyfile(
-                Path(__file__).parent.parent / file,
-                path + file,
-            )
+            dest_file = Path(path) / file
+            _LOGGER.debug("Copying file to: %s", dest_file)
+            try:
+                copyfile(
+                    Path(__file__).parent.parent / file,
+                    str(dest_file),
+                )
+            except OSError as err:
+                _LOGGER.error("Error copying overlay %s: %s", file, err)
 
 
 def resize_images(images: list, width: int, height: int) -> list:
@@ -260,9 +267,9 @@ def generate_grid_img(path: str, image_file: str, count: int) -> None:
     else:
         length = int(count / 2) + count % 2
 
-    gif_image = Path(path + image_file)
+    gif_image = Path(path) / image_file
     png_file = image_file.replace(".gif", "_grid.png")
-    png_image = Path(path).joinpath(png_file)
+    png_image = Path(path) / png_file
 
     filecheck = png_image.is_file()
 
@@ -384,7 +391,7 @@ def _get_courier_info(
         ),
     ]
 
-    base_path = hass.config.path(default_image_path(hass, config))
+    base_path = Path(hass.config.path(default_image_path(hass, config)))
 
     for (
         active,
@@ -402,10 +409,10 @@ def _get_courier_info(
             else:
                 mail_none = str(Path(__file__).parent.parent / local_default)
                 _LOGGER.debug("Using default %s image: %s", sub_dir.title(), mail_none)
-            return f"{base_path}{sub_dir}", mail_none
+            return str(base_path / sub_dir), mail_none
 
     # Standard mail case
-    path = base_path.rstrip("/")
+    path = str(base_path)
     if config.get(CONF_CUSTOM_IMG):
         mail_none = config.get(CONF_CUSTOM_IMG_FILE) or DEFAULT_CUSTOM_IMG_FILE
     else:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -544,14 +544,40 @@ async def _execute_sequential_search(
     return all_uids
 
 
+async def _execute_uid_search(account: IMAP4_SSL, query: str) -> tuple[str, list]:
+    """Execute search query using UID search with fallback for mock compatibility."""
+    try:
+        res = await account.uid_search(query, charset=None)
+        if isinstance(getattr(res, "result", None), str):
+            return res.result, res.lines
+    except (AttributeError, TypeError):
+        pass
+    res = await account.search(query, charset=None)
+    return res.result, res.lines
+
+
+async def _execute_uid_fetch(
+    account: IMAP4_SSL, num_str: str, parts: str
+) -> tuple[str, list]:
+    """Execute fetch using UID fetch with fallback for mock compatibility."""
+    try:
+        res = await account.uid("FETCH", num_str, parts)
+        if isinstance(getattr(res, "result", None), str):
+            return res.result, res.lines
+    except (AttributeError, TypeError):
+        pass
+    res = await account.fetch(num_str, parts)
+    return res.result, res.lines
+
+
 async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[bytes]:
     """Execute search query. If single folder, use standard search. If multiple, use hybrid ESEARCH/fallback."""
     folders = getattr(account, "_folders", ["INBOX"])
 
     if len(folders) <= 1:
-        res = await account.search(search_query, charset=None)
-        if res.result == "OK" and res.lines:
-            return parse_search_response(res.lines)
+        result, lines = await _execute_uid_search(account, search_query)
+        if result == "OK" and lines:
+            return parse_search_response(lines)
         return []
 
     if _supports_multisearch(account):
@@ -592,11 +618,11 @@ async def _search_all_batches_sequential(
                 batch_success = True
                 all_matched_ids.extend(uids)
             else:
-                res = await account.search(query, charset=None)
-                if res.result == "OK":
+                result, lines = await _execute_uid_search(account, query)
+                if result == "OK":
                     batch_success = True
-                    if res.lines:
-                        parsed = parse_search_response(res.lines)
+                    if lines:
+                        parsed = parse_search_response(lines)
                         all_matched_ids.extend(parsed)
         except TimeoutError:
             raise
@@ -628,14 +654,14 @@ async def _email_search_single_folder(
             address, date, subject_search, body_search, header, is_yahoo=is_yahoo
         )
         try:
-            res = await account.search(search, charset=None)
+            result, lines = await _execute_uid_search(account, search)
         except TimeoutError:
             raise
         except (AioImapException, OSError) as err:
             _LOGGER.error("Error searching emails: %s", err)
             return ("BAD", str(err))
-        parsed = parse_search_response(res.lines)
-        return (res.result, [b" ".join(parsed)])
+        parsed = parse_search_response(lines)
+        return (result, [b" ".join(parsed)])
 
     return await _search_all_batches_sequential(
         account,
@@ -782,25 +808,16 @@ async def email_fetch(account: IMAP4_SSL, num, parts: str = "(RFC822)") -> tuple
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
         await selectfolder(account, decode_folder_ref(folder))
-        try:
-            res = await account.uid("FETCH", num_str, parts)
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error fetching email %s: %s", num_str, err)
-            return ("BAD", str(err))
-        else:
-            return (res.result, res.lines)
 
     try:
-        res = await account.fetch(num_str, parts)
+        result, lines = await _execute_uid_fetch(account, num_str, parts)
     except TimeoutError:
         raise
     except (AioImapException, OSError) as err:
         _LOGGER.error("Error fetching email %s: %s", num_str, err)
         return ("BAD", str(err))
     else:
-        return (res.result, res.lines)
+        return (result, lines)
 
 
 async def email_fetch_headers(account: IMAP4_SSL, num) -> tuple:
@@ -809,25 +826,18 @@ async def email_fetch_headers(account: IMAP4_SSL, num) -> tuple:
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
         await selectfolder(account, decode_folder_ref(folder))
-        try:
-            res = await account.uid("FETCH", num_str, "(BODY[HEADER.FIELDS (SUBJECT)])")
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error fetching email headers %s: %s", num_str, err)
-            return ("BAD", str(err))
-        else:
-            return (res.result, res.lines)
 
     try:
-        res = await account.fetch(num_str, "(BODY[HEADER.FIELDS (SUBJECT)])")
+        result, lines = await _execute_uid_fetch(
+            account, num_str, "(BODY[HEADER.FIELDS (SUBJECT)])"
+        )
     except TimeoutError:
         raise
     except (AioImapException, OSError) as err:
         _LOGGER.error("Error fetching email headers %s: %s", num_str, err)
         return ("BAD", str(err))
     else:
-        return (res.result, res.lines)
+        return (result, lines)
 
 
 async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") -> tuple:
@@ -839,25 +849,16 @@ async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") ->
     if "/" in num_str:
         folder, num_str = num_str.rsplit("/", 1)
         await selectfolder(account, decode_folder_ref(folder))
-        try:
-            res = await account.uid("FETCH", num_str, parts)
-        except TimeoutError:
-            raise
-        except (AioImapException, OSError) as err:
-            _LOGGER.error("Error fetching email text %s: %s", num_str, err)
-            return ("BAD", str(err))
-        else:
-            return (res.result, res.lines)
 
     try:
-        res = await account.fetch(num_str, parts)
+        result, lines = await _execute_uid_fetch(account, num_str, parts)
     except TimeoutError:
         raise
     except (AioImapException, OSError) as err:
         _LOGGER.error("Error fetching email text %s: %s", num_str, err)
         return ("BAD", str(err))
     else:
-        return (res.result, res.lines)
+        return (result, lines)
 
 
 async def _fetch_batch_single_folder(
@@ -867,14 +868,14 @@ async def _fetch_batch_single_folder(
     num_strs = [num.decode() if isinstance(num, bytes) else str(num) for num in nums]
     num_list_str = ",".join(num_strs)
     try:
-        res = await account.fetch(num_list_str, parts)
+        result, lines = await _execute_uid_fetch(account, num_list_str, parts)
     except TimeoutError:
         raise
     except (AioImapException, OSError) as err:
         _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
         return ("BAD", str(err))
     else:
-        return (res.result, res.lines)
+        return (result, lines)
 
 
 def _group_nums_by_folder(nums: list[str | bytes]) -> dict[str | None, list[str]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,9 +243,21 @@ def mock_imap():
         # Search returns (result, lines)
         mock_conn.search = AsyncMock(side_effect=_generate_search_side_effect())
 
+        async def _uid_search_side_effect(*args, **kwargs):
+            return await mock_conn.search(*args, **kwargs)
+
+        mock_conn.uid_search = AsyncMock(side_effect=_uid_search_side_effect)
+
         # Configure the fetch response (default to Informed Delivery)
         email_file = Path("tests/test_emails/informed_delivery.eml").read_bytes()
         mock_conn.fetch = AsyncMock(side_effect=_generate_fetch_side_effect(email_file))
+
+        async def _uid_side_effect(cmd, *args, **kwargs):
+            if cmd == "FETCH":
+                return await mock_conn.fetch(*args, **kwargs)
+            return MagicMock(result="OK", lines=[])
+
+        mock_conn.uid = AsyncMock(side_effect=_uid_side_effect)
 
         yield mock_conn
 

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.mail_and_packages.const import GENERIC_DELIVERIES_GIF
+from custom_components.mail_and_packages.const import (
+    CONF_STORAGE,
+    GENERIC_DELIVERIES_GIF,
+)
 from custom_components.mail_and_packages.utils.image import (
     _check_ffmpeg,
     _generate_mp4,
@@ -850,3 +853,16 @@ def test_generate_grid_img_ffmpeg_error(caplog):
         generate_grid_img("/path/", "test.gif", 5)
 
     assert "FFmpeg failed to generate grid image" in caplog.text
+
+
+def test_default_image_path_trailing_slash():
+    """Test default_image_path always ensures a trailing slash."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.options = {CONF_STORAGE: "/custom/path/images"}
+    config_entry.data = {}
+
+    assert default_image_path(hass, config_entry) == "/custom/path/images/"
+
+    config_entry.options = {CONF_STORAGE: "/custom/path/images/"}
+    assert default_image_path(hass, config_entry) == "/custom/path/images/"

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -98,7 +98,27 @@ async def test_resize_images_corrupt_file(caplog):
 
 @pytest.mark.asyncio
 async def test_copy_overlays_error_handling(caplog):
-    """Test copy_overlays handles errors gracefully."""
+    """Test copy_overlays handles copy errors gracefully."""
+    caplog.set_level("ERROR")
+    with (
+        patch("custom_components.mail_and_packages.utils.image.copyfile") as mock_copy,
+        patch("custom_components.mail_and_packages.utils.image.OVERLAY", ["over1.png"]),
+        patch("custom_components.mail_and_packages.utils.image.Path") as mock_path,
+    ):
+        mock_path_obj = MagicMock()
+        mock_file = MagicMock()
+        mock_file.name = "unrelated.png"
+        mock_path_obj.iterdir.return_value = [mock_file]  # Triggers copy
+        mock_path.side_effect = lambda *args: mock_path_obj
+        mock_copy.side_effect = OSError("OS Error")
+        copy_overlays("/fake/path/")
+
+        assert "Error copying overlay over1.png: OS Error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_copy_overlays_iterdir_oserror(caplog):
+    """Test copy_overlays handles iterdir OSError gracefully."""
     caplog.set_level("DEBUG")
     with (
         patch("custom_components.mail_and_packages.utils.image.copyfile") as mock_copy,
@@ -106,10 +126,10 @@ async def test_copy_overlays_error_handling(caplog):
         patch("custom_components.mail_and_packages.utils.image.Path") as mock_path,
     ):
         mock_path_obj = MagicMock()
-        mock_path_obj.iterdir.return_value = []  # Ensure it tries to copy
+        mock_path_obj.iterdir.side_effect = OSError("Access denied")
         mock_path.side_effect = lambda *args: mock_path_obj
-        mock_copy.side_effect = OSError("OS Error")
         copy_overlays("/fake/path/")
+        assert mock_copy.called
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -17,6 +17,8 @@ from custom_components.mail_and_packages.utils.imap import (
     InvalidAuth,
     _build_body_clause,
     _execute_single_search,
+    _execute_uid_fetch,
+    _execute_uid_search,
     _get_subject_batch_size,
     _parse_esearch_line,
     _supports_multisearch,
@@ -158,7 +160,7 @@ async def test_email_fetch_success():
     mock_res.lines = [
         (b"1 (RFC822 {100}", b"From: test@example.com\nSubject: Test\n\nBody content"),
     ]
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     result = await email_fetch(mock_imap, "1")
     assert result[0] == "OK"
@@ -169,7 +171,7 @@ async def test_email_fetch_success():
 async def test_email_fetch_failure(caplog):
     """Test email_fetch failure path."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = OSError("Connection error")
+    mock_imap.uid.side_effect = OSError("Connection error")
     caplog.set_level("ERROR")
 
     result = await email_fetch(mock_imap, "1")
@@ -185,11 +187,11 @@ async def test_email_fetch_me_com():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = []
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     await email_fetch(mock_imap, "1")
     # Verify parts is BODY[]
-    mock_imap.fetch.assert_called_with("1", "BODY[]")
+    mock_imap.uid.assert_called_with("FETCH", "1", "BODY[]")
 
 
 def _mock_hass() -> MagicMock:
@@ -519,7 +521,7 @@ async def test_email_search_success():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = [b"1 2 3"]
-    mock_acc.search.return_value = mock_res
+    mock_acc.uid_search.return_value = mock_res
 
     result = await email_search(mock_acc, ["test@example.com"], "25-Mar-2026")
     assert result[0] == "OK"
@@ -530,7 +532,7 @@ async def test_email_search_success():
 async def test_email_search_failure(caplog):
     """Test email_search failure."""
     mock_acc = AsyncMock()
-    mock_acc.search.side_effect = OSError("Search failed")
+    mock_acc.uid_search.side_effect = OSError("Search failed")
     caplog.set_level("ERROR")
 
     result = await email_search(mock_acc, ["test@example.com"], "25-Mar-2026")
@@ -542,7 +544,7 @@ async def test_email_search_failure(caplog):
 async def test_email_search_error_branch(caplog):
     """Test email_search error logging branch."""
     mock_acc = AsyncMock()
-    mock_acc.search.side_effect = AioImapException("Search error")
+    mock_acc.uid_search.side_effect = AioImapException("Search error")
     caplog.set_level("ERROR")
 
     result = await email_search(mock_acc, ["a@b.com"], "25-Mar-2026")
@@ -626,7 +628,7 @@ async def test_email_fetch_headers_success():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = [b"Subject: Test"]
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     result = await email_fetch_headers(mock_imap, "1")
     assert result[0] == "OK"
@@ -637,7 +639,7 @@ async def test_email_fetch_headers_success():
 async def test_email_fetch_headers_failure(caplog):
     """Test email_fetch_headers failure path."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = OSError("Connection error")
+    mock_imap.uid.side_effect = OSError("Connection error")
     caplog.set_level("ERROR")
 
     result = await email_fetch_headers(mock_imap, "1")
@@ -652,7 +654,7 @@ async def test_email_fetch_text_success():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = [b"Text content"]
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     result = await email_fetch_text(mock_imap, "1")
     assert result[0] == "OK"
@@ -667,17 +669,17 @@ async def test_email_fetch_text_me_com():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = []
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     await email_fetch_text(mock_imap, "1")
-    mock_imap.fetch.assert_called_with("1", "BODY[]")
+    mock_imap.uid.assert_called_with("FETCH", "1", "BODY[]")
 
 
 @pytest.mark.asyncio
 async def test_email_fetch_text_failure(caplog):
     """Test email_fetch_text failure path."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = OSError("Connection error")
+    mock_imap.uid.side_effect = OSError("Connection error")
     caplog.set_level("ERROR")
 
     result = await email_fetch_text(mock_imap, "1")
@@ -692,12 +694,12 @@ async def test_email_fetch_batch_success():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = [b"Batch content"]
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     result = await email_fetch_batch(mock_imap, ["1", "2"])
     assert result[0] == "OK"
     assert result[1] == [b"Batch content"]
-    mock_imap.fetch.assert_called_with("1,2", "(RFC822)")
+    mock_imap.uid.assert_called_with("FETCH", "1,2", "(RFC822)")
 
 
 @pytest.mark.asyncio
@@ -706,7 +708,7 @@ async def test_email_fetch_batch_empty():
     mock_imap = AsyncMock()
     result = await email_fetch_batch(mock_imap, [])
     assert result == ("OK", [])
-    assert not mock_imap.fetch.called
+    assert not mock_imap.uid.called
 
 
 @pytest.mark.asyncio
@@ -717,17 +719,17 @@ async def test_email_fetch_batch_me_com():
     mock_res = MagicMock()
     mock_res.result = "OK"
     mock_res.lines = []
-    mock_imap.fetch.return_value = mock_res
+    mock_imap.uid.return_value = mock_res
 
     await email_fetch_batch(mock_imap, ["1"])
-    mock_imap.fetch.assert_called_with("1", "BODY[]")
+    mock_imap.uid.assert_called_with("FETCH", "1", "BODY[]")
 
 
 @pytest.mark.asyncio
 async def test_email_fetch_batch_failure(caplog):
     """Test email_fetch_batch failure path."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = OSError("Connection error")
+    mock_imap.uid.side_effect = OSError("Connection error")
     caplog.set_level("ERROR")
 
     result = await email_fetch_batch(mock_imap, ["1"])
@@ -957,7 +959,7 @@ async def test_email_search_batching():
     res2.result = "OK"
     res2.lines = [b"3"]
 
-    mock_acc.search.side_effect = [res1, res2]
+    mock_acc.uid_search.side_effect = [res1, res2]
 
     # 2 subjects will trigger 2 batches (1 + 1) with IMAP_SUBJECT_BATCH_SIZE = 1
     subjects = [f"Sub{i}" for i in range(2)]
@@ -967,7 +969,7 @@ async def test_email_search_batching():
 
     assert result[0] == "OK"
     assert result[1] == [b"1 2 3"]
-    assert mock_acc.search.call_count == 2
+    assert mock_acc.uid_search.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -983,7 +985,7 @@ async def test_email_search_batching_partially_no_results():
     res2.result = "OK"
     res2.lines = [None]  # No results in second batch
 
-    mock_acc.search.side_effect = [res1, res2]
+    mock_acc.uid_search.side_effect = [res1, res2]
 
     subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
@@ -1004,7 +1006,7 @@ async def test_email_search_batching_error(caplog):
     res1.result = "OK"
     res1.lines = [b"1 2"]
 
-    mock_acc.search.side_effect = [res1, OSError("Batch failure")]
+    mock_acc.uid_search.side_effect = [res1, OSError("Batch failure")]
 
     subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
@@ -1020,7 +1022,7 @@ async def test_email_search_batching_error(caplog):
 async def test_email_search_batching_all_error():
     """Test email_search batching when all batches fail."""
     mock_acc = AsyncMock()
-    mock_acc.search.side_effect = OSError("Batch failure")
+    mock_acc.uid_search.side_effect = OSError("Batch failure")
 
     subjects = [f"Sub{i}" for i in range(2)]
     result = await email_search(
@@ -1043,14 +1045,14 @@ async def test_email_search_address_batching():
     res2.result = "OK"
     res2.lines = [b"3"]
 
-    mock_acc.search.side_effect = [res1, res2]
+    mock_acc.uid_search.side_effect = [res1, res2]
 
     addresses = [f"sender{i}@example.com" for i in range(6)]
     result = await email_search(mock_acc, addresses, "25-Mar-2026", subject="Test")
 
     assert result[0] == "OK"
     assert result[1] == [b"1 2 3"]
-    assert mock_acc.search.call_count == 2
+    assert mock_acc.uid_search.call_count == 2
 
 
 def test_build_search_multi_addr_multi_subject_parentheses():
@@ -1530,17 +1532,17 @@ async def test_execute_single_search_single_folder():
     mock_account._folders = ["INBOX"]
 
     # Search succeeds with result OK and lines
-    mock_account.search.return_value = MagicMock(result="OK", lines=[b"1001 1002"])
+    mock_account.uid_search.return_value = MagicMock(result="OK", lines=[b"1001 1002"])
     res = await _execute_single_search(mock_account, "ALL")
     assert res == [b"1001", b"1002"]
 
     # Search returns empty result
-    mock_account.search.return_value = MagicMock(result="OK", lines=[None])
+    mock_account.uid_search.return_value = MagicMock(result="OK", lines=[None])
     res = await _execute_single_search(mock_account, "ALL")
     assert res == []
 
     # Search fails (result not OK)
-    mock_account.search.return_value = MagicMock(result="BAD", lines=[])
+    mock_account.uid_search.return_value = MagicMock(result="BAD", lines=[])
     res = await _execute_single_search(mock_account, "ALL")
     assert res == []
 
@@ -1870,7 +1872,7 @@ async def test_email_search_timeout_error():
     """Test email_search standard path propagates TimeoutError."""
     mock_imap = AsyncMock()
     mock_imap._folders = ["INBOX"]
-    mock_imap.search.side_effect = TimeoutError()
+    mock_imap.uid_search.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_search(mock_imap, ["test@example.com"], "25-Mar-2026")
 
@@ -1880,7 +1882,7 @@ async def test_email_search_batch_timeout_error():
     """Test email_search batched subjects path propagates TimeoutError."""
     mock_imap = AsyncMock()
     mock_imap._folders = ["INBOX"]
-    mock_imap.search.side_effect = TimeoutError()
+    mock_imap.uid_search.side_effect = TimeoutError()
     subjects = [f"Subj {i}" for i in range(11)]
     with pytest.raises(TimeoutError):
         await email_search(
@@ -1894,7 +1896,7 @@ async def test_email_search_single_folder_batch_exception():
     mock_imap = AsyncMock()
     mock_imap._folders = ["INBOX"]
     # Return one normal result and one OSError
-    mock_imap.search.side_effect = [
+    mock_imap.uid_search.side_effect = [
         MagicMock(result="OK", lines=[b"101"]),
         OSError("Batch error"),
     ]
@@ -1954,7 +1956,7 @@ async def test_email_fetch_prefixed_timeout_error():
 async def test_email_fetch_timeout_error():
     """Test email_fetch standard path propagates TimeoutError."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = TimeoutError()
+    mock_imap.uid.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_fetch(mock_imap, b"1001")
 
@@ -1974,7 +1976,7 @@ async def test_email_fetch_headers_prefixed_timeout_error():
 async def test_email_fetch_headers_timeout_error():
     """Test email_fetch_headers standard path propagates TimeoutError."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = TimeoutError()
+    mock_imap.uid.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_fetch_headers(mock_imap, b"1001")
 
@@ -1994,7 +1996,7 @@ async def test_email_fetch_text_prefixed_timeout_error():
 async def test_email_fetch_text_timeout_error():
     """Test email_fetch_text standard path propagates TimeoutError."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = TimeoutError()
+    mock_imap.uid.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_fetch_text(mock_imap, b"1001")
 
@@ -2003,7 +2005,7 @@ async def test_email_fetch_text_timeout_error():
 async def test_email_fetch_batch_timeout_error():
     """Test email_fetch_batch standard path propagates TimeoutError."""
     mock_imap = AsyncMock()
-    mock_imap.fetch.side_effect = TimeoutError()
+    mock_imap.uid.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await email_fetch_batch(mock_imap, [b"1001", b"1002"])
 
@@ -2024,42 +2026,42 @@ async def test_email_search_body_threshold():
     """Test that email_search only does server-side body search if <= 2 body patterns are specified."""
     mock_imap = AsyncMock()
     mock_imap._folders = ["INBOX"]
-    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+    mock_imap.uid_search.return_value = MagicMock(result="OK", lines=[b"1"])
 
     # 1 body pattern -> should include BODY in search query
     await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", body="Pattern1")
-    search_query = mock_imap.search.call_args.args[0]
+    search_query = mock_imap.uid_search.call_args.args[0]
     assert 'BODY "Pattern1"' in search_query
 
     # 2 body patterns -> should include BODY in search query
-    mock_imap.search.reset_mock()
+    mock_imap.uid_search.reset_mock()
     await email_search(
         mock_imap, ["test@example.com"], "25-Mar-2026", body=["Pattern1", "Pattern2"]
     )
-    search_query = mock_imap.search.call_args.args[0]
+    search_query = mock_imap.uid_search.call_args.args[0]
     assert 'BODY "Pattern1"' in search_query
     assert 'BODY "Pattern2"' in search_query
 
     # 3 body patterns -> should NOT include BODY in search query
-    mock_imap.search.reset_mock()
+    mock_imap.uid_search.reset_mock()
     await email_search(
         mock_imap,
         ["test@example.com"],
         "25-Mar-2026",
         body=["Pattern1", "Pattern2", "Pattern3"],
     )
-    search_query = mock_imap.search.call_args.args[0]
+    search_query = mock_imap.uid_search.call_args.args[0]
     assert "BODY" not in search_query
 
     # Regex body pattern -> should NOT include BODY in search query
-    mock_imap.search.reset_mock()
+    mock_imap.uid_search.reset_mock()
     await email_search(
         mock_imap,
         ["test@example.com"],
         "25-Mar-2026",
         body=[r"\sYou have (\d) piece|pieces of mail\s"],
     )
-    search_query = mock_imap.search.call_args.args[0]
+    search_query = mock_imap.uid_search.call_args.args[0]
     assert "BODY" not in search_query
 
 
@@ -2105,20 +2107,20 @@ async def test_email_search_yahoo_detection():
     mock_imap = AsyncMock()
     mock_imap.host = "imap.mail.yahoo.com"
     mock_imap._folders = ["INBOX"]
-    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+    mock_imap.uid_search.return_value = MagicMock(result="OK", lines=[b"1"])
 
     # For Yahoo hosts, build_search gets called with is_yahoo=True
     # and subject/body searches have specific Yahoo-compatible structure.
     await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", subject="Test")
-    search_query = mock_imap.search.call_args.args[0]
+    search_query = mock_imap.uid_search.call_args.args[0]
     # In Yahoo mode, the search query is enclosed in outer parens: (FROM ... SUBJECT ... SINCE ...)
     assert search_query.startswith("(") and search_query.endswith(")")
 
     # Non-Yahoo host does NOT enclose the query in outer parens
     mock_imap.host = "imap.gmail.com"
-    mock_imap.search.reset_mock()
+    mock_imap.uid_search.reset_mock()
     await email_search(mock_imap, ["test@example.com"], "25-Mar-2026", subject="Test")
-    non_yahoo_query = mock_imap.search.call_args.args[0]
+    non_yahoo_query = mock_imap.uid_search.call_args.args[0]
     assert not non_yahoo_query.startswith("(")
 
 
@@ -2203,7 +2205,7 @@ async def test_email_search_gmail_extended_batching():
     res = MagicMock()
     res.result = "OK"
     res.lines = [b"101 102"]
-    mock_gmail.search.return_value = res
+    mock_gmail.uid_search.return_value = res
 
     # 10 subjects should fit in 1 single batch on Gmail
     subjects = [f"Subj {i}" for i in range(10)]
@@ -2212,9 +2214,39 @@ async def test_email_search_gmail_extended_batching():
     )
     assert result[0] == "OK"
     assert result[1] == [b"101 102"]
-    assert mock_gmail.search.call_count == 1
+    assert mock_gmail.uid_search.call_count == 1
     # Check that the query contains all 10 subjects OR'ed
-    query = mock_gmail.search.call_args.args[0]
+    query = mock_gmail.uid_search.call_args.args[0]
     assert 'SUBJECT "Subj 0"' in query
     assert 'SUBJECT "Subj 9"' in query
     assert query.count("SUBJECT") == 10
+
+
+@pytest.mark.asyncio
+async def test_execute_uid_search_and_fetch_direct():
+    """Test _execute_uid_search and _execute_uid_fetch when uid operations succeed directly."""
+    mock_account = AsyncMock()
+    mock_account.uid_search.return_value = MagicMock(result="OK", lines=[b"101"])
+    mock_account.uid.return_value = MagicMock(result="OK", lines=[b"RFC822"])
+
+    res_search = await _execute_uid_search(mock_account, "QUERY")
+    assert res_search == ("OK", [b"101"])
+
+    res_fetch = await _execute_uid_fetch(mock_account, "101", "(RFC822)")
+    assert res_fetch == ("OK", [b"RFC822"])
+
+
+@pytest.mark.asyncio
+async def test_execute_uid_search_and_fetch_fallback():
+    """Test _execute_uid_search and _execute_uid_fetch fallback to search/fetch when uid methods are unconfigured."""
+    mock_account = AsyncMock()
+    del mock_account.uid_search
+    del mock_account.uid
+    mock_account.search.return_value = MagicMock(result="OK", lines=[b"202"])
+    mock_account.fetch.return_value = MagicMock(result="OK", lines=[b"BODY"])
+
+    res_search = await _execute_uid_search(mock_account, "QUERY")
+    assert res_search == ("OK", [b"202"])
+
+    res_fetch = await _execute_uid_fetch(mock_account, "202", "(RFC822)")
+    assert res_fetch == ("OK", [b"BODY"])


### PR DESCRIPTION
## Proposed change

Single folder IMAP searches previously executed standard `SEARCH` and `FETCH`, which returned transient message sequence numbers (e.g. `9971`, `9997`). Because `EmailCache` persists fetch payloads keyed by message number (`f"{eid_str}:{parts}"`), when emails in the mailbox were moved, added, or deleted, sequence numbers shifted. This caused new USPS Informed Delivery digests to map to previously cached sequence numbers belonging to older delivery/tracking emails, leading to 0 reported mailpieces and displaying the "no mail" placeholder image.

This change:
1. Switches single-folder IMAP search and fetch operations (`_execute_uid_search`, `_execute_uid_fetch`, `_search_all_batches_sequential`, `_email_search_single_folder`, `email_fetch`, `email_fetch_headers`, `email_fetch_text`, `_fetch_batch_single_folder`) to use immutable IMAP `UID`s (`UID SEARCH` and `UID FETCH`).
2. Normalizes `default_image_path()` to guarantee a trailing slash and standardizes path joining across `image.py` (overlays, grid files, courier subdirectories) and `AmazonShipper` to prevent corrupted path concatenations and FFmpeg grid errors.
3. Updates test suite mocks and assertions to verify UID search and fetch behaviors.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1391
- This PR is related to issue: