### PR TITLE
fix(imap): wrap forwarding header address match in parentheses

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -161,7 +161,7 @@ AMAZON_DOMAINS = [
     "amazon.se",
 ]
 AMAZON_DELIVERED_SUBJECT = [
-    "Delivered: ",
+    "Delivered",
     "Your Amazon order has arrived!",
     "Consegna effettuata:",
     "Dostarczono:",

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -287,9 +287,9 @@ def _build_address_clause(
 ) -> str:
     """Build FROM / HEADER address search clause."""
     if header:
-        parts = [f'OR HEADER "{header}" "{a}" FROM "{a}"' for a in address]
+        parts = [f'(OR HEADER "{header}" "{a}" FROM "{a}")' for a in address]
         if len(parts) == 1:
-            return f"({parts[0]})" if is_yahoo else parts[0]
+            return parts[0]
         or_prefix = " ".join(["OR"] * (len(parts) - 1))
         return (
             f"({or_prefix} {' '.join(parts)})"

--- a/tests/shippers/test_amazon.py
+++ b/tests/shippers/test_amazon.py
@@ -1157,6 +1157,25 @@ async def test_is_amazon_delivered_skips_non_bytes_response_parts(hass):
 
 
 @pytest.mark.asyncio
+async def test_is_amazon_delivered_item_count_format(hass):
+    """Test that _is_amazon_delivered matches newer 'Delivered N item(s): ...' subjects (issue #1403)."""
+    shipper = AmazonShipper(
+        hass,
+        {"image_path": "/fake/path/", "amazon_image": "amazon.jpg"},
+    )
+    subjects = [
+        b"Subject: Delivered 2 items: Phone Accessories, Electronics\nContent-Type: text/html\n\nNo images",
+        b"Subject: Delivered 1 item: Plumbing Supplies\nContent-Type: text/html\n\nNo images",
+        b"Subject: Delivered: Your Amazon order has arrived!\nContent-Type: text/html\n\nNo images",
+    ]
+    for subj_bytes in subjects:
+        is_delivered, _ = shipper._is_amazon_delivered(
+            [subj_bytes], ["Delivered", "Your Amazon order has arrived!"]
+        )
+        assert is_delivered is True
+
+
+@pytest.mark.asyncio
 async def test_amazon_de_emails(hass):
     """Test that amazon.de German-language emails are parsed and counted correctly."""
     shipper = AmazonShipper(

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -449,7 +449,7 @@ def test_build_search_single_header():
     )
     assert (
         search
-        == 'OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" SINCE 25-Mar-2026'
+        == '(OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -473,7 +473,7 @@ def test_build_search_multiple_header():
     )
     assert (
         search
-        == 'OR OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com" SINCE 25-Mar-2026'
+        == 'OR (OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") (OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com") SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -484,7 +484,7 @@ def test_build_search_multiple_header():
     )
     assert (
         search_yahoo
-        == '((OR OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com") SINCE 25-Mar-2026)'
+        == '((OR (OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") (OR HEADER "X-SimpleLogin-Original-From" "pkginfo@ups.com" FROM "pkginfo@ups.com")) SINCE 25-Mar-2026)'
     )
 
 
@@ -498,7 +498,7 @@ def test_build_search_header_with_subject():
     )
     assert (
         search
-        == 'OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com" SUBJECT "UPS Ship Notification" SINCE 25-Mar-2026'
+        == '(OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") SUBJECT "UPS Ship Notification" SINCE 25-Mar-2026'
     )
 
     utf8, search_yahoo = build_search(
@@ -511,6 +511,21 @@ def test_build_search_header_with_subject():
     assert (
         search_yahoo
         == '((OR HEADER "X-SimpleLogin-Original-From" "mcinfo@ups.com" FROM "mcinfo@ups.com") SUBJECT "UPS Ship Notification" SINCE 25-Mar-2026)'
+    )
+
+
+def test_build_search_header_with_multiple_subjects_issue_1403():
+    """Test build_search with header and multiple subjects preserves OR precedence (issue #1403)."""
+    subjects = ["Delivered", "Your Amazon order has arrived!"]
+    utf8, search = build_search(
+        ["pickup-point@amazon.com"],
+        "04-Sep-2026",
+        subject=subjects,
+        header="Delivered-To: user@example.com",
+    )
+    assert (
+        search
+        == '(OR HEADER "Delivered-To: user@example.com" "pickup-point@amazon.com" FROM "pickup-point@amazon.com") OR SUBJECT "Delivered" SUBJECT "Your Amazon order has arrived!" SINCE 04-Sep-2026'
     )
 
 


### PR DESCRIPTION
## Proposed change

1. **IMAP Forwarding Header Grouping**:
   When `CONF_FORWARDING_HEADER` is configured, `_build_address_clause()` constructs address matching clauses combining `HEADER ""` and `FROM ""` using IMAP `OR`. In RFC 3501, IMAP `OR` is a prefix binary operator (`OR <key1> <key2>`). Without parentheses around each compound `(OR HEADER "" FROM "")` pair, standard IMAP query parsers (e.g., Gmail) interpret trailing search criteria (`SUBJECT ...` or `SINCE ...`) as the second operand of the address `OR`, breaking operator precedence and causing search queries to match zero messages.
   This PR wraps each compound `(OR HEADER "" FROM "")` sub-clause in parentheses, properly grouping the address criteria and preserving IMAP search operator precedence according to RFC 3501.

2. **Amazon Delivered Subject Matching**:
   Update `AMAZON_DELIVERED_SUBJECT` in `const.py` from `"Delivered: "` to `"Delivered"`. Amazon notifications for multiple items use subject lines such as `"Delivered 2 items: ..."` or `"Delivered 1 item: ..."`, which failed the strict `"Delivered: "` substring check in `_is_amazon_delivered()` and prevented delivery count increments.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [x] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #1403
- This PR is related to issue:
