### PR TITLE
fix(coordinator): stop counting delivered packages as in transit

### DIFF
--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -650,7 +650,14 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             if not shipper or shipper in shippers_counted:
                 continue
 
-            if key.endswith(("_delivering", "_packages")):
+            # Only *_delivering feeds the in-transit total. A shipper's
+            # *_packages sensor is a computed rollup of _delivering +
+            # _delivered (GenericShipper._compute_package_totals), so counting
+            # it here keeps a package "in transit" after it is delivered: the
+            # delivery drops _delivering to 0 but leaves _packages at 1, and
+            # the rollup then reports that one package as both in transit and
+            # delivered until the counts reset at midnight.
+            if key.endswith("_delivering"):
                 transit += value
                 shippers_counted.add(shipper)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -310,6 +310,7 @@ async def test_aggregate_package_counts(hass):
         "usps_delivered": 1,
         "ups_delivering": 2,
         "ups_delivered": 0,
+        "fedex_delivering": 1,
         "fedex_packages": 3,
         "fedex_delivered": 2,
         "amazon_packages": 5,
@@ -325,14 +326,17 @@ async def test_aggregate_package_counts(hass):
     coordinator._aggregate_package_counts(test_data)
 
     # Expected Transit:
-    # usps_delivering (1) + ups_delivering (2) + fedex_packages (3) + amazon_packages (5)
-    # + amazon_exception (1) + dhl_exception (1)
-    # = 1 + 2 + 3 + 5 + 1 + 1 = 13
-    assert test_data["zpackages_transit"] == 13
+    # usps_delivering (1) + ups_delivering (2) + fedex_delivering (1)
+    # + amazon_packages (5) + amazon_exception (1) + dhl_exception (1)
+    # = 1 + 2 + 1 + 5 + 1 + 1 = 11
+    # fedex_packages (3) is a _delivering + _delivered rollup, so it is not
+    # counted: its 2 delivered packages are not in transit.
+    assert test_data["zpackages_transit"] == 11
 
     # Expected Delivering:
-    # usps_delivering (1) + ups_delivering (2) + amazon_delivering (2) = 5
-    assert test_data["zpackages_delivering"] == 5
+    # usps_delivering (1) + ups_delivering (2) + amazon_delivering (2)
+    # + fedex_delivering (1) = 6
+    assert test_data["zpackages_delivering"] == 6
 
     # Expected Delivered:
     # usps_delivered (1) + fedex_delivered (2) + amazon_delivered (1)
@@ -356,6 +360,44 @@ async def test_aggregate_package_counts_no_resource(hass):
 
     assert "zpackages_transit" not in test_data
     assert "zpackages_delivered" not in test_data
+
+
+@pytest.mark.asyncio
+async def test_aggregate_transit_excludes_delivered_packages(hass):
+    """A delivered package must not stay in the in-transit rollup.
+
+    Regression test: *_packages is a rollup of *_delivering + *_delivered, so
+    once the only package of the day is delivered *_delivering drops to 0
+    while *_packages stays at 1. Counting *_packages as transit reported that
+    single package as both "1 in transit" and "1 delivered" for the rest of
+    the day, until the counts reset at midnight.
+    """
+    with patch("homeassistant.helpers.frame.report_usage"):
+        coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
+
+    # Out for delivery: one package, in transit.
+    out_for_delivery = {
+        "zpackages_transit": 0,
+        "zpackages_delivered": 0,
+        "fedex_delivering": 1,
+        "fedex_delivered": 0,
+        "fedex_packages": 1,
+    }
+    coordinator._aggregate_package_counts(out_for_delivery)
+    assert out_for_delivery["zpackages_transit"] == 1
+    assert out_for_delivery["zpackages_delivered"] == 0
+
+    # Delivered: the same package, no longer in transit.
+    delivered = {
+        "zpackages_transit": 0,
+        "zpackages_delivered": 0,
+        "fedex_delivering": 0,
+        "fedex_delivered": 1,
+        "fedex_packages": 1,
+    }
+    coordinator._aggregate_package_counts(delivered)
+    assert delivered["zpackages_transit"] == 0
+    assert delivered["zpackages_delivered"] == 1
 
 
 @pytest.mark.asyncio
@@ -637,16 +679,18 @@ async def test_sum_transit_counts_prefers_delivering_over_packages(hass):
 
 
 @pytest.mark.asyncio
-async def test_sum_transit_counts_packages_only(hass):
-    """Cover packages-only shippers when delivering is not present."""
+async def test_sum_transit_counts_ignores_packages_rollup(hass):
+    """*_packages rollups never contribute to the in-transit total."""
     with patch("homeassistant.helpers.frame.report_usage"):
         coordinator = MailDataUpdateCoordinator(hass, FAKE_CONFIG_DATA)
 
     data = {
-        "hermes_packages": 2,  # packages-only
+        "hermes_packages": 2,  # rollup of the delivering + delivered below
+        "hermes_delivering": 1,
+        "hermes_delivered": 1,
         "dhl_delivering": 1,
     }
-    assert coordinator._sum_transit_counts(data) == 3  # hermes 2 + dhl delivering 1
+    assert coordinator._sum_transit_counts(data) == 2  # hermes 1 + dhl 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

`sensor.mail_packages_in_transit` keeps counting a package after it has been delivered, so the same package reads as both in transit and delivered until the counts reset at midnight.

`_sum_transit_counts()` adds a shipper's `*_packages` sensor to the rollup whenever `*_delivering` is absent or zero:

```python
if key.endswith(("_delivering", "_packages")):
    transit += value
    shippers_counted.add(shipper)
```

Since #1399 standardised `*_packages` as a computed rollup of `*_delivering + *_delivered` (`GenericShipper._compute_package_totals`, and every `*_packages` entry in `SENSOR_DATA` is now an empty config with no IMAP search of its own), that fallback double-counts delivered packages.

Delivery is exactly where it breaks: the delivered email drops `*_delivering` to 0, the `value <= 0` guard skips that key, and `*_packages` is still 1 because it now equals 0 delivering + 1 delivered.

## Observed

One FedEx package, one day, nothing else moving:

| local time | event | `fedex_delivering` | `fedex_delivered` | `fedex_packages` | `packages_in_transit` |
|---|---|---|---|---|---|
| 09:54 | out-for-delivery email | 0 → 1 | 0 | 0 → 1 | 0 → **1** ✅ |
| 11:32 | delivered email | 1 → **0** | 0 → **1** | **1** | **1** ❌ |

The dashboard read `1 transit` and `1 delivered` for the rest of the day for a single package that was already on the porch.

It compounds across carriers: a delivered FedEx package plus a UPS package genuinely out for delivery reports 2 in transit.

## The fix

Only `*_delivering` feeds the total, which is what `docs/architecture.md` already documents the sensor to be — *"total count of all packages across all carriers currently out for delivery today"*.

Unchanged:

- **Exceptions** are still added for all shippers.
- **`amazon_packages`** keeps its special case. `AmazonShipper` has its own `process_batch` and does not go through `_compute_package_totals`, so `amazon_packages` still means "total arriving" rather than a delivering+delivered rollup.
- `shippers_counted` still does its job — it is what stops `amazon_delivering` being added on top of `amazon_packages`.

## Tests

- `test_sum_transit_counts_packages_only` covered a "packages-only shipper" that no longer exists after #1399 (`hermes` has `hermes_delivering`), so it is retargeted at the new invariant.
- `test_aggregate_package_counts`'s fedex entry gains the `fedex_delivering: 1` its rollup of 3 implies; expected transit goes 13 → 11 and delivering 5 → 6.
- New `test_aggregate_transit_excludes_delivered_packages` walks the single package through both states.

`752 passed`, coverage 99.81%, ruff clean.
