### PR TITLE
fix(shippers): standardize packages sensors as rollups and remove shipped subjects

### DIFF
--- a/.agents/skills/shipper_integration/SKILL.md
+++ b/.agents/skills/shipper_integration/SKILL.md
@@ -18,7 +18,12 @@ This skill defines the requirements for adding or updating carrier-specific ship
 * All shipper names, attributes, sensor names, and defaults must be registered in the central constants file: [const.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/custom_components/mail_and_packages/const.py).
 * Do not hardcode shipper-specific identifiers directly in the coordinator or generic files.
 
-### 3. Testing New Shippers
+### 3. Sensor Taxonomy & Search Criteria
+* **`*_delivering`**: Only search for active out-for-delivery or scheduled-for-delivery-today notifications (e.g., "Out for delivery", "Paket kommt heute"). Do NOT track general "shipped", "picked up", "received at facility", or intermediate in-transit emails.
+* **`*_delivered`**: Search for delivered notifications (e.g., "Item Delivered", "wurde zugestellt").
+* **`*_packages`**: Must ALWAYS be configured as an empty dictionary (`{}`) in `SENSOR_DATA`. All `*_packages` sensors are computed rollups representing active package volume (`delivering + delivered`) and must never perform independent IMAP searches.
+
+### 4. Testing New Shippers
 * Create a corresponding test file under `tests/shippers/` (e.g. `test_new_shipper.py`).
 * Use the shared mock fixtures and mock IMAP client overrides defined in [conftest.py](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/tests/conftest.py).
 * Verify that email content parsing, sensor values, and edge cases (such as subject mismatches or empty bodies) are fully covered.

--- a/.agents/skills/shipper_integration/SKILL.md
+++ b/.agents/skills/shipper_integration/SKILL.md
@@ -24,6 +24,7 @@ This skill defines the requirements for adding or updating carrier-specific ship
 * **`*_packages`**: Must ALWAYS be configured as an empty dictionary (`{}`) in `SENSOR_DATA`.
   - *Why it exists in `SENSOR_DATA`*: The key is required for entity registration in `sensor.py`, options flow sensor selection, and sensor type descriptions.
   - *Why it must remain `{}`*: An empty config signals to the shipper and coordinator processing engines that the sensor does not perform its own IMAP searches; instead, its value is automatically calculated as a computed rollup total (`delivering + delivered`).
+* For complete architectural details and design rationales on why general "in-transit" packages are excluded, consult [docs/architecture.md](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/docs/architecture.md).
 
 ### 4. Testing New Shippers
 * Create a corresponding test file under `tests/shippers/` (e.g. `test_new_shipper.py`).

--- a/.agents/skills/shipper_integration/SKILL.md
+++ b/.agents/skills/shipper_integration/SKILL.md
@@ -21,7 +21,9 @@ This skill defines the requirements for adding or updating carrier-specific ship
 ### 3. Sensor Taxonomy & Search Criteria
 * **`*_delivering`**: Only search for active out-for-delivery or scheduled-for-delivery-today notifications (e.g., "Out for delivery", "Paket kommt heute"). Do NOT track general "shipped", "picked up", "received at facility", or intermediate in-transit emails.
 * **`*_delivered`**: Search for delivered notifications (e.g., "Item Delivered", "wurde zugestellt").
-* **`*_packages`**: Must ALWAYS be configured as an empty dictionary (`{}`) in `SENSOR_DATA`. All `*_packages` sensors are computed rollups representing active package volume (`delivering + delivered`) and must never perform independent IMAP searches.
+* **`*_packages`**: Must ALWAYS be configured as an empty dictionary (`{}`) in `SENSOR_DATA`.
+  - *Why it exists in `SENSOR_DATA`*: The key is required for entity registration in `sensor.py`, options flow sensor selection, and sensor type descriptions.
+  - *Why it must remain `{}`*: An empty config signals to the shipper and coordinator processing engines that the sensor does not perform its own IMAP searches; instead, its value is automatically calculated as a computed rollup total (`delivering + delivered`).
 
 ### 4. Testing New Shippers
 * Create a corresponding test file under `tests/shippers/` (e.g. `test_new_shipper.py`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ This repository is a **Home Assistant Custom Integration** that connects to an I
   - `conftest.py`: Shared testing fixtures and mock IMAP client overrides.
   - `test_init.py`, `test_config_flow.py`, etc.: Integration and unit tests.
 
+### Architecture & Design Reference
+- For detailed system architecture, sensor lifecycle definitions, and design rationales (such as why general in-transit emails are not tracked), consult [docs/architecture.md](file:///home/firstof9/github/Home-Assistant-Mail-And-Packages/docs/architecture.md).
+
 ### IMAP Integration & Compatibility Guidelines
 - **IMAP RFC Compliance**: All IMAP query keys and arguments used in search commands (e.g. `search()`) must strictly conform to the IMAP RFC specifications (e.g., RFC 3501). Do not use FETCH-specific section/body specifiers (like `BODY[TEXT]`) inside `SEARCH` commands; instead, use standard search keys such as `BODY` or `TEXT` to prevent setup/login timeouts or parse errors on strictly compliant IMAP servers.
 - **Test Fidelity**: Keep mock IMAP structures and test assertions aligned with standard RFC query formatting so invalid query structures are not masked by test mocks.

--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -388,10 +388,7 @@ SENSOR_DATA = {
         "email": ["mcinfo@ups.com"],
         "subject": ["UPS Update: New Scheduled Delivery Date"],
     },
-    "ups_packages": {
-        "email": ["mcinfo@ups.com", "pkginfo@ups.com"],
-        "subject": ["UPS Ship Notification"],
-    },
+    "ups_packages": {},
     "ups_tracking": {"pattern": ["1Z?[0-9A-Z]{16}"]},
     # FedEx
     "fedex_delivered": {
@@ -421,14 +418,7 @@ SENSOR_DATA = {
             "Ihre Sendung wird voraussichtlich heute zugestellt",
         ],
     },
-    "fedex_packages": {
-        "email": [
-            "TrackingUpdates@fedex.com",
-            "fedexcanada@fedex.com",
-            "noreply@fedex.com",
-        ],
-        "subject": ["Your shipment is on the way"],
-    },
+    "fedex_packages": {},
     "fedex_exception": {
         "email": [
             "TrackingUpdates@fedex.com",
@@ -554,23 +544,7 @@ SENSOR_DATA = {
             "komen we bij je langs",
         ],
     },
-    # Transit-only DHL DE subjects (not out-for-delivery).
-    # Do NOT match "Jetzt Live verfolgen" here — OFD subjects also contain it.
-    "dhl_packages": {
-        "email": [
-            "donotreply_odd@dhl.com",
-            "NoReply.ODD@dhl.com",
-            "noreply@dhl.de",
-            "no-reply@dhl.de",
-            "pl.no.reply@dhl.com",
-            "support@dhl.com",
-            "noreply@dhlecommerce.nl",
-            "noreply@dhl.nl",
-        ],
-        "subject": [
-            "ist unterwegs",
-        ],
-    },
+    "dhl_packages": {},
     "dhl_tracking": {
         "pattern": [
             "(?:JJD\\d{18}|JVGL\\d{20}|MDP[A-Z0-9]{5,15}|00\\d{18}|(?<![0-9])\\d{10,11}(?![0-9]))",
@@ -830,12 +804,11 @@ SENSOR_DATA = {
     },
     "bonshaw_distribution_network_delivering": {
         "email": ["parcel_tracking@bonshawdelivery.com"],
-        "subject": ["Parcel Out for Delivery! En attente de livraison!"],
+        "subject": [
+            "Parcel Out for Delivery! En attente de livraison!",
+        ],
     },
-    "bonshaw_distribution_network_packages": {
-        "email": ["parcel_tracking@bonshawdelivery.com"],
-        "subject": ["Your package has been received!"],
-    },
+    "bonshaw_distribution_network_packages": {},
     "bonshaw_distribution_network_tracking": {"pattern": ["BNI[0-9]{9}"]},
     # Purolator
     "purolator_delivered": {
@@ -858,10 +831,7 @@ SENSOR_DATA = {
             "Your package is now out for delivery",
         ],
     },
-    "purolator_packages": {
-        "email": ["NotificationService@purolator.com"],
-        "subject": ["Purolator - Your shipment has been picked up"],
-    },
+    "purolator_packages": {},
     "purolator_tracking": {"pattern": ["(?:[A-Z]{3}\\d{9}|\\d{12,15})"]},
     # Intelcom
     "intelcom_delivered": {
@@ -900,21 +870,7 @@ SENSOR_DATA = {
             "Your package will be there in the next hour!",
         ],
     },
-    "intelcom_packages": {
-        "email": [
-            "notifications@intelcom.ca",
-            "notifications@dragonflyshipping.ca",
-            "notifications@dragonflyshipping.com",
-            "notifications@nl.dragonflyinternational.com",
-            "notifications@ca.dragonflyinternational.com",
-        ],
-        "subject": [
-            "Your package has been received!",
-            "We've received your package",
-            "We've received your",
-            "Je pakket is bij ons aangekomen",
-        ],
-    },
+    "intelcom_packages": {},
     "intelcom_tracking": {
         "pattern": ["(NSPRSO[0-9]{10}|AMZNL[0-9]{12}|INTLCMI[0-9]+)"]
     },
@@ -967,10 +923,7 @@ SENSOR_DATA = {
             "Arrived:",
         ],
     },
-    "walmart_packages": {
-        "email": ["help@walmart.com"],
-        "subject": ["Thanks for your delivery order"],
-    },
+    "walmart_packages": {},
     "walmart_exception": {
         "email": ["help@walmart.com"],
         "subject": ["delivery is delayed"],
@@ -991,14 +944,7 @@ SENSOR_DATA = {
             "has arrived",
         ],
     },
-    "home_depot_packages": {
-        "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
-        "subject": [
-            "Shipped:",
-            "order shipped!",
-            "on its way",
-        ],
-    },
+    "home_depot_packages": {},
     "home_depot_exception": {
         "email": ["homedepot@order.homedepot.com", "order.homedepot.com"],
         "subject": [
@@ -1022,15 +968,11 @@ SENSOR_DATA = {
             "t.shopifyemail.com",
             "no-reply@parcelpanel.net",
         ],
-        "subject": ["is out for delivery"],
-    },
-    "shopify_packages": {
-        "email": [
-            "t.shopifyemail.com",
-            "no-reply@parcelpanel.net",
+        "subject": [
+            "is out for delivery",
         ],
-        "subject": ["is on the way"],
     },
+    "shopify_packages": {},
     "shopify_tracking": {
         "pattern": ["shipment from order #?([A-Za-z0-9()\\-]+)"],
     },

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -523,14 +523,10 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
                 data[f"{prefix}_tracking"] = list(in_transit.keys())
                 data[f"{prefix}_delivering"] = len(in_transit)
             if in_transit:
-                packages_cfg = const.SENSOR_DATA.get(f"{prefix}_packages", {})
-                # Keep IMAP-backed packages sensors (e.g. DHL "ist unterwegs")
-                # instead of overwriting them with OFD tracking totals.
-                if not (packages_cfg.get("email") or packages_cfg.get("subject")):
-                    delivered_count = data.get(f"{prefix}_delivered", 0)
-                    data[f"{prefix}_packages"] = len(in_transit) + (
-                        delivered_count if isinstance(delivered_count, int) else 0
-                    )
+                delivered_count = data.get(f"{prefix}_delivered", 0)
+                data[f"{prefix}_packages"] = len(in_transit) + (
+                    delivered_count if isinstance(delivered_count, int) else 0
+                )
 
     def _latch_mail_delivered(self, data: dict, today_iso: str) -> None:
         """Latch usps_mail_delivered on for the rest of the day once seen.
@@ -654,16 +650,7 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             if not shipper or shipper in shippers_counted:
                 continue
 
-            if key.endswith("_delivering"):
-                transit += value
-                packages_cfg = const.SENSOR_DATA.get(f"{shipper}_packages", {})
-                # IMAP-backed packages (e.g. DHL "ist unterwegs") are additive.
-                if packages_cfg.get("email") or packages_cfg.get("subject"):
-                    packages_val = data.get(f"{shipper}_packages", 0)
-                    if isinstance(packages_val, int) and packages_val > 0:
-                        transit += packages_val
-                shippers_counted.add(shipper)
-            elif key.endswith("_packages"):
+            if key.endswith(("_delivering", "_packages")):
                 transit += value
                 shippers_counted.add(shipper)
 

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -29,19 +29,16 @@ from .const import (
     AMAZON_OTP,
     AMAZON_OTP_CODE,
     ATTR_CODE,
-    ATTR_EMAIL,
     ATTR_GRID_IMAGE_NAME,
     ATTR_IMAGE,
     ATTR_IMAGE_NAME,
     ATTR_IMAGE_PATH,
     ATTR_ORDER,
-    ATTR_SUBJECT,
     ATTR_TRACKING_NUM,
     ATTR_USPS_IMAGE,
     CONF_PATH,
     DOMAIN,
     IMAGE_SENSORS,
-    SENSOR_DATA,
     SENSOR_TYPES,
     VERSION,
 )
@@ -98,14 +95,6 @@ class PackagesSensor(CoordinatorEntity, RestoreSensor):
             prefix = "_".join(parts[:-1])
             if parts[-1] in DELIVERED_SUFFIXES:
                 self._tracking_key = f"{prefix}_delivered_tracking"
-            elif parts[-1] == "packages":
-                packages_cfg = SENSOR_DATA.get(self.type, {})
-                # IMAP-backed packages (e.g. DHL "ist unterwegs") keep their
-                # own tracking list; empty-config packages still mirror OFD.
-                if packages_cfg.get(ATTR_EMAIL) or packages_cfg.get(ATTR_SUBJECT):
-                    self._tracking_key = f"{self.type}_tracking"
-                else:
-                    self._tracking_key = f"{prefix}_tracking"
             else:
                 self._tracking_key = f"{prefix}_tracking"
         else:

--- a/custom_components/mail_and_packages/shippers/generic.py
+++ b/custom_components/mail_and_packages/shippers/generic.py
@@ -246,7 +246,6 @@ class GenericShipper(Shipper):
         )
 
         self._deduplicate_batch_tracking(batch_results)
-        self._sync_packages_tracking(batch_results)
         self._compute_package_totals(batch_results)
 
         # Merge results and aggregate global tracking
@@ -322,7 +321,6 @@ class GenericShipper(Shipper):
                     "delivered": set(),
                     "delivering": set(),
                     "update_targets": [],
-                    "package_targets": [],
                 }
 
             tracking = set(sensor_res.get(ATTR_TRACKING, []))
@@ -338,30 +336,10 @@ class GenericShipper(Shipper):
             elif sensor.endswith(("_delivering", "_exception")):
                 shippers[prefix]["delivering"].update(tracking)
                 shippers[prefix]["update_targets"].append((sensor, sensor_res))
-            elif sensor.endswith("_packages"):
-                shippers[prefix]["package_targets"].append((sensor, sensor_res))
 
         for data in shippers.values():
             # Remove "delivered" tracking numbers from in-transit sensors
             self._apply_deduplication(data["update_targets"], data["delivered"])
-            # Remove "delivering" and "delivered" tracking numbers from _packages
-            # so _packages only shows packages not yet out for delivery or delivered
-            in_pipeline = data["delivering"] | data["delivered"]
-            self._apply_deduplication(data["package_targets"], in_pipeline)
-
-    def _sync_packages_tracking(
-        self,
-        batch_results: list[tuple[str, dict[str, Any]]],
-    ) -> None:
-        """Store IMAP-backed packages tracking after OFD/delivered dedup."""
-        for sensor, sensor_res in batch_results:
-            if not sensor.endswith("_packages"):
-                continue
-            config = SENSOR_DATA.get(sensor, {})
-            if config.get(ATTR_EMAIL) or config.get(ATTR_SUBJECT):
-                sensor_res[f"{sensor}_tracking"] = list(
-                    sensor_res.get(ATTR_TRACKING, [])
-                )
 
     def _apply_deduplication(
         self,
@@ -388,7 +366,7 @@ class GenericShipper(Shipper):
         self,
         batch_results: list[tuple[str, dict[str, Any]]],
     ) -> None:
-        """Compute _packages sensors with empty config as delivering + delivered.
+        """Compute _packages sensors as delivering + delivered.
 
         These sensors have no IMAP search of their own; their value is the
         sum of the shipper's _delivering and _delivered counts (matching the
@@ -402,9 +380,6 @@ class GenericShipper(Shipper):
         for sensor, sensor_res in batch_results:
             if not sensor.endswith("_packages"):
                 continue
-            config = SENSOR_DATA.get(sensor, {})
-            if config.get(ATTR_EMAIL) or config.get(ATTR_SUBJECT):
-                continue  # sensor has its own IMAP search config
             prefix = sensor.replace("_packages", "")
             computed = sensor_counts.get(f"{prefix}_delivering", 0) + sensor_counts.get(
                 f"{prefix}_delivered", 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,100 @@
+# Mail and Packages Architecture & Design Standards
+
+This document describes the architectural design, sensor taxonomy, data pipeline, and design rationales for the **Home Assistant Mail and Packages** integration.
+
+---
+
+## 1. Core Architecture Overview
+
+Mail and Packages connects to an IMAP email server, parses delivery notifications across multiple shipping carriers and retail merchants, and surfaces sensor and camera entities to Home Assistant.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    IMAP Mail Server                         │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ (IMAP RFC 3501 Search & Fetch)
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│             DataUpdateCoordinator (_async_update_data)      │
+│  - EmailCache (Store-backed IMAP email deduplication)       │
+│  - Server-aware batch searching                             │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     GenericShipper                          │
+│  - Carrier regex matching & subject parsing                 │
+│  - Embedded marketplace tracking extraction (Shopify, HD)   │
+│  - Deduplication (_deduplicate_batch_tracking)              │
+│  - Rollup total computation (_compute_package_totals)       │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Home Assistant Entities                    │
+│  - Sensor entities (*_delivering, *_delivered, *_packages)  │
+│  - Summary rollups (mail_packages_in_transit, etc.)         │
+│  - Camera entities (mail_usps_camera, shipper badges)       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Sensor Taxonomy & Lifecycle
+
+Each supported carrier defines up to three standard package sensor entities in `const.py` (`SENSOR_DATA`):
+
+| Sensor Suffix | Purpose | Configuration in `SENSOR_DATA` | IMAP Search Executed? |
+| :--- | :--- | :--- | :--- |
+| **`*_delivering`** | Packages currently **out for delivery** or scheduled for delivery **today** | List of `email` senders, `subject` patterns, optional `body` patterns | **Yes** |
+| **`*_delivered`** | Packages successfully **delivered today** (resets at midnight) | List of `email` senders, `subject` patterns, optional `body` patterns | **Yes** |
+| **`*_packages`** | Computed rollup total of active package volume for the carrier | `{}` (Empty dictionary) | **No** (Computed dynamically) |
+
+### Additional Global Sensors
+- **`sensor.mail_packages_in_transit`**: Total count of all packages across all carriers currently out for delivery today.
+- **`sensor.mail_packages_delivered`**: Total count of all packages delivered today across all carriers.
+- **`sensor.mail_deliveries_message`**: Formatted summary text for notifications and Lovelace dashboard cards.
+- **`sensor.mail_updated`**: Diagnostic timestamp of the last successful mailbox scan.
+
+---
+
+## 3. Why General "Shipped / In-Transit" Packages Are Not Tracked
+
+A foundational design decision of Mail and Packages is that **general "shipped", "picked up", or intermediate "in-transit" emails are excluded from sensor tracking**.
+
+### Rationale
+
+1. **Email-Based Parsing vs. Carrier API Tracking**:
+   - The integration operates purely by querying consumer email inboxes over IMAP. It does not interface directly with carrier tracking APIs or webhooks.
+   - Most carriers and retailers send an initial "Order Shipped" or "Shipment Notice" email once, followed by days of silence with no intermediate status updates until the final delivery morning.
+2. **State Management & Inbox Expiration Ambiguity**:
+   - Email inboxes do not automatically update old messages when a physical package advances along transit hubs.
+   - Tracking raw "shipped" notifications causes stale messages to linger in search windows, artificially inflating package counts for days or weeks without any reliable mechanism to know when transit has completed (especially if a delivery email is missed, deleted, or formatted differently).
+3. **Actionable Daily Automation Scope**:
+   - The primary objective of Mail and Packages is to trigger **actionable same-day home automations**—alerting household members when packages are on the truck for delivery today (`*_delivering`) or have been left on the porch (`*_delivered`).
+   - Broad long-term parcel tracking across multi-week transit routes is better suited for dedicated parcel tracking integrations backed by carrier web APIs.
+
+---
+
+## 4. Why `*_packages` Sensors Are Configured as `{}` in `SENSOR_DATA`
+
+All carrier `*_packages` sensors must be defined as an empty dictionary (`{}`) in `SENSOR_DATA`:
+
+1. **Entity Registration**:
+   - Home Assistant entity generation (`sensor.py`), options flow sensor selection, and `SENSOR_TYPES` descriptions require each entity key to exist in `SENSOR_DATA`.
+2. **Explicit Search Exclusion**:
+   - An empty dictionary signals to `GenericShipper.process_batch()` and `DataUpdateCoordinator` that the sensor must **not** perform an independent IMAP query.
+3. **Dynamic Rollup Total**:
+   - In `shippers/generic.py`, `_compute_package_totals()` calculates `*_packages` as:
+     $$\text{packages} = \text{delivering} + \text{delivered}$$
+   - This ensures total package counts accurately reflect all carrier activity for the day without duplicate network requests or double-counting.
+
+---
+
+## 5. Deduplication & Transit Pipeline
+
+During each coordinator update cycle:
+1. **Per-Carrier IMAP Search**: Shippers search IMAP for delivered and out-for-delivery messages within the configured time window (`custom_days`).
+2. **Extended Window Delivery Filtering**: `_deduplicate_batch_tracking` removes tracking numbers found in delivered emails from the active delivering list so delivered items do not continue to show as out for delivery.
+3. **Embedded Carrier Tracking Extraction**: For retailers and marketplace platforms (such as Home Depot or Shopify) that embed third-party carrier tracking numbers (UPS, FedEx, Canada Post, etc.) in their order notification emails, `GenericShipper` extracts the underlying carrier tracking ID to prevent duplicate counts when both merchant and courier emails are received for the same package.
+4. **Email Caching (`EmailCache`)**: Uses Home Assistant's `Store` helper (`custom_components/mail_and_packages/utils/cache.py`) to persist email body hashes and message IDs across updates, preventing redundant fetches of unchanged messages.

--- a/tests/shippers/test_generic.py
+++ b/tests/shippers/test_generic.py
@@ -698,8 +698,7 @@ async def test_process_batch_deduplication(hass):
         if sensor == "ups_delivering":
             return {"ups_delivering": 2, ATTR_TRACKING: ["T1", "T2"], ATTR_COUNT: 2}
         if sensor == "ups_packages":
-            # T1 already in delivered/delivering; T3 is a new upcoming shipment
-            return {"ups_packages": 2, ATTR_TRACKING: ["T1", "T3"]}
+            return {"ups_packages": 0, ATTR_TRACKING: []}
         if sensor == "fedex_delivered":
             return {"fedex_delivered": 1, ATTR_TRACKING: ["F1"]}
         if sensor == "fedex_delivering":
@@ -719,16 +718,15 @@ async def test_process_batch_deduplication(hass):
         # UPS Deduplication
         assert result["ups_delivered"] == 1
         assert result["ups_delivering"] == 1  # T1 removed (already delivered)
-        # ups_packages has its own IMAP search; T1 and T2 are removed (in pipeline)
-        # leaving only T3 (upcoming shipment not yet delivering/delivered)
-        assert result["ups_packages"] == 1
+        # ups_packages is a computed total: 1 delivering + 1 delivered = 2
+        assert result["ups_packages"] == 2
 
         # FedEx Deduplication
         assert result["fedex_delivered"] == 1
         assert result["fedex_delivering"] == 0  # F1 removed
 
         # Tracking Aggregation
-        assert set(result[ATTR_TRACKING]) == {"T1", "T2", "F1", "T3"}
+        assert set(result[ATTR_TRACKING]) == {"T1", "T2", "F1"}
 
 
 @pytest.mark.asyncio
@@ -946,15 +944,15 @@ async def test_ups_packages_empty_config_skips_imap(hass):
 
 
 @pytest.mark.asyncio
-async def test_ups_packages_searches_imap(hass):
-    """Test that ups_packages now performs an IMAP search with its own config."""
+async def test_ups_delivering_searches_imap(hass):
+    """Test that ups_delivering performs an IMAP search with its own config."""
     shipper = GenericShipper(hass, {})
     mock_account = AsyncMock()
     with patch(
         "custom_components.mail_and_packages.shippers.generic.email_search",
         return_value=("OK", [b""]),
     ) as mock_search:
-        await shipper.process(mock_account, "today", "ups_packages")
+        await shipper.process(mock_account, "today", "ups_delivering")
         mock_search.assert_called_once()
         call_args = mock_search.call_args
         # Verify UPS emails are passed
@@ -962,15 +960,15 @@ async def test_ups_packages_searches_imap(hass):
 
 
 @pytest.mark.asyncio
-async def test_ups_packages_with_forwarded_emails_includes_both(hass):
-    """Test that forwarded_emails are prepended to UPS emails for ups_packages."""
+async def test_ups_delivering_with_forwarded_emails_includes_both(hass):
+    """Test that forwarded_emails are prepended to UPS emails for ups_delivering."""
     shipper = GenericShipper(hass, {"forwarded_emails": ["forwarder@example.com"]})
     mock_account = AsyncMock()
     with patch(
         "custom_components.mail_and_packages.shippers.generic.email_search",
         return_value=("OK", [b""]),
     ) as mock_search:
-        await shipper.process(mock_account, "today", "ups_packages")
+        await shipper.process(mock_account, "today", "ups_delivering")
         mock_search.assert_called_once()
         email_list = mock_search.call_args.kwargs["address"]
         assert "forwarder@example.com" in email_list
@@ -978,10 +976,8 @@ async def test_ups_packages_with_forwarded_emails_includes_both(hass):
 
 
 def test_compute_package_totals(hass):
-    """Test _compute_package_totals sets _packages as delivering + delivered for carriers with empty config."""
+    """Test _compute_package_totals sets _packages as delivering + delivered for carriers."""
     shipper = GenericShipper(hass, {})
-    # capost_packages / hermes_packages still have {} config — computed totals
-    # dhl_packages is IMAP-backed ("ist unterwegs") and must keep its own count
     batch_results = [
         (
             "capost_delivering",
@@ -996,8 +992,8 @@ def test_compute_package_totals(hass):
         ("hermes_delivered", {"hermes_delivered": 0, ATTR_COUNT: 0, ATTR_TRACKING: []}),
         ("hermes_packages", {"hermes_packages": 0, ATTR_COUNT: 0, ATTR_TRACKING: []}),
         ("dhl_delivering", {"dhl_delivering": 2, ATTR_COUNT: 2, ATTR_TRACKING: []}),
-        ("dhl_delivered", {"dhl_delivered": 0, ATTR_COUNT: 0, ATTR_TRACKING: []}),
-        ("dhl_packages", {"dhl_packages": 5, ATTR_COUNT: 5, ATTR_TRACKING: ["T1"]}),
+        ("dhl_delivered", {"dhl_delivered": 1, ATTR_COUNT: 1, ATTR_TRACKING: []}),
+        ("dhl_packages", {"dhl_packages": 0, ATTR_COUNT: 0, ATTR_TRACKING: []}),
     ]
     shipper._compute_package_totals(batch_results)
 
@@ -1010,53 +1006,17 @@ def test_compute_package_totals(hass):
     assert hermes_res[ATTR_COUNT] == 2
 
     _, dhl_res = next(r for r in batch_results if r[0] == "dhl_packages")
-    assert dhl_res["dhl_packages"] == 5
-    assert dhl_res[ATTR_COUNT] == 5
+    assert dhl_res["dhl_packages"] == 3  # 2 delivering + 1 delivered
+    assert dhl_res[ATTR_COUNT] == 3
 
 
-def test_dhl_ofd_vs_unterwegs_subject_split():
-    """DHL OFD subjects stay on delivering; 'ist unterwegs' is packages-only."""
+def test_dhl_delivering_subjects():
+    """DHL delivering subjects include 'kommt heute' and not 'ist unterwegs'."""
     delivering = SENSOR_DATA["dhl_delivering"]["subject"]
-    packages = SENSOR_DATA["dhl_packages"]["subject"]
 
     assert "kommt heute" in delivering
     assert "ist unterwegs" not in delivering
-    assert "Jetzt Live verfolgen" not in delivering
-
-    assert "ist unterwegs" in packages
-    assert "kommt heute" not in packages
-    assert "Jetzt Live verfolgen" not in packages
-    assert SENSOR_DATA["dhl_packages"].get("email")
-
-
-def test_sync_packages_tracking_after_dedup(hass):
-    """IMAP-backed packages tracking is stored after OFD numbers are removed."""
-    shipper = GenericShipper(hass, {})
-    batch_results = [
-        (
-            "dhl_delivering",
-            {
-                "dhl_delivering": 1,
-                ATTR_COUNT: 1,
-                ATTR_TRACKING: ["OFD1"],
-            },
-        ),
-        (
-            "dhl_packages",
-            {
-                "dhl_packages": 2,
-                ATTR_COUNT: 2,
-                ATTR_TRACKING: ["OFD1", "TRANSIT1"],
-            },
-        ),
-    ]
-    shipper._deduplicate_batch_tracking(batch_results)
-    shipper._sync_packages_tracking(batch_results)
-
-    _, packages_res = next(r for r in batch_results if r[0] == "dhl_packages")
-    assert packages_res["dhl_packages"] == 1
-    assert packages_res[ATTR_TRACKING] == ["TRANSIT1"]
-    assert packages_res["dhl_packages_tracking"] == ["TRANSIT1"]
+    assert SENSOR_DATA["dhl_packages"] == {}
 
 
 @pytest.mark.asyncio
@@ -1149,8 +1109,8 @@ async def test_process_packages_ignores_since_date(hass):
 
 
 @pytest.mark.asyncio
-async def test_ups_packages_uses_since_date(hass):
-    """ups_packages with real config uses since_date for IMAP search window."""
+async def test_ups_delivering_uses_since_date(hass):
+    """ups_delivering with real config uses since_date for IMAP search window."""
     shipper = GenericShipper(hass, {})
     mock_account = AsyncMock()
 
@@ -1161,7 +1121,7 @@ async def test_ups_packages_uses_since_date(hass):
         await shipper.process(
             mock_account,
             "22-Apr-2026",
-            "ups_packages",
+            "ups_delivering",
             since_date="19-Apr-2026",
         )
 
@@ -1413,14 +1373,23 @@ async def test_etsy_on_the_way_class(hass, mock_imap_etsy_on_the_way):
 
 
 @pytest.mark.asyncio
-async def test_shopify_on_the_way_class(hass, mock_imap_shopify_on_the_way):
-    """Test standard Shopify on-the-way email parsing via GenericShipper."""
-    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+async def test_shopify_out_for_delivery_class(hass, mock_imap):
+    """Test standard Shopify out-for-delivery email parsing via GenericShipper."""
+    email_file = await hass.async_add_executor_job(
+        Path("tests/test_emails/shopify_on_the_way.eml").read_text
+    )
+    email_file = email_file.replace(
+        "Subject: A shipment from order MC1605 is on the way",
+        "Subject: A shipment from order MC1605 is out for delivery",
+    )
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
 
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
     result = await shipper.process(
-        mock_imap_shopify_on_the_way,
+        mock_imap,
         "today",
-        "shopify_packages",
+        "shopify_delivering",
     )
     assert result[ATTR_COUNT] == 1
     assert result[ATTR_TRACKING] == ["MC1605"]
@@ -1524,7 +1493,7 @@ def test_aliexpress_2026_subject_patterns(subject, expected_sensor):
                 "Purolator - Your shipment has been picked up / Votre envoi a été "
                 "ramassé - PIN/NIC:335596611426"
             ),
-            "purolator_packages",
+            None,
         ),
         # Non-shipping notifications from the same sender must not match
         (
@@ -1566,7 +1535,6 @@ def test_purolator_2026_subject_patterns(subject, expected_sensor):
         for sensor in (
             "purolator_delivered",
             "purolator_delivering",
-            "purolator_packages",
         )
         if any(
             expected.lower() in subject.lower()
@@ -1620,9 +1588,9 @@ def test_etsy_subject_patterns(subject, expected_sensor):
 @pytest.mark.parametrize(
     ("subject", "expected_sensor"),
     [
-        ("A shipment from order MC1605 is on the way", "shopify_packages"),
-        ("A shipment from order #24498 is on the way", "shopify_packages"),
-        ("A shipment from order BAK(2)-563319 is on the way", "shopify_packages"),
+        ("A shipment from order MC1605 is on the way", None),
+        ("A shipment from order #24498 is on the way", None),
+        ("A shipment from order BAK(2)-563319 is on the way", None),
         ("A shipment from order MC1605 is out for delivery", "shopify_delivering"),
         ("A shipment from order #53495 has been delivered", "shopify_delivered"),
         # Non-shipping mail from Shopify's shared senders must not match
@@ -1635,7 +1603,7 @@ def test_shopify_subject_patterns(subject, expected_sensor):
     """Each standard Shopify template subject maps to exactly one sensor."""
     matched = [
         sensor
-        for sensor in ("shopify_delivered", "shopify_delivering", "shopify_packages")
+        for sensor in ("shopify_delivered", "shopify_delivering")
         if any(
             expected.lower() in subject.lower()
             for expected in SENSOR_DATA[sensor][ATTR_SUBJECT]
@@ -1900,12 +1868,20 @@ def test_shopify_tracking_pattern(text, expected):
 
 
 @pytest.mark.asyncio
-async def test_shopify_carrier_tracking_extraction(hass, mock_imap_shopify_on_the_way):
+async def test_shopify_carrier_tracking_extraction(hass, mock_imap):
     """The carrier tracking number embedded in a Shopify email is mapped."""
-    shipper = GenericShipper(hass, {"image_path": "test/path/"})
-    result = await shipper.process(
-        mock_imap_shopify_on_the_way, "today", "shopify_packages"
+    email_file = await hass.async_add_executor_job(
+        Path("tests/test_emails/shopify_on_the_way.eml").read_text
     )
+    email_file = email_file.replace(
+        "Subject: A shipment from order MC1605 is on the way",
+        "Subject: A shipment from order MC1605 is out for delivery",
+    )
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+
+    shipper = GenericShipper(hass, {"image_path": "test/path/"})
+    result = await shipper.process(mock_imap, "today", "shopify_delivering")
     assert result[ATTR_COUNT] == 1
     assert result["shopify_carrier_tracking"] == {"MC1605": "9443743716845537"}
 
@@ -1917,13 +1893,14 @@ async def test_shopify_no_carrier_tracking_is_noop(hass, mock_imap):
         Path("tests/test_emails/shopify_on_the_way.eml").read_text
     )
     email_file = email_file.replace(
-        "Canada post tracking number: 9443743716845537", "Track your shipment"
-    )
+        "Subject: A shipment from order MC1605 is on the way",
+        "Subject: A shipment from order MC1605 is out for delivery",
+    ).replace("Canada post tracking number: 9443743716845537", "Track your shipment")
     mock_imap.select.return_value = ("OK", [b""])
     mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
 
     shipper = GenericShipper(hass, {"image_path": "test/path/"})
-    result = await shipper.process(mock_imap, "today", "shopify_packages")
+    result = await shipper.process(mock_imap, "today", "shopify_delivering")
     assert result[ATTR_COUNT] == 1
     assert "shopify_carrier_tracking" not in result
 

--- a/tests/shippers/test_home_depot.py
+++ b/tests/shippers/test_home_depot.py
@@ -70,22 +70,23 @@ async def test_home_depot_delivering(hass):
 
 
 @pytest.mark.asyncio
-async def test_home_depot_shipped(hass):
-    """Test Home Depot package shipped email parsing via GenericShipper."""
+async def test_home_depot_delivering_carrier_tracking(hass):
+    """Test Home Depot out for delivery email parsing with carrier tracking via GenericShipper."""
     shipper = GenericShipper(hass, {})
 
     msg = MIMEMultipart("alternative")
     msg["From"] = "The Home Depot <HomeDepot@order.homedepot.com>"
-    msg["Subject"] = "Order #WK00000000 Shipped: Your order is on its way, Customer!"
-    msg["Date"] = "Sun, 08 Mar 2026 18:07:00 -0400"
+    msg["Subject"] = (
+        "Order #WK00000000: Your Home Depot order is out for delivery today."
+    )
+    msg["Date"] = "Tue, 10 Mar 2026 11:16:00 -0400"
 
     html_body = """
     <html>
       <body>
         <b>Order #: </b><a href="#">WK00000000</a>
-        <b>Your package has shipped, Customer!</b>
+        <p>Get ready, Customer! Your delivery arrives today!</p>
         <p>Tracking ID: 123456789012</p>
-        <p>ETA by FedEx: Tue, Mar 10</p>
       </body>
     </html>
     """
@@ -115,15 +116,15 @@ async def test_home_depot_shipped(hass):
             return_value=(
                 "OK",
                 [
-                    b"Subject: Order #WK00000000 Shipped: Your order is on its way, Customer!\r\n"
+                    b"Subject: Order #WK00000000: Your Home Depot order is out for delivery today.\r\n"
                 ],
             ),
         ),
     ):
         result = await shipper.process(
             account=mock_account,
-            date="08-Mar-2026",
-            sensor_type="home_depot_packages",
+            date="10-Mar-2026",
+            sensor_type="home_depot_delivering",
         )
 
     assert result[ATTR_COUNT] == 1
@@ -138,8 +139,10 @@ async def test_home_depot_marketplace_carrier_tracking(hass):
 
     msg = MIMEMultipart("alternative")
     msg["From"] = "The Home Depot <HomeDepot@order.homedepot.com>"
-    msg["Subject"] = "Order #WK00000000 Shipped: Your order is on its way, Customer!"
-    msg["Date"] = "Sun, 08 Mar 2026 18:07:00 -0400"
+    msg["Subject"] = (
+        "Order #WK00000000: Your Home Depot order is out for delivery today."
+    )
+    msg["Date"] = "Tue, 10 Mar 2026 11:16:00 -0400"
 
     html_body = """
     <html>
@@ -168,7 +171,7 @@ async def test_home_depot_marketplace_carrier_tracking(hass):
         ),
     ):
         mapping = await shipper._collect_carrier_tracking(
-            "home_depot_packages",
+            "home_depot_delivering",
             [b"1"],
             mock_account,
         )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -470,8 +470,7 @@ async def test_apply_tracking_state_overrides_delivering(hass):
 
     # 1Z111, 1Z222 carried over + 1Z333 newly added = 3
     assert data["ups_delivering"] == 3
-    # ups_packages is IMAP-backed — preserve its own count
-    assert data["ups_packages"] == 1
+    assert data["ups_packages"] == 3  # 3 in transit + 0 delivered
     assert set(data["ups_tracking"]) == {"1Z111", "1Z222", "1Z333"}
 
 
@@ -495,8 +494,7 @@ async def test_apply_tracking_state_removes_delivered(hass):
 
     assert "9261290" not in coordinator._in_transit_tracking["fedex"]
     assert data["fedex_delivering"] == 1
-    # fedex_packages is IMAP-backed — preserve its own count
-    assert data["fedex_packages"] == 3
+    assert data["fedex_packages"] == 2  # 1 in transit + 1 delivered
 
 
 @pytest.mark.asyncio
@@ -575,16 +573,16 @@ async def test_apply_tracking_state_no_details_keeps_email_count(hass):
 
 
 @pytest.mark.asyncio
-async def test_apply_tracking_state_preserves_imap_backed_dhl_packages(hass):
-    """IMAP-backed dhl_packages must not be overwritten by OFD transit totals."""
+async def test_apply_tracking_state_derives_packages_total(hass):
+    """*_packages sensors are derived from in_transit tracking + delivered count."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
     coordinator._in_transit_tracking["dhl"] = {"OFD1": "2026-04-20"}
     data = {
         "dhl_delivering": 1,
-        "dhl_delivered": 0,
-        "dhl_packages": 3,
+        "dhl_delivered": 2,
+        "dhl_packages": 0,
     }
     tracking_details = {
         "dhl_delivering": ["OFD1"],
@@ -593,7 +591,7 @@ async def test_apply_tracking_state_preserves_imap_backed_dhl_packages(hass):
     coordinator._apply_tracking_state(data, tracking_details, "2026-04-22")
 
     assert data["dhl_delivering"] == 1
-    assert data["dhl_packages"] == 3
+    assert data["dhl_packages"] == 3  # 1 in transit + 2 delivered
     assert data["dhl_tracking"] == ["OFD1"]
 
 
@@ -624,8 +622,8 @@ async def test_apply_tracking_state_overwrites_empty_config_packages(hass):
 
 
 @pytest.mark.asyncio
-async def test_sum_transit_counts_adds_imap_backed_packages(hass):
-    """Transit total includes delivering plus IMAP-backed packages."""
+async def test_sum_transit_counts_prefers_delivering_over_packages(hass):
+    """Transit total counts delivering if present, ignoring packages rollup."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
@@ -633,21 +631,20 @@ async def test_sum_transit_counts_adds_imap_backed_packages(hass):
         "dhl_delivering": 1,
         "dhl_packages": 2,
         "hermes_delivering": 1,
-        "hermes_packages": 9,  # empty config; ignored once delivering counted
+        "hermes_packages": 9,  # ignored once delivering counted
     }
-    assert coordinator._sum_transit_counts(data) == 4  # dhl 1+2 + hermes 1
+    assert coordinator._sum_transit_counts(data) == 2  # dhl 1 + hermes 1
 
 
 @pytest.mark.asyncio
-async def test_sum_transit_counts_packages_only_and_non_int_imap_packages(hass):
-    """Cover packages-only shippers and non-int IMAP-backed packages values."""
+async def test_sum_transit_counts_packages_only(hass):
+    """Cover packages-only shippers when delivering is not present."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
     data = {
-        "hermes_packages": 2,  # empty-config packages-only
+        "hermes_packages": 2,  # packages-only
         "dhl_delivering": 1,
-        "dhl_packages": "oops",  # IMAP-backed but not an int — ignored
     }
     assert coordinator._sum_transit_counts(data) == 3  # hermes 2 + dhl delivering 1
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -116,7 +116,7 @@ async def test_sensor(hass, mock_update, entity_registry: er.EntityRegistry):
     state = s("mail_dhl_packages")
     assert state
     assert state.state == "1"
-    assert state.attributes["tracking_#"] == ["00340435071043104047"]
+    assert state.attributes["tracking_#"] == ["1234567890"]
 
     state = s("mail_auspost_delivered")
     assert state


### PR DESCRIPTION
## Proposed change

- Standardize all `*_packages` sensors as computed rollup totals (`delivering + delivered`) and set their `SENSOR_DATA` configuration to `{}` across all carriers.
- Remove redundant search logic and dedicated IMAP querying for `_packages` sensors in `coordinator.py`, `sensor.py`, and `shippers/generic.py`.
- Remove "shipped", "picked up", "package received", and transit-only subjects (e.g., DHL `"ist unterwegs"`, Home Depot `"Shipped:"`, UPS `"UPS Ship Notification"`, FedEx `"Your shipment is on the way"`, Shopify `"is on the way"`) from `*_delivering` sensors, ensuring `*_delivering` only tracks active out-for-delivery / delivering-today notifications.
- Update tests across all affected shippers and coordinators.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1398
- This PR is related to issue: