### PR TITLE
fix(shipper): decode subject before searching for tracking numbers

### DIFF
--- a/custom_components/mail_and_packages/utils/shipper.py
+++ b/custom_components/mail_and_packages/utils/shipper.py
@@ -6,6 +6,7 @@ import base64
 import email
 import logging
 import re
+from email.header import decode_header, make_header
 from pathlib import Path
 from typing import Any
 
@@ -70,7 +71,7 @@ def _find_tracking_in_subject(
     """Find tracking number in email subject."""
     email_subject = msg["subject"]
     if email_subject:
-        email_subject = str(email_subject)
+        email_subject = str(make_header(decode_header(str(email_subject))))
         if (found := pattern.findall(email_subject)) and len(found) > 0:
             _LOGGER.debug("Found tracking number in email subject: %s", found[0])
             return found[0]

--- a/tests/utils/test_shipper.py
+++ b/tests/utils/test_shipper.py
@@ -36,6 +36,24 @@ async def test_get_tracking_subject():
 
 
 @pytest.mark.asyncio
+async def test_get_tracking_subject_mime_encoded():
+    """Test get_tracking decodes a MIME-encoded subject before matching."""
+    mock_acc = AsyncMock()
+    raw = (
+        b"Subject: =?UTF-8?q?USPS=C2=AE_Item_Delivered,_Front_Door/Porch_"
+        b"9200000000000000001?=\n =?UTF-8?q?0000042?=\n\nBody"
+    )
+
+    with patch(
+        "custom_components.mail_and_packages.utils.shipper.email_fetch",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        mock_fetch.return_value = ("OK", [raw])
+        result = await get_tracking("1", mock_acc, r"9[2345]\d{15,26}")
+        assert result == ["92000000000000000010000042"]
+
+
+@pytest.mark.asyncio
 async def test_get_tracking_body_ups():
     """Test get_tracking finds UPS number in body (simplified logic)."""
     mock_acc = AsyncMock()


### PR DESCRIPTION
My USPS delivered sensor reported a truncated 19 digit tracking number.

The subject wasn't being decoded before the regex ran over it. Example:

```
Subject: =?UTF-8?q?USPS=C2=AE_Item_Delivered,_Front_Door/Porch_9200000000000000001?=
 =?UTF-8?q?0000042?=
```

That returned 9200000000000000001.

Decoding it first in `_find_tracking_in_subject` (utils/shipper.py):

```python
email_subject = str(make_header(decode_header(str(email_subject))))
```

returns the full 92000000000000000010000042.

Most subjects come through fine either way, which is presumably why this
hasn't turned up before.

Added a test — fails without the change, passes with it. tests/utils and
tests/shippers are green.

Note: used Claude Code to find and fix, but verified and tested by me.
