### PR TITLE
fix(royal_mail): add subject pattern for delivery confirmation emails

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -609,7 +609,10 @@ SENSOR_DATA = {
     # Royal Mail
     "royal_delivered": {
         "email": ["no-reply@royalmail.com"],
-        "subject": ["has been delivered"],
+        "subject": [
+            "has been delivered",
+            "You have received your Royal Mail",
+        ],
     },
     "royal_delivering": {
         "email": ["no-reply@royalmail.com"],

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -500,19 +500,25 @@ class GenericShipper(Shipper):
         if not header_val:
             return None
 
-        decoded = decode_header(header_val)[0]
-        subject_bytes, encoding = decoded
-        if encoding:
-            try:
-                if isinstance(subject_bytes, bytes):
-                    return subject_bytes.decode(encoding, "ignore").strip()
-                return str(subject_bytes).strip()
-            except (LookupError, UnicodeError):
-                pass
+        decoded_parts = []
+        for subject_bytes, encoding in decode_header(header_val):
+            if encoding:
+                try:
+                    if isinstance(subject_bytes, bytes):
+                        decoded_parts.append(subject_bytes.decode(encoding, "ignore"))
+                        continue
+                    decoded_parts.append(str(subject_bytes))
+                    continue
+                except (LookupError, UnicodeError):
+                    pass
 
-        if isinstance(subject_bytes, bytes):
-            return subject_bytes.decode("utf-8", "ignore").strip()
-        return str(subject_bytes).strip()
+            if isinstance(subject_bytes, bytes):
+                decoded_parts.append(subject_bytes.decode("utf-8", "ignore"))
+            else:
+                decoded_parts.append(str(subject_bytes))
+
+        full_subject = "".join(decoded_parts)
+        return " ".join(full_subject.split())
 
     async def _verify_matched_subjects(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -990,6 +990,34 @@ def mock_imap_royal_out_for_delivery(mock_imap):
 
 
 @pytest.fixture
+def mock_imap_royal_delivered(mock_imap):
+    """Mock IMAP search with Royal Mail delivered email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/royal_mail_uk_delivered.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_royal_delivered_alternate(mock_imap):
+    """Mock IMAP search with Royal Mail delivered alternate subject email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/royal_mail_uk_delivered.eml").read_text(
+        encoding="utf-8",
+    )
+    email_file = email_file.replace(
+        "Subject: Your Royal Mail parcel from John Lewis & Partners has been\n delivered",
+        "Subject: You have received your Royal Mail parcel from John Lewis & Partners",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
 def mock_copyoverlays():
     """Fixture to mock copy_overlays."""
     with patch(

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -2002,3 +2002,70 @@ def test_danish_carrier_patterns():
     assert any(s in gls_deliv_subj for s in SENSOR_DATA["gls_delivering"]["subject"])
     assert gls_del_email in SENSOR_DATA["gls_delivered"]["email"]
     assert any(s in gls_del_subj for s in SENSOR_DATA["gls_delivered"]["subject"])
+
+
+@pytest.mark.asyncio
+async def test_royal_mail_out_for_delivery_class(
+    hass, mock_imap_royal_out_for_delivery
+):
+    """Test Royal Mail out for delivery parsing via GenericShipper."""
+    shipper = GenericShipper(
+        hass,
+        {
+            "image_path": "test/path/royal_mail/",
+            "image_name": "testfilename.jpg",
+        },
+    )
+
+    with patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"):
+        result = await shipper.process(
+            mock_imap_royal_out_for_delivery,
+            "today",
+            "royal_delivering",
+        )
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["MA038501234GB"]
+
+
+@pytest.mark.asyncio
+async def test_royal_mail_delivered_class(hass, mock_imap_royal_delivered):
+    """Test Royal Mail delivered parsing via GenericShipper."""
+    shipper = GenericShipper(
+        hass,
+        {
+            "image_path": "test/path/royal_mail/",
+            "image_name": "testfilename.jpg",
+        },
+    )
+
+    with patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"):
+        result = await shipper.process(
+            mock_imap_royal_delivered,
+            "today",
+            "royal_delivered",
+        )
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["MA038501234GB"]
+
+
+@pytest.mark.asyncio
+async def test_royal_mail_delivered_alternate_subject_class(
+    hass, mock_imap_royal_delivered_alternate
+):
+    """Test Royal Mail delivered parsing with alternate subject format."""
+    shipper = GenericShipper(
+        hass,
+        {
+            "image_path": "test/path/royal_mail/",
+            "image_name": "testfilename.jpg",
+        },
+    )
+
+    with patch("custom_components.mail_and_packages.shippers.generic.Path.mkdir"):
+        result = await shipper.process(
+            mock_imap_royal_delivered_alternate,
+            "today",
+            "royal_delivered",
+        )
+        assert result[ATTR_COUNT] == 1
+        assert result[ATTR_TRACKING] == ["MA038501234GB"]


### PR DESCRIPTION
## Proposed change

- Add `"You have received your Royal Mail"` to `SHIPPERS["royal_delivered"]["subject"]` in `const.py` to match Royal Mail delivery confirmation emails formatted as `"You have received your Royal Mail parcel from [Retailer Name]"`.
- Update `GenericShipper._decode_subject` in `generic.py` to process all chunks returned by `decode_header` and normalize folded whitespace (`\r`, `\n`, `\t`, multiple spaces), ensuring multi-line folded subject headers are accurately matched during subject verification.
- Add test fixtures and unit tests in `tests/conftest.py` and `tests/shippers/test_generic.py` for Royal Mail delivered and out-for-delivery scenarios.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1396
- This PR is related to issue: