### PR TITLE
fix(image): apply EXIF orientation before writing GIF frames

### DIFF
--- a/custom_components/mail_and_packages/utils/image.py
+++ b/custom_components/mail_and_packages/utils/image.py
@@ -188,6 +188,14 @@ def resize_images(images: list, width: int, height: int) -> list:
             img_path = Path(image_path)
             with img_path.open("rb") as fd_img:
                 img = Image.open(fd_img)
+                # Bake in the EXIF orientation before anything else. Delivery
+                # photos come straight off a courier's handheld and are very
+                # often stored rotated with an Orientation tag, and the frames
+                # written below are GIF, which cannot carry EXIF at all — so
+                # this is the last point at which the tag still exists. Doing
+                # it any later (generate_delivery_gif also calls
+                # exif_transpose) is a no-op on frames whose EXIF is gone.
+                img = ImageOps.exif_transpose(img)
                 img.thumbnail((width, height), resample=Image.Resampling.LANCZOS)
                 img = ImageOps.pad(
                     img,

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PIL import Image as PILImage
 
 from custom_components.mail_and_packages.const import (
     CONF_STORAGE,
@@ -452,6 +453,38 @@ async def test_resize_images_success():
         result = resize_images(["/fake/path/test.jpg"], 100, 100)
         assert len(result) == 1
         assert "_resized.gif" in result[0]
+
+
+@pytest.mark.asyncio
+async def test_resize_images_applies_exif_orientation(tmp_path):
+    """A rotated source photo is uprighted before its EXIF is discarded.
+
+    Regression test: courier delivery photos are commonly stored rotated
+    with an EXIF Orientation tag. resize_images writes GIF frames and GIF
+    carries no EXIF, so the orientation has to be applied here — applying it
+    downstream in generate_delivery_gif is a no-op, and the delivery photo
+    ends up on the camera entity lying on its side.
+    """
+    source = tmp_path / "delivery.jpg"
+    # Portrait as stored, landscape as displayed (Orientation 6 = rotate 90).
+    photo = PILImage.new("RGB", (40, 80), "black")
+    photo.paste((255, 0, 0), (0, 0, 40, 40))
+    photo.paste((0, 0, 255), (0, 40, 40, 80))
+    exif = photo.getexif()
+    exif[0x0112] = 6
+    photo.save(source, "JPEG", exif=exif)
+
+    resized = resize_images([str(source)], 100, 100)
+    assert len(resized) == 1
+
+    with PILImage.open(resized[0]) as result:
+        # The pad colour is black, so the non-black bounding box is the photo.
+        left, upper, right, lower = result.convert("RGB").getbbox()
+
+    # Displayed upright the photo is landscape, so ImageOps.pad leaves bars
+    # above and below it. Without the transpose it stays portrait and the
+    # bars are on the sides instead.
+    assert right - left > lower - upper
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

Delivery photos are rendered 90 degrees out of true whenever the source carries an EXIF `Orientation` tag.

`generate_delivery_gif()` already tries to handle this:

```python
img = ImageOps.exif_transpose(img)  # auto-rotates according to EXIF
```

but it never sees a file with EXIF on it. Every caller runs `resize_images()` first, and `resize_images()` saves each frame as **GIF**, which carries no EXIF — so the tag is gone one step before the correction runs, and the transpose is a no-op on every real code path.

## Observed

A FedEx delivery photo off a Zebra TC78 handheld, stored 240x320 with `Orientation = 6`:

- **Email client** (honours the tag): 320x240 landscape, upright.
- **Camera entity**: 240x320, lying on its side.

It costs most of the frame too — padded as portrait it is letterboxed into the 800x600 canvas instead of filling it.

Courier handhelds routinely store rotated pixels plus an Orientation tag rather than rotating the pixels, so this is the common case for delivery photos rather than an edge case.

## The fix

Move the transpose into `resize_images()`, at the last point where the tag still exists.

That covers all four callers — the generic delivery camera plus the Amazon, USPS and Post DE shippers, which all pass originals through `resize_images()` before `generate_delivery_gif()`.

`ImageOps.exif_transpose` is a no-op for images with no Orientation tag, so images that were already correct are unaffected. The existing call in `generate_delivery_gif()` is left alone — it is still correct for anything that hands it originals directly.

## Tests

New `test_resize_images_applies_exif_orientation` builds a real portrait JPEG with `Orientation = 6` and asserts the padded result is landscape. Verified to fail on `dev` and pass with the fix.

`752 passed`, coverage 99.81%, ruff clean.
