### PR TITLE
fix(amazon): sanitize stale entry data and improve amazon domain selector

### DIFF
--- a/custom_components/mail_and_packages/__init__.py
+++ b/custom_components/mail_and_packages/__init__.py
@@ -5,10 +5,12 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_RESOURCES,
+    CONF_TOKEN,
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
@@ -119,8 +121,8 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 OAUTH_TOKEN_KEYS = {
-    "token",
-    "access_token",
+    CONF_TOKEN,
+    CONF_ACCESS_TOKEN,
     "refresh_token",
     "expires_at",
     "expires_in",
@@ -252,24 +254,22 @@ async def async_migrate_entry(hass, config_entry):
     _migrate_legacy_versions(updated_config, version, config_entry)
     _apply_default_config(updated_config)
 
-    # Version 20 migration: split non-IMAP options out of data
-    if version < 20:
-        imap_keys = {
-            CONF_HOST,
-            CONF_PORT,
-            CONF_USERNAME,
-            CONF_PASSWORD,
-            CONF_IMAP_SECURITY,
-            CONF_VERIFY_SSL,
-            CONF_AUTH_TYPE,
-            "token",
-            "access_token",
-            "refresh_token",
-            "auth_implementation",
-        }
-        for key in list(updated_config.keys()):
-            if key not in imap_keys:
-                updated_options[key] = updated_config.pop(key)
+    # Ensure non-IMAP options are removed from data and moved to options
+    imap_keys = {
+        CONF_HOST,
+        CONF_PORT,
+        CONF_USERNAME,
+        CONF_PASSWORD,
+        CONF_IMAP_SECURITY,
+        CONF_VERIFY_SSL,
+        CONF_AUTH_TYPE,
+        *OAUTH_TOKEN_KEYS,
+    }
+    for key in list(updated_config.keys()):
+        if key not in imap_keys:
+            val = updated_config.pop(key)
+            if key not in updated_options:
+                updated_options[key] = val
 
     if updated_config != config_entry.data or updated_options != config_entry.options:
         hass.config_entries.async_update_entry(

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, selector
 
 from .const import (
+    AMAZON_DOMAINS,
     AUTH_TYPE_OAUTH_GOOGLE,
     AUTH_TYPE_OAUTH_MICROSOFT,
     AUTH_TYPE_PASSWORD,
@@ -766,8 +767,15 @@ def _get_schema_step_amazon(
     schema_dict: dict = {
         vol.Required(
             CONF_AMAZON_DOMAIN,
-            default=_get_default(CONF_AMAZON_DOMAIN),
-        ): cv.string,
+            default=_get_default(CONF_AMAZON_DOMAIN, DEFAULT_AMAZON_DOMAIN),
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=AMAZON_DOMAINS,
+                custom_value=True,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_AMAZON_DOMAIN,
+            )
+        ),
     }
 
     if not forwarding_header or forwarding_header == "(none)":

--- a/custom_components/mail_and_packages/strings.json
+++ b/custom_components/mail_and_packages/strings.json
@@ -263,6 +263,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/ca.json
+++ b/custom_components/mail_and_packages/translations/ca.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/cs.json
+++ b/custom_components/mail_and_packages/translations/cs.json
@@ -281,6 +281,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/de.json
+++ b/custom_components/mail_and_packages/translations/de.json
@@ -205,6 +205,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/en.json
+++ b/custom_components/mail_and_packages/translations/en.json
@@ -284,6 +284,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/es.json
+++ b/custom_components/mail_and_packages/translations/es.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/es_419.json
+++ b/custom_components/mail_and_packages/translations/es_419.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/fi.json
+++ b/custom_components/mail_and_packages/translations/fi.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/fr.json
+++ b/custom_components/mail_and_packages/translations/fr.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/hu.json
+++ b/custom_components/mail_and_packages/translations/hu.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/it.json
+++ b/custom_components/mail_and_packages/translations/it.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/ko.json
+++ b/custom_components/mail_and_packages/translations/ko.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/nl.json
+++ b/custom_components/mail_and_packages/translations/nl.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/no.json
+++ b/custom_components/mail_and_packages/translations/no.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/pl.json
+++ b/custom_components/mail_and_packages/translations/pl.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/pt.json
+++ b/custom_components/mail_and_packages/translations/pt.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/pt_BR.json
+++ b/custom_components/mail_and_packages/translations/pt_BR.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/ru.json
+++ b/custom_components/mail_and_packages/translations/ru.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/sk.json
+++ b/custom_components/mail_and_packages/translations/sk.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/sl.json
+++ b/custom_components/mail_and_packages/translations/sl.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/sv.json
+++ b/custom_components/mail_and_packages/translations/sv.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/custom_components/mail_and_packages/translations/zh_Hant_HK.json
+++ b/custom_components/mail_and_packages/translations/zh_Hant_HK.json
@@ -201,6 +201,23 @@
         "oauth2_microsoft": "OAuth2 - Microsoft (Outlook/Exchange)",
         "oauth2_google": "OAuth2 - Google (Gmail)"
       }
+    },
+    "amazon_domain": {
+      "options": {
+        "amazon_com": "United States (amazon.com)",
+        "amazon_ca": "Canada (amazon.ca)",
+        "amazon_co_uk": "United Kingdom (amazon.co.uk)",
+        "amazon_in": "India (amazon.in)",
+        "amazon_de": "Germany (amazon.de)",
+        "amazon_it": "Italy (amazon.it)",
+        "amazon_com_au": "Australia (amazon.com.au)",
+        "amazon_pl": "Poland (amazon.pl)",
+        "amazon_es": "Spain (amazon.es)",
+        "amazon_fr": "France (amazon.fr)",
+        "amazon_ae": "United Arab Emirates (amazon.ae)",
+        "amazon_nl": "Netherlands (amazon.nl)",
+        "amazon_se": "Sweden (amazon.se)"
+      }
     }
   },
   "issues": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -971,6 +971,60 @@ async def test_migrate_version_20():
 
 
 @pytest.mark.asyncio
+async def test_migrate_stale_data_keys_cleaned():
+    """Test migration cleans non-IMAP keys from data even if version is 20."""
+    mock_entry = MagicMock()
+    mock_entry.version = 20
+    mock_entry.data = {
+        CONF_HOST: "imap.test.email",
+        CONF_PORT: 993,
+        CONF_USERNAME: "test@test.email",
+        CONF_PASSWORD: "password",
+        CONF_IMAP_SECURITY: "SSL",
+        CONF_VERIFY_SSL: True,
+        CONF_AUTH_TYPE: "password",
+        CONF_AMAZON_DOMAIN: "amazon.de",
+    }
+    mock_entry.options = {
+        CONF_AMAZON_DOMAIN: "amazon.com",
+    }
+    mock_hass = MagicMock()
+
+    result = await async_migrate_entry(mock_hass, mock_entry)
+    assert result is True
+    _, kwargs = mock_hass.config_entries.async_update_entry.call_args
+    # Non-IMAP keys are purged from data
+    assert CONF_AMAZON_DOMAIN not in kwargs["data"]
+    # Existing options take precedence when present in options
+    assert kwargs["options"][CONF_AMAZON_DOMAIN] == "amazon.com"
+
+
+@pytest.mark.asyncio
+async def test_migrate_moves_missing_options_from_data():
+    """Test migration moves non-IMAP keys from data to options if not present in options."""
+    mock_entry = MagicMock()
+    mock_entry.version = 20
+    mock_entry.data = {
+        CONF_HOST: "imap.test.email",
+        CONF_PORT: 993,
+        CONF_USERNAME: "test@test.email",
+        CONF_PASSWORD: "password",
+        CONF_IMAP_SECURITY: "SSL",
+        CONF_VERIFY_SSL: True,
+        CONF_AUTH_TYPE: "password",
+        CONF_AMAZON_DOMAIN: "amazon.de",
+    }
+    mock_entry.options = {}
+    mock_hass = MagicMock()
+
+    result = await async_migrate_entry(mock_hass, mock_entry)
+    assert result is True
+    _, kwargs = mock_hass.config_entries.async_update_entry.call_args
+    assert CONF_AMAZON_DOMAIN not in kwargs["data"]
+    assert kwargs["options"][CONF_AMAZON_DOMAIN] == "amazon.de"
+
+
+@pytest.mark.asyncio
 async def test_capost_mail_processing(hass, mock_imap_capost_mail, integration_capost):
     """Test processing of Canada Post mail emails."""
     entry = integration_capost


### PR DESCRIPTION
## Proposed change

- During entry migration, sanitize `config_entry.data` by purging non-IMAP options and moving missing options into `config_entry.options`. This fixes an issue where lingering or duplicate data keys in `data` caused stale options (such as `amazon_domain = "amazon.com"`) to silently take precedence and break email searches for other regions like `amazon.de`.
- Refactor `CONF_AMAZON_DOMAIN` in config flow and options flow to use a dropdown selector (`SelectSelector`) with localized friendly labels (e.g. `Germany (amazon.de)`, `United States (amazon.com)`) with `custom_value=True` for manual entries.
- Add selector translations for `amazon_domain` across all supported translation files.
- Import and use `CONF_TOKEN` and `CONF_ACCESS_TOKEN` from `homeassistant.const` in `__init__.py`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1393
- This PR is related to issue:
