### PR TITLE
fix(tests): support kwargs in generic camera exists mock for anyio 4.15+

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2393,7 +2393,7 @@ async def test_generic_camera_rebuilds_gif_when_missing(hass, caplog):
 
     gif_exists = True
 
-    def _exists(self) -> bool:
+    def _exists(self, *args, **kwargs) -> bool:
         """Report the delivery image as present, the GIF per gif_exists."""
         if GENERIC_DELIVERIES_GIF in str(self):
             return gif_exists


### PR DESCRIPTION
## Proposed change

`anyio` 4.15.0 was released on 2026-09-02 and began forwarding `follow_symlinks=True` (and arbitrary kwargs) down through `anyio.Path.exists()` to the underlying synchronous `pathlib.Path.exists()`.

In `test_generic_camera_rebuilds_gif_when_missing` (`tests/test_camera.py`), the mocked `_exists` function did not accept arguments (`def _exists(self) -> bool:`), causing `TypeError: test_generic_camera_rebuilds_gif_when_missing.<locals>._exists() got an unexpected keyword argument 'follow_symlinks'` and breaking CI in environments resolving `anyio>=4.15.0`.

This PR updates `_exists` to accept `*args, **kwargs`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
